### PR TITLE
perf: re-grid L5 onto the post-singleton frontier (light split tier)

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -651,10 +651,16 @@ attribute [irreducible] symbolBitCount fixedBlockBytes dynBlockBytes dynBlockByt
 
     The mid-band values are the `mid-sweep` optimum for the #2737 ladder
     (Silesia grid over chain × `goodMatch` × split, then interleaved pinned
-    timing): L4 = 64 (with the lazy gate, the old L5 point), L5 = 128 (gate
-    off — `goodMatch` buys more ratio per cycle than deepening the chain, so
-    L5 = (128, gate off) dominates the old L7 = (256, gate off)). **L6's depth
-    drops back to 64 on purpose**: the split tier starts there, and at equal
+    timing): L4 = 64 (with the lazy gate, the old L5 point). **L5 = 24 since
+    the L5 re-grid** (`gate-sweep`, run after the hash3 singleton #2824, gm/ld
+    re-grid #2825, and greedy re-grid #2830 landings): the old L5 = (128,
+    single-block, gate off) had fallen ~14% inside the L4↔L6 mixing line — the
+    recent landings made the split tier so much cheaper that a shallow-chain
+    *split* point (chain 24, gate 64, probe /4, no singleton) matches the old
+    L5's speed while banking −0.53pp weighted-Silesia ratio (0.3302 → 0.3249),
+    +4% above the blend; every deeper single-block point stayed inside it.
+    **L6's depth drops back to 64 on purpose** (the split tier historically
+    started there): at equal
     cycles the observation-divergence split + a shallow chain beats a deep
     chain without the split — the block-split, not the chain, is L6's budget.
     **L7 also sits at 64 since the post-singleton re-grid** (the hash3
@@ -689,7 +695,7 @@ def chainDepth (level : UInt8) : Nat :=
   else if level ≤ 2 then 8
   else if level ≤ 3 then 16
   else if level ≤ 4 then 64
-  else if level ≤ 5 then 128
+  else if level ≤ 5 then 24
   else if level ≤ 7 then 64
   else if level ≤ 8 then 512
   else 1024
@@ -719,14 +725,17 @@ def insertCap (level : UInt8) : Nat :=
 
     Only L4 keeps the full gate (#2737 `mid-sweep`): disabling it gains ~16bp of
     Silesia geomean ratio at *any* chain depth — more ratio per cycle than
-    deepening the chain — so every level from 5 up spends its first budget
-    increment here. **Exception: L6 gates at 64 since the hash3-singleton
+    deepening the chain. **Exception: L6 gates at 64 since the hash3-singleton
     re-grid** — with the singleton paying the ratio bill, (gate 64, ld/8)
     buys +8% weighted speed for +0.09pp, the point that strictly dominates
-    miniz_oxide L6; L7 keeps the gate off and the old L6 ratio point. -/
+    miniz_oxide L6; L7 keeps the gate off and the old L6 ratio point.
+    **L5 also gates at 64 since the L5 re-grid** (`gate-sweep`, see
+    `chainDepth`): the winning shallow split point pairs the intermediate gate
+    with its chain-24 walk — at that depth the gate's skipped lookahead probes
+    are most of the lazy tier's marginal cost. -/
 def goodMatch (level : UInt8) : Nat :=
   if level ≤ 4 then 8
-  else if level == 6 then 64
+  else if level ≤ 6 then 64
   else 259
 
 /-- Per-level `niceLen` cutoff (libdeflate `nice_match_length`, `deflate_compress.c`):
@@ -763,7 +772,7 @@ def niceLen (level : UInt8) : Nat :=
 
 /-- Lazy lookahead probe depth (libdeflate `deflate_compress.c`): the second
     `chainWalk` at `pos+1` runs at *half* the `pos` walk's `chainDepth`, not full
-    depth. Since the `goodMatch` gate is disabled at L5+ (`goodMatch = 259`), every
+    depth. Since the `goodMatch` gate is disabled at L7+ (`goodMatch = 259`), every
     matched position otherwise pays two full-depth chain walks; libdeflate probes
     its first lookahead at half depth (and its second at quarter) and still holds
     better ratios than us, so the deferral quality a half-depth probe gives up is
@@ -774,14 +783,19 @@ def niceLen (level : UInt8) : Nat :=
     `goodMatch = 64` gate it buys +8% weighted-Silesia speed for +0.09pp on a
     tier where the hash3 singleton already banked −0.28pp — the resulting
     (0.3205, ~36.5 MB/s) point strictly dominates miniz_oxide L6. L7 (the old
-    L6 config) stays at `/2`.
+    L6 config) stays at `/2`. **L5 probes at `/4` since the L5 re-grid**
+    (`gate-sweep`, see `chainDepth`): the winning (chain 24, gate 64) split
+    point took its probe at 6 — deep enough to keep the deferral wins the
+    gate lets through, half the cost of the `/2` default.
 
     Only levels ≥ 4 (the lazy `deflate_slow` tier) consult this; the greedy
     matcher (1–3) has no lookahead. Depth is a pure heuristic — the chain is
     re-verified at emission (`chainWalk_spec` holds for any fuel) — so any value
     keeps the encoder contracts. -/
 def lazyDepth (level : UInt8) : Nat :=
-  if level == 6 then chainDepth level / 8 else chainDepth level / 2
+  if level == 5 then chainDepth level / 4
+  else if level == 6 then chainDepth level / 8
+  else chainDepth level / 2
 
 /-- Enable the hash3 length-3 singleton at the split tier (levels 6–8). Our
     lazy matcher walks hash4-keyed chains only, so length-3 matches are invisible
@@ -789,8 +803,10 @@ def lazyDepth (level : UInt8) : Nat :=
     this is our whole weighted-ratio deficit to miniz_oxide L6. The singleton
     probe (`h3Seed`, TOO_FAR-capped) restores them at −0.28pp corpus-weighted
     Silesia ratio for ≤~5% matcher speed. L1–L5 keep the probe-free loops (the
-    #2742 verdict against probing the fast band stands); L9/L10 already carry
-    their own singleton in the cache build. -/
+    #2742 verdict against probing the fast band stands, and the L5 re-grid
+    retested the singleton at L5's shallow split points — every h3 row fell
+    below the no-h3 frontier there); L9/L10 already carry their own singleton
+    in the cache build. -/
 def useH3Level (level : UInt8) : Bool := decide (6 ≤ level ∧ level ≤ 8)
 
 /-- The per-level LZ77 matcher (zlib-faithful): levels 1–3 (`deflate_fast`) use the
@@ -1242,7 +1258,7 @@ def deflateDynamicBlocksSharedSized (data : ByteArray) (toks : Array LZ77Token) 
 The libdeflate-style divergence heuristic and the shared-window block emitter,
 both walking the `packTok`-encoded `UInt32` stream directly — the packed twins
 of `chooseSplitsHeuristic` and `emitSharedBlocksAt`. This is what lets the
-mid-band levels (6–8) afford per-block Huffman trees at all: the per-block
+mid-band levels (5–8) afford per-block Huffman trees at all: the per-block
 frequency pass runs on `tokenFreqsP` (dense packed tables) and the emit on
 `emitTokensWithCodesP`, so the split candidate never materializes boxed
 `LZ77Token`s and never touches the `findTableCode` linear scans. At level 8 the
@@ -1538,7 +1554,7 @@ def deflateDynamicBlocksSharedAtSizedP (data : ByteArray) (toks : Array UInt32)
     (`deflateObsSplitSizedFreqsP_snd`), the whole-stream histogram the base
     candidate needs — derived here by folding the per-block frequencies the
     sizing pass already built, instead of a second whole-stream `tokenFreqsP`
-    walk. `deflateRaw` (levels 6–8, cuts non-empty) forces this once and feeds
+    walk. `deflateRaw` (levels 5–8, cuts non-empty) forces this once and feeds
     component 2 to `deflateRawBasePPrepF`. -/
 def deflateObsSplitSizedFreqsP (data : ByteArray) (toks : Array UInt32)
     (cuts : List Nat) : (Nat × (Unit → ByteArray)) × (Array Nat × Array Nat) :=
@@ -1672,7 +1688,7 @@ theorem deflateRawBasePPrep_emit (data : ByteArray) (ptokens : Array UInt32) :
 
 /-- `deflateRawBasePPrep` with the whole-stream frequencies supplied as a
     parameter instead of recomputed via `tokenFreqsP ptokens` (#2772). When the
-    levels-6–8 split has cuts, `deflateRaw` passes the frequencies the split-sizing
+    levels-5–8 split has cuts, `deflateRaw` passes the frequencies the split-sizing
     pass already summed (`deflateObsSplitSizedFreqsP`'s component 2, provably
     `tokenFreqsP ptokens`), so the base candidate skips the second whole-stream
     frequency walk. At `f = tokenFreqsP ptokens` this is definitionally
@@ -1950,7 +1966,7 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
     (The zlib/FFI bindings are a separate 0–9 path and are unchanged.)
 
     Level 0 = stored; levels 1–5 run the single-block cost-model dispatch
-    (`deflateRawBase`); levels 6–8 (#2737) additionally try the cross-block
+    (`deflateRawBase`); levels 5–8 (#2737, L5 since the L5 re-grid) additionally try the cross-block
     (shared-window) split candidate — one whole-file match pass, token stream
     partitioned per block, references cross block boundaries — with the
     partition chosen by the packed observation-divergence heuristic
@@ -2033,17 +2049,21 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
     guarantees we never regress below the base. All branches are
     roundtrip-verified.
 
-    The split tier starts at level 6 (#2737; previously level ≥ 8, and before
-    that ≥ 7 — see #2698 for that history): with the boundaries chosen by the
-    cheap streaming heuristic and the whole split pipeline on packed tokens,
-    the candidates are **sized with their per-block trees captured**
-    (`deflateRawBasePPrep` / `deflateDynamicBlocksSharedAtSizedP`) and only the
-    winner is emitted (#2753), reusing the trees the sizing pass already built —
-    so exactly one emit pass runs instead of two (three at L8). Levels 4–5 stay
-    single-block on purpose — they carry the old mid-band's high-speed points
-    (even a size-only split pass would push them off that territory), while
-    levels 6–8 spend the same cycles on per-block trees instead of deeper
-    chains. Levels 1–3 (`deflate_fast`, emit-bound) stay single-block greedy.
+    The split tier starts at level 5 (the L5 re-grid; previously level ≥ 6 per
+    #2737, before that ≥ 8, and before that ≥ 7 — see #2698 for that history):
+    with the boundaries chosen by the cheap streaming heuristic and the whole
+    split pipeline on packed tokens, the candidates are **sized with their
+    per-block trees captured** (`deflateRawBasePPrep` /
+    `deflateDynamicBlocksSharedAtSizedP`) and only the winner is emitted
+    (#2753), reusing the trees the sizing pass already built — so exactly one
+    emit pass runs instead of two (three at L8). Level 4 stays single-block on
+    purpose — it carries the old mid-band's high-speed point (even a size-only
+    split pass would push it off that territory). L5 joined the split tier in
+    the re-grid: post-#2824/#2825/#2830 the old single-block L5 sat ~14%
+    inside the L4↔L6 mixing line, and a shallow split point (chain 24, gate
+    64, probe /4, no singleton) matches its speed at −0.53pp weighted-Silesia
+    ratio — the split's per-block trees buy more than the deep chain did.
+    Levels 1–3 (`deflate_fast`, emit-bound) stay single-block greedy.
 
     Before any of that, an `incompressiblePrescan` reads a bounded sample (≤128 KiB,
     short-circuited on the first compressible region) and, on unambiguously
@@ -2055,7 +2075,7 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
 def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
   if level == 0 then deflateStoredPure data
   else if incompressiblePrescan data then deflateStoredPure data
-  else if 6 ≤ level then
+  else if 5 ≤ level then
     -- One *packed* matcher pass shared by the base and shared-split candidates
     -- (the matcher is 83–84% of each candidate's cost — Wave-0 profile, D-2).
     -- Both candidates consume the packed words end-to-end (freqs *and* emit):
@@ -2091,7 +2111,7 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
         pickSmaller (deflateRawBaseP data ptokens)
           (deflateDynamicBlocksOptimalWindowed data sharedTokChunk)
     else
-      -- Levels 6–8: base vs cross-block shared-window split at the
+      -- Levels 5–8: base vs cross-block shared-window split at the
       -- observation-divergence boundaries (#2737),
       -- **size-arbitrated** (#2753). Both candidates are *prepared* — sized to
       -- their flushed byte count with per-block trees captured

--- a/Zip/Spec/DeflateBaseFreqsReuse.lean
+++ b/Zip/Spec/DeflateBaseFreqsReuse.lean
@@ -97,7 +97,7 @@ theorem deflateRawBasePPrepF_obsFreqs (data : ByteArray) (toks : Array UInt32) (
       = deflateRawBasePPrep data toks := by
   rw [deflateObsSplitSizedFreqsP_snd, deflateRawBasePPrepF_tokenFreqsP]
 
-/-- **Byte-identity of the reuse dispatch.** The levels-6–8 size-arbitrated pair
+/-- **Byte-identity of the reuse dispatch.** The levels-5–8 size-arbitrated pair
     selected by the frequency-reusing dispatch is the *same prepared pair* the
     original dispatch selected: identical prepared sizes, identical tie, identical
     emit thunk. The base candidate reuses the split-sizing frequencies, but nothing

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -14,7 +14,7 @@ Proves the unified roundtrip theorem for `deflateRaw`:
 `deflateRaw` is defined in `Zip/Native/DeflateDynamic.lean`. Level 0 is a stored
 block; level ≥ 1 runs the single-block cost-model dispatch `deflateRawBase`
 (stored / fixed / dynamic, all sized from one hash-chain token pass, emitting
-only the smallest); levels 6–8 additionally compare the cross-block
+only the smallest); levels 5–8 additionally compare the cross-block
 shared-window split at the observation-divergence boundaries (#2737) against
 that base via `pickSmaller`, so the split is a first-class candidate that can
 only ever win; and levels 9/10 compare the near-optimal / exact-DP candidates
@@ -128,7 +128,7 @@ set_option maxRecDepth 8000 in
     This is the Phase B4 capstone theorem from PLAN.md. Generalized to any
     `maxOutputSize` large enough to hold the input. The incompressible pre-scan
     and the level-0 path both dispatch to `deflateStoredPure` directly; the
-    cost-model stored fallback is covered by `deflateRawBase`; the level-6–8
+    cost-model stored fallback is covered by `deflateRawBase`; the level-5–8
     size-arbitrated split (`emitSmallerBy`, #2753) and level-9/10 optimal
     candidates each emit one of concretely-roundtripping blocks. -/
 theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
@@ -199,10 +199,10 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
               exact inflate_pickSmaller _ _ data maxOutputSize
                 (inflate_deflateRawBase data level _ hsize)
                 (inflate_deflateDynamicBlocksOptimalWindowed data sharedTokChunk _ hsize)
-          · -- levels 6–8: obs-split candidate, `hwithObs`
+          · -- levels 5–8: obs-split candidate, `hwithObs`
             exact hwithObs _ rfl
       · split
-        · -- levels 4–5: the lazy-tier base candidate, unchanged
+        · -- level 4: the lazy-tier base candidate, unchanged
           exact inflate_deflateRawBase data level _ hsize
         · -- levels 1–3: fused greedy base candidate, byte-identical to
           -- `deflateRawBase` (`deflateRawBaseF_eq`)
@@ -353,10 +353,10 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
                   bits = contentBits ++ padding ∧ padding.length < 8)
                 _ _ (deflateRawBase_pad data level)
                 (deflateDynamicBlocksOptimalWindowed_pad data sharedTokChunk)
-          · -- levels 6–8
+          · -- levels 5–8
             exact hwithObs _ rfl
       · split
-        · -- levels 4–5: lazy-tier base, unchanged
+        · -- level 4: lazy-tier base, unchanged
           exact deflateRawBase_pad data level
         · -- levels 1–3: fused greedy base (`deflateRawBaseF_eq`)
           rw [Zip.Native.Deflate.deflateRawBaseF_eq data level (by assumption)]
@@ -585,10 +585,10 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
                     remaining.length < 8)
                 _ _ (deflateRawBase_goR_pad data level)
                 (deflateDynamicBlocksOptimalWindowed_goR_pad data sharedTokChunk)
-          · -- levels 6–8
+          · -- levels 5–8
             exact hwithObs _ rfl
       · split
-        · -- levels 4–5: lazy-tier base, unchanged
+        · -- level 4: lazy-tier base, unchanged
           exact deflateRawBase_goR_pad data level
         · -- levels 1–3: fused greedy base (`deflateRawBaseF_eq`)
           rw [Zip.Native.Deflate.deflateRawBaseF_eq data level (by assumption)]

--- a/bench/ZipGateSweep.lean
+++ b/bench/ZipGateSweep.lean
@@ -1,18 +1,31 @@
 import Zip
 
-/-! # gate-sweep — intermediate lazy-gate (`goodMatch`) + probe-depth sweep at the split tier
+/-! # gate-sweep — lazy-gate/probe-depth sweep, now regridding the L5 slot
 
-The #2737 `mid-sweep` grid only ever tried `goodMatch ∈ {8, 259}` (full gating
-vs. disabled). This sweep probes the *intermediate* gate values at the L6 split
-config: with the gate at `g`, a first match of length ≥ `g` skips the lazy
-`pos+1` lookahead walk entirely — on match-rich files that deletes a large
-fraction of the second chain walks for a ratio cost that shrinks as `g` grows.
-Also grids the lazy probe depth (`lazyDepth`, production `chain/2`; #2781
-suggests `/4`) and deeper chains re-paired with a gate.
+Originally the intermediate `goodMatch` sweep at the L6 split config (#2781/
+#2824 grid history preserved in git). This revision points the same harness at
+the **L5 slot**: the committed dashboard has L5 (single-block, chain 128, gate
+off, probe /2, no singleton) 15.6% *inside* the L4↔L6 mixing line — it predates
+the hash3-singleton (#2824), gm/ld re-grid (#2825), and greedy re-grid (#2830)
+landings. The grid pits cheaper single-block points against shallow split-tier
+points (with and without the hash3 singleton) for the L5 ratio band.
 
-Ratio rows go through the *exact* production L6–L8 dispatch (sized prep,
-base-vs-obs-split arbitration — the same code `deflateRaw` runs), so `out`
-is byte-for-byte what the shipped encoder would emit at that config.
+Each `Cfg` now carries a `split` flag: `split = true` rows go through the
+*exact* production L6–L8 dispatch (sized prep, base-vs-obs-split arbitration —
+the same code `deflateRaw` runs at the split tier); `split = false` rows go through the
+production single-block base path (`deflateRawBasePPrep`, forced — exactly
+`deflateRawBaseP`, the L4–L5 dispatch), so `out` is byte-for-byte what the
+shipped encoder would emit at that config. The grid includes the pre-re-grid
+production L4, L5, and L6 knob rows as anchors: the old L5 was the
+certification row (byte-identical to `deflateRaw · 5` on pre-re-grid master,
+checked per-file against the extra `prod-deflateRaw-l5` ratio row), and L4/L6
+let the mixing line be computed in this harness's own units.
+
+Verdict (landed as the L5 re-grid): `split-noh3-c24-gm64-ld6` — every deeper
+single-block point stayed 3-4% inside the L4↔L6 blend, every split point
+cleared it, and c24/gm64/ld6 peaked at +4% with the old L5's speed at −0.53pp
+weighted ratio. Since that landing, `prod-deflateRaw-l5` matches the
+`split-noh3-c24-gm64-ld6` row (production L5) rather than `prod-l5-single-*`.
 
     <file>,<label>,<inBytes>,<outBytes>
 
@@ -33,34 +46,48 @@ structure Cfg where
   nl : Nat
   lazyD : Nat
   h3 : Bool := false
+  split : Bool := true
 
-/-- The grid: production L6 first (the certification row — must reproduce the
-    shipped L6 bytes), then gate values, probe depths, and deeper chains. -/
+/-- The grid: the production L5 row first (the certification row — single-block,
+    must reproduce the shipped L5 bytes), the production L4/L6 rows as mixing-line
+    anchors, then the L5-slot candidates: cheaper single-block points, shallow
+    split points without the singleton, and shallow split points with it. -/
 def cfgs : List Cfg := [
-  ⟨"h3-prod-c64-gm259-ld32",  64, 259, 65, 32, true⟩,
-  ⟨"noh3-c64-gm259-ld32",     64, 259, 65, 32, false⟩,
-  ⟨"h3-ld16",                 64, 259, 65, 16, true⟩,
-  ⟨"h3-gm64",                 64,  64, 65, 32, true⟩,
-  ⟨"h3-gm64-ld16",            64,  64, 65, 16, true⟩,
-  ⟨"h3-gm32-ld16",            64,  32, 65, 16, true⟩,
-  ⟨"h3-c48-gm259-ld24",       48, 259, 65, 24, true⟩,
-  ⟨"h3-c48-gm64-ld16",        48,  64, 65, 16, true⟩,
-  ⟨"h3-c96-gm259-ld48",       96, 259, 65, 48, true⟩,
-  ⟨"h3-ld8",                  64, 259, 65,  8, true⟩,
-  ⟨"h3-gm64-ld8",             64,  64, 65,  8, true⟩ ]
+  ⟨"prod-l5-single-c128-gm259-ld64", 128, 259,  65, 64, false, false⟩,
+  ⟨"prod-l4-single-c64-gm8-ld32",     64,   8, 258, 32, false, false⟩,
+  ⟨"prod-l6-split-h3-c64-gm64-ld8",   64,  64,  65,  8, true,  true⟩,
+  ⟨"single-c64-gm259-ld32",           64, 259,  65, 32, false, false⟩,
+  ⟨"single-c96-gm64-ld24",            96,  64,  65, 24, false, false⟩,
+  ⟨"single-c128-gm64-ld16",          128,  64,  65, 16, false, false⟩,
+  ⟨"split-noh3-c32-gm64-ld8",         32,  64,  65,  8, false, true⟩,
+  ⟨"split-noh3-c48-gm64-ld12",        48,  64,  65, 12, false, true⟩,
+  ⟨"split-noh3-c64-gm32-ld8",         64,  32,  65,  8, false, true⟩,
+  ⟨"split-h3-c32-gm64-ld8",           32,  64,  65,  8, true,  true⟩,
+  ⟨"split-h3-c48-gm64-ld12",          48,  64,  65, 12, true,  true⟩,
+  ⟨"split-h3-c24-gm32-ld6",           24,  32,  65,  6, true,  true⟩,
+  -- Edge extension: the first grid's best margin sat at its shallowest no-h3
+  -- chain (c32), so probe one step past the edge in both singleton modes.
+  ⟨"split-noh3-c24-gm64-ld6",         24,  64,  65,  6, false, true⟩,
+  ⟨"split-noh3-c16-gm64-ld4",         16,  64,  65,  4, false, true⟩,
+  ⟨"split-h3-c16-gm64-ld4",           16,  64,  65,  4, true,  true⟩ ]
 
-/-- One config through the exact production split-tier dispatch (the L6–L7
-    arm of `deflateRaw`: sized preps, obs-split arbitration, winner emitted). -/
+/-- One config through the exact production dispatch for its mode: `split = true`
+    is the split-tier arm of `deflateRaw` (sized preps, obs-split arbitration,
+    winner emitted); `split = false` is the single-block lazy-base arm (`deflateRawBasePPrep`
+    forced — definitionally `deflateRawBaseP`). -/
 def runCfg (cfg : Cfg) (data : ByteArray) : Nat :=
   let ptokens := lz77ChainLazyIterPMerged data cfg.chain 32768 1000000000 cfg.gm cfg.nl cfg.lazyD cfg.h3
-  let cuts := chooseSplitsHeuristicP ptokens data.size
-  let withObs : Nat × (Unit → ByteArray) :=
-    if cuts.isEmpty then deflateRawBasePPrep data ptokens
-    else
-      let obsFreqs := deflateObsSplitSizedFreqsP data ptokens cuts
-      let basePrep := deflateRawBasePPrepF data ptokens obsFreqs.2
-      if basePrep.1 < obsFreqs.1.1 then basePrep else obsFreqs.1
-  (withObs.2 ()).size
+  if cfg.split then
+    let cuts := chooseSplitsHeuristicP ptokens data.size
+    let withObs : Nat × (Unit → ByteArray) :=
+      if cuts.isEmpty then deflateRawBasePPrep data ptokens
+      else
+        let obsFreqs := deflateObsSplitSizedFreqsP data ptokens cuts
+        let basePrep := deflateRawBasePPrepF data ptokens obsFreqs.2
+        if basePrep.1 < obsFreqs.1.1 then basePrep else obsFreqs.1
+    (withObs.2 ()).size
+  else
+    ((deflateRawBasePPrep data ptokens).2 ()).size
 
 def timeMain (paths : List String) : IO Unit := do
   let mut files : List ByteArray := []
@@ -83,6 +110,9 @@ def ratioMain (paths : List String) : IO Unit := do
   for path in paths do
     let data ← IO.FS.readBinFile path
     let name := (path.splitOn "/").getLastD path
+    -- Certification reference: the *actual* production level-5 output (through
+    -- `deflateRaw`, prescan included) — the `prod-l5-single-*` row must match it.
+    IO.println s!"{name},prod-deflateRaw-l5,{data.size},{(Zip.Native.Deflate.deflateRaw data 5).size}"
     for cfg in cfgs do
       IO.println s!"{name},{cfg.label},{data.size},{runCfg cfg data}"
       (← IO.getStdout).flush

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pbf927d2aeb)">
+   <g clip-path="url(#p712c782a15)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJGElEQVR4nO3Yz6qd5R2G4b2StdXoVqJgGrSEQh0qHelE5849EI/ASY+hZ1AKnYvQQceddFg6aaG0BBG0EGMSd7Z7rz8OCj2C++Wni+s6gufj5fvWvd7N4bs/Hs/4ebl6Nr1gnR9O89mO11fTE5bZvHZvesIaL748vWCdza3pBWvcnO57dqpndnz05fSEZU7zxAAABgksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY9uHm0fSGJa73V9MTlrl/91fTE5a5ONybnrDE5vmT6QnL/OX5P6YnLPHWC29OT1hmf9hNT1ji6e5yesIyu+N+esIS77/69vSEZdxgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx7cX53esMSh+1hesIyF2cvTU9Y5/HD6QVLHJ8/mZ6wzAcPPpyesMTl7nTP7PsTfbZ3Lt6dnrDM9WY3PWGJ43/+Nj1hGTdYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAENveuX0xvWGJq/3l9IR1NifcxS+9Nr1gic0Jn9n5bjc9YYlTPrNXtqf5nn19/dX0hGV2h+vpCUu8/crd6QnLnO4XBABgiMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2Gb/998ep0fA/x0O0wvgf275//mz4/vBT4gvCABATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMS2n/734fSGJZ78sJ+esMxfv3o6PWGZLz75aHrCEr+482B6wjK/+f0fpics8fGv35iesMy/vn0+PWGJO9vb0xOW+fxP/5yesMTl7z6bnrCMGywAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCIbXaHPx+nR6ywP+ymJyxza3O6XXz76nJ6whq3t9ML1vn+0fSCJfZ3709PWOZwPExPWOJ8c7rv2c3xNH/Tznen+VxnZ26wAAByAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILa9vHkyvWGJm8P19IRlXr883Wc7e/rN9IIljtc30xOW2Tx4b3rCEtf7q+kJyzy7eTw9YYk37/xyesIy588eT09Y4vj1v6cnLOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGI/ArfPiPPxwywhAAAAAElFTkSuQmCC" id="image5522453d41" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJGElEQVR4nO3Yz6qd5R2G4b2StdXoVqJgGrSEQh0qHelE5849EI/ASY+hZ1AKnYvQQceddFg6aaG0BBG0EGMSd7Z7rz8OCj2C++Wni+s6gufj5fvWvd7N4bs/Hs/4ebl6Nr1gnR9O89mO11fTE5bZvHZvesIaL748vWCdza3pBWvcnO57dqpndnz05fSEZU7zxAAABgksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY9uHm0fSGJa73V9MTlrl/91fTE5a5ONybnrDE5vmT6QnL/OX5P6YnLPHWC29OT1hmf9hNT1ji6e5yesIyu+N+esIS77/69vSEZdxgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx7cX53esMSh+1hesIyF2cvTU9Y5/HD6QVLHJ8/mZ6wzAcPPpyesMTl7nTP7PsTfbZ3Lt6dnrDM9WY3PWGJ43/+Nj1hGTdYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAENveuX0xvWGJq/3l9IR1NifcxS+9Nr1gic0Jn9n5bjc9YYlTPrNXtqf5nn19/dX0hGV2h+vpCUu8/crd6QnLnO4XBABgiMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2Gb/998ep0fA/x0O0wvgf275//mz4/vBT4gvCABATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMS2n/734fSGJZ78sJ+esMxfv3o6PWGZLz75aHrCEr+482B6wjK/+f0fpics8fGv35iesMy/vn0+PWGJO9vb0xOW+fxP/5yesMTl7z6bnrCMGywAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCIbXaHPx+nR6ywP+ymJyxza3O6XXz76nJ6whq3t9ML1vn+0fSCJfZ3709PWOZwPExPWOJ8c7rv2c3xNH/Tznen+VxnZ26wAAByAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILa9vHkyvWGJm8P19IRlXr883Wc7e/rN9IIljtc30xOW2Tx4b3rCEtf7q+kJyzy7eTw9YYk37/xyesIy588eT09Y4vj1v6cnLOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGI/ArfPiPPxwywhAAAAAElFTkSuQmCC" id="image5d286abd3a" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mfb7b332f97" d="M 0 0 
+       <path id="m4660d45a0d" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfb7b332f97" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4660d45a0d" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mfb7b332f97" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4660d45a0d" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mfb7b332f97" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4660d45a0d" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mfb7b332f97" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4660d45a0d" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mfb7b332f97" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4660d45a0d" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mfb7b332f97" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4660d45a0d" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mfb7b332f97" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4660d45a0d" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mfb7b332f97" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4660d45a0d" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mfb7b332f97" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4660d45a0d" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mfb7b332f97" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4660d45a0d" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mfb7b332f97" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4660d45a0d" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m1b0a635ea6" d="M 0 0 
+       <path id="me3c8494e90" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1b0a635ea6" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3c8494e90" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m1b0a635ea6" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3c8494e90" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1b0a635ea6" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3c8494e90" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m1b0a635ea6" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3c8494e90" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m1b0a635ea6" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3c8494e90" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m1b0a635ea6" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3c8494e90" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m1b0a635ea6" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3c8494e90" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m1b0a635ea6" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3c8494e90" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,7 +1303,7 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +26 -->
+    <!-- +25 -->
     <g transform="translate(108.442626 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1321,44 +1321,14 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +34 -->
+    <!-- +35 -->
     <g transform="translate(147.693424 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
@@ -1393,6 +1363,16 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -45 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
 L 2419 1625 
@@ -1413,17 +1393,9 @@ L 2253 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -46 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_23">
@@ -1510,11 +1482,11 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- +45 -->
+    <!-- +44 -->
     <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
@@ -1527,17 +1499,49 @@ z
    <g id="text_29">
     <!-- -36 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -89 -->
+    <!-- -90 -->
     <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
@@ -2176,18 +2180,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image9fbc430177" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imageaa08e81497" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="me3363ae164" d="M 0 0 
+       <path id="md12914cf2e" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me3363ae164" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md12914cf2e" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2210,7 +2214,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#me3363ae164" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md12914cf2e" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2224,7 +2228,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#me3363ae164" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md12914cf2e" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2238,7 +2242,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#me3363ae164" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md12914cf2e" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2251,7 +2255,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#me3363ae164" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md12914cf2e" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2264,7 +2268,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#me3363ae164" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md12914cf2e" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2277,7 +2281,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#me3363ae164" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md12914cf2e" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2938,8 +2942,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.448437 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-11T10:44:33Z  ·  Linux chungus2 x86_64  ·  commit c014c7e1  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.058516 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3008,14 +3012,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3055,109 +3059,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3372.705078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3436.328125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3497.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3561.474609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3593.261719 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3625.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3656.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3688.623047 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3720.410156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3748.193359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3809.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3870.996094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3934.375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3997.851562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4036.714844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4097.896484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4157.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4218.599609 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4259.712891 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4293.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4321.1875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4382.710938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4443.990234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4507.369141 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4570.992188 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4604.683594 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4663.863281 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4727.486328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4759.273438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4822.896484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4886.519531 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4918.306641 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4981.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5018.013672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5056.876953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5111.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5175.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5207.267578 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5239.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5270.841797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5302.628906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5334.416016 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5373.625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5437.003906 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5475.867188 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5537.048828 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5600.427734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5663.904297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5727.283203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5790.759766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5854.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5893.347656 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6008.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6040.710938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6138.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6199.646484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6263.123047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6290.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6352.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6415.564453 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6447.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6499.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6562.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6624.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6864.246094 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6903.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6937.146484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6968.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7010.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7071.326172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7110.535156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7138.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7199.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7231.287109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7259.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7311.169922 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7342.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7406.433594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7467.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7507.166016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7568.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7608.052734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7705.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7733.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7796.626953 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7824.410156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7876.509766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7915.71875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7943.501953 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pbf927d2aeb">
+  <clipPath id="p712c782a15">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m7a3c2e627c" d="M 0 0 
+       <path id="mb597b53ad5" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7a3c2e627c" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb597b53ad5" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7a3c2e627c" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb597b53ad5" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7a3c2e627c" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb597b53ad5" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7a3c2e627c" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb597b53ad5" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7a3c2e627c" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb597b53ad5" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m7a3c2e627c" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb597b53ad5" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m7a3c2e627c" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb597b53ad5" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m35279ccf8d" d="M 0 0 
+       <path id="m84a1297166" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m35279ccf8d" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84a1297166" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m35279ccf8d" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84a1297166" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m35279ccf8d" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84a1297166" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mf0efc75edf" d="M 0 0 
+       <path id="m07cfa57592" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#mf0efc75edf" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m07cfa57592" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.783126 137.330928) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.783126 137.275483) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.775489 294.848343) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.775489 295.520927) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="mf3d8523f00" d="M -2.5 2.5 
+     <path id="m157e9df645" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0c24897947)">
-     <use xlink:href="#mf3d8523f00" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d8523f00" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d8523f00" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d8523f00" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d8523f00" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d8523f00" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d8523f00" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d8523f00" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d8523f00" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3c6da9ddf3)">
+     <use xlink:href="#m157e9df645" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m157e9df645" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m157e9df645" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m157e9df645" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m157e9df645" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m157e9df645" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m157e9df645" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m157e9df645" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m157e9df645" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="mfe1247db2c" d="M 0 -2.5 
+     <path id="me464033c52" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0c24897947)">
-     <use xlink:href="#mfe1247db2c" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe1247db2c" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe1247db2c" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe1247db2c" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe1247db2c" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe1247db2c" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe1247db2c" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe1247db2c" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe1247db2c" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3c6da9ddf3)">
+     <use xlink:href="#me464033c52" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me464033c52" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me464033c52" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me464033c52" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me464033c52" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me464033c52" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me464033c52" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me464033c52" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me464033c52" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="m14949d883f" d="M -0 3.535534 
+     <path id="m13393285ec" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0c24897947)">
-     <use xlink:href="#m14949d883f" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14949d883f" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14949d883f" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14949d883f" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14949d883f" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14949d883f" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14949d883f" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14949d883f" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14949d883f" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14949d883f" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14949d883f" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14949d883f" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3c6da9ddf3)">
+     <use xlink:href="#m13393285ec" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13393285ec" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13393285ec" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13393285ec" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13393285ec" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13393285ec" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13393285ec" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13393285ec" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13393285ec" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13393285ec" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13393285ec" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13393285ec" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m58db1fb298" d="M -0 2.5 
+     <path id="mf8a19550cd" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0c24897947)">
-     <use xlink:href="#m58db1fb298" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3c6da9ddf3)">
+     <use xlink:href="#mf8a19550cd" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m471ca2777a" d="M -0.833333 2.5 
+     <path id="mee5a143b8b" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0c24897947)">
-     <use xlink:href="#m471ca2777a" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m471ca2777a" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m471ca2777a" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m471ca2777a" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m471ca2777a" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m471ca2777a" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m471ca2777a" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m471ca2777a" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m471ca2777a" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3c6da9ddf3)">
+     <use xlink:href="#mee5a143b8b" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee5a143b8b" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee5a143b8b" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee5a143b8b" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee5a143b8b" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee5a143b8b" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee5a143b8b" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee5a143b8b" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee5a143b8b" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="m8cae01923a" d="M -1.25 2.5 
+     <path id="m0f4dfb2a88" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0c24897947)">
-     <use xlink:href="#m8cae01923a" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cae01923a" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cae01923a" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cae01923a" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cae01923a" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cae01923a" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cae01923a" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cae01923a" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cae01923a" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3c6da9ddf3)">
+     <use xlink:href="#m0f4dfb2a88" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f4dfb2a88" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f4dfb2a88" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f4dfb2a88" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f4dfb2a88" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f4dfb2a88" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f4dfb2a88" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f4dfb2a88" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f4dfb2a88" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="me5581fab54" d="M 0 -2.5 
+     <path id="mbac8da0224" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p0c24897947)">
-     <use xlink:href="#me5581fab54" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5581fab54" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5581fab54" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5581fab54" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5581fab54" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5581fab54" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5581fab54" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5581fab54" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5581fab54" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p3c6da9ddf3)">
+     <use xlink:href="#mbac8da0224" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbac8da0224" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbac8da0224" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbac8da0224" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbac8da0224" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbac8da0224" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbac8da0224" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbac8da0224" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbac8da0224" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="mc3b5d58e6e" d="M 0 -2.5 
+     <path id="mecf7ed7aee" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0c24897947)">
-     <use xlink:href="#mc3b5d58e6e" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3b5d58e6e" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3b5d58e6e" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3b5d58e6e" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3b5d58e6e" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3b5d58e6e" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3b5d58e6e" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3b5d58e6e" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3b5d58e6e" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3c6da9ddf3)">
+     <use xlink:href="#mecf7ed7aee" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mecf7ed7aee" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mecf7ed7aee" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mecf7ed7aee" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mecf7ed7aee" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mecf7ed7aee" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mecf7ed7aee" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mecf7ed7aee" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mecf7ed7aee" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="mc914babc9f" d="M 0 3.5 
+      <path id="mf3b870fea9" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mc914babc9f" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mf3b870fea9" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#mf3d8523f00" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m157e9df645" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#mfe1247db2c" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me464033c52" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#m14949d883f" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m13393285ec" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m58db1fb298" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf8a19550cd" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m471ca2777a" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mee5a143b8b" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#m8cae01923a" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0f4dfb2a88" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#me5581fab54" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mbac8da0224" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#mc3b5d58e6e" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mecf7ed7aee" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p0c24897947)">
-     <use xlink:href="#mc914babc9f" x="289.783126" y="142.330928" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc914babc9f" x="232.839775" y="147.876362" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc914babc9f" x="214.084819" y="153.034684" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc914babc9f" x="181.367844" y="168.3472" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc914babc9f" x="165.308999" y="177.551546" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc914babc9f" x="160.074948" y="184.227623" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc914babc9f" x="157.029538" y="187.304888" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc914babc9f" x="149.72506" y="196.428799" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc914babc9f" x="115.00257" y="273.659433" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc914babc9f" x="99.775489" y="299.848343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p3c6da9ddf3)">
+     <use xlink:href="#mf3b870fea9" x="289.783126" y="142.275483" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf3b870fea9" x="232.839775" y="147.891741" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf3b870fea9" x="214.084819" y="152.995401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf3b870fea9" x="181.367844" y="168.413369" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf3b870fea9" x="160.736439" y="176.913328" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf3b870fea9" x="160.074948" y="184.358377" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf3b870fea9" x="157.029538" y="187.445169" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf3b870fea9" x="149.72506" y="196.495802" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf3b870fea9" x="115.00257" y="273.836357" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf3b870fea9" x="99.775489" y="300.520927" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.783126 142.330928 
-L 288.596807 142.453329 
-L 287.410487 142.575415 
-L 286.224167 142.697188 
-L 285.037847 142.818648 
-L 283.851527 142.939798 
-L 282.665207 143.060639 
-L 281.478888 143.181173 
-L 280.292568 143.301401 
-L 279.106248 143.421325 
-L 277.919928 143.540946 
-L 276.733608 143.660266 
-L 275.547289 143.779287 
-L 274.360969 143.898009 
-L 273.174649 144.016435 
-L 271.988329 144.134565 
-L 270.802009 144.252402 
-L 269.615689 144.369947 
-L 268.42937 144.487201 
-L 267.24305 144.604165 
-L 266.05673 144.720842 
-L 264.87041 144.837232 
-L 263.68409 144.953337 
-L 262.49777 145.069158 
-L 261.311451 145.184697 
-L 260.125131 145.299955 
-L 258.938811 145.414933 
-L 257.752491 145.529634 
-L 256.566171 145.644057 
-L 255.379852 145.758205 
-L 254.193532 145.872078 
-L 253.007212 145.985679 
-L 251.820892 146.099008 
-L 250.634572 146.212066 
-L 249.448252 146.324856 
-L 248.261933 146.437378 
-L 247.075613 146.549633 
-L 245.889293 146.661623 
-L 244.702973 146.77335 
-L 243.516653 146.884813 
-L 242.330333 146.996015 
-L 241.144014 147.106957 
-L 239.957694 147.217639 
-L 238.771374 147.328064 
-L 237.585054 147.438232 
-L 236.398734 147.548145 
-L 235.212415 147.657803 
-L 234.026095 147.767208 
-L 232.839775 147.876362 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.783126 142.275483 
+L 288.596807 142.39954 
+L 287.410487 142.523273 
+L 286.224167 142.646684 
+L 285.037847 142.769774 
+L 283.851527 142.892546 
+L 282.665207 143.015 
+L 281.478888 143.137139 
+L 280.292568 143.258964 
+L 279.106248 143.380477 
+L 277.919928 143.501679 
+L 276.733608 143.622571 
+L 275.547289 143.743157 
+L 274.360969 143.863436 
+L 273.174649 143.983411 
+L 271.988329 144.103082 
+L 270.802009 144.222453 
+L 269.615689 144.341524 
+L 268.42937 144.460296 
+L 267.24305 144.578771 
+L 266.05673 144.696951 
+L 264.87041 144.814837 
+L 263.68409 144.932431 
+L 262.49777 145.049733 
+L 261.311451 145.166746 
+L 260.125131 145.283471 
+L 258.938811 145.399909 
+L 257.752491 145.516062 
+L 256.566171 145.631931 
+L 255.379852 145.747517 
+L 254.193532 145.862822 
+L 253.007212 145.977848 
+L 251.820892 146.092594 
+L 250.634572 146.207064 
+L 249.448252 146.321258 
+L 248.261933 146.435177 
+L 247.075613 146.548824 
+L 245.889293 146.662198 
+L 244.702973 146.775302 
+L 243.516653 146.888137 
+L 242.330333 147.000704 
+L 241.144014 147.113004 
+L 239.957694 147.225038 
+L 238.771374 147.336809 
+L 237.585054 147.448316 
+L 236.398734 147.559562 
+L 235.212415 147.670547 
+L 234.026095 147.781273 
+L 232.839775 147.891741 
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 232.839775 147.876362 
-L 232.449047 147.989756 
-L 232.058318 148.102881 
-L 231.66759 148.215736 
-L 231.276862 148.328323 
-L 230.886134 148.440643 
-L 230.495405 148.552697 
-L 230.104677 148.664487 
-L 229.713949 148.776015 
-L 229.323221 148.88728 
-L 228.932492 148.998285 
-L 228.541764 149.10903 
-L 228.151036 149.219518 
-L 227.760308 149.329748 
-L 227.369579 149.439723 
-L 226.978851 149.549443 
-L 226.588123 149.65891 
-L 226.197395 149.768124 
-L 225.806666 149.877087 
-L 225.415938 149.985801 
-L 225.02521 150.094266 
-L 224.634482 150.202483 
-L 224.243753 150.310453 
-L 223.853025 150.418178 
-L 223.462297 150.525659 
-L 223.071569 150.632897 
-L 222.68084 150.739893 
-L 222.290112 150.846647 
-L 221.899384 150.953162 
-L 221.508656 151.059438 
-L 221.117927 151.165476 
-L 220.727199 151.271278 
-L 220.336471 151.376843 
-L 219.945743 151.482175 
-L 219.555014 151.587272 
-L 219.164286 151.692138 
-L 218.773558 151.796771 
-L 218.38283 151.901175 
-L 217.992101 152.005348 
-L 217.601373 152.109294 
-L 217.210645 152.213012 
-L 216.819917 152.316503 
-L 216.429188 152.419769 
-L 216.03846 152.52281 
-L 215.647732 152.625628 
-L 215.257004 152.728224 
-L 214.866275 152.830597 
-L 214.475547 152.932751 
-L 214.084819 153.034684 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 232.839775 147.891741 
+L 232.449047 148.00387 
+L 232.058318 148.115734 
+L 231.66759 148.227335 
+L 231.276862 148.338674 
+L 230.886134 148.449752 
+L 230.495405 148.56057 
+L 230.104677 148.67113 
+L 229.713949 148.781432 
+L 229.323221 148.891478 
+L 228.932492 149.00127 
+L 228.541764 149.110807 
+L 228.151036 149.220092 
+L 227.760308 149.329126 
+L 227.369579 149.43791 
+L 226.978851 149.546444 
+L 226.588123 149.65473 
+L 226.197395 149.76277 
+L 225.806666 149.870564 
+L 225.415938 149.978113 
+L 225.02521 150.085419 
+L 224.634482 150.192483 
+L 224.243753 150.299305 
+L 223.853025 150.405887 
+L 223.462297 150.51223 
+L 223.071569 150.618334 
+L 222.68084 150.724202 
+L 222.290112 150.829834 
+L 221.899384 150.935231 
+L 221.508656 151.040394 
+L 221.117927 151.145325 
+L 220.727199 151.250023 
+L 220.336471 151.354491 
+L 219.945743 151.458729 
+L 219.555014 151.562738 
+L 219.164286 151.66652 
+L 218.773558 151.770075 
+L 218.38283 151.873404 
+L 217.992101 151.976508 
+L 217.601373 152.079389 
+L 217.210645 152.182047 
+L 216.819917 152.284482 
+L 216.429188 152.386697 
+L 216.03846 152.488692 
+L 215.647732 152.590468 
+L 215.257004 152.692026 
+L 214.866275 152.793367 
+L 214.475547 152.894492 
+L 214.084819 152.995401 
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 214.084819 153.034684 
-L 213.403215 153.409764 
-L 212.721611 153.781898 
-L 212.040008 154.151134 
-L 211.358404 154.517516 
-L 210.676801 154.881088 
-L 209.995197 155.241891 
-L 209.313593 155.59997 
-L 208.63199 155.955363 
-L 207.950386 156.308111 
-L 207.268782 156.658254 
-L 206.587179 157.005829 
-L 205.905575 157.350874 
-L 205.223971 157.693425 
-L 204.542368 158.033518 
-L 203.860764 158.371189 
-L 203.17916 158.706471 
-L 202.497557 159.039398 
-L 201.815953 159.370002 
-L 201.13435 159.698317 
-L 200.452746 160.024374 
-L 199.771142 160.348202 
-L 199.089539 160.669833 
-L 198.407935 160.989297 
-L 197.726331 161.306622 
-L 197.044728 161.621836 
-L 196.363124 161.934968 
-L 195.68152 162.246045 
-L 194.999917 162.555094 
-L 194.318313 162.862141 
-L 193.636709 163.167211 
-L 192.955106 163.470331 
-L 192.273502 163.771524 
-L 191.591898 164.070816 
-L 190.910295 164.368229 
-L 190.228691 164.663788 
-L 189.547088 164.957516 
-L 188.865484 165.249434 
-L 188.18388 165.539566 
-L 187.502277 165.827932 
-L 186.820673 166.114555 
-L 186.139069 166.399455 
-L 185.457466 166.682653 
-L 184.775862 166.964168 
-L 184.094258 167.244022 
-L 183.412655 167.522233 
-L 182.731051 167.79882 
-L 182.049447 168.073803 
-L 181.367844 168.3472 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 214.084819 152.995401 
+L 213.403215 153.373495 
+L 212.721611 153.748596 
+L 212.040008 154.120753 
+L 211.358404 154.49001 
+L 210.676801 154.856412 
+L 209.995197 155.220004 
+L 209.313593 155.580829 
+L 208.63199 155.938927 
+L 207.950386 156.29434 
+L 207.268782 156.647107 
+L 206.587179 156.997269 
+L 205.905575 157.344863 
+L 205.223971 157.689926 
+L 204.542368 158.032496 
+L 203.860764 158.372607 
+L 203.17916 158.710295 
+L 202.497557 159.045595 
+L 201.815953 159.378539 
+L 201.13435 159.709161 
+L 200.452746 160.037492 
+L 199.771142 160.363565 
+L 199.089539 160.68741 
+L 198.407935 161.009057 
+L 197.726331 161.328537 
+L 197.044728 161.645877 
+L 196.363124 161.961107 
+L 195.68152 162.274254 
+L 194.999917 162.585346 
+L 194.318313 162.89441 
+L 193.636709 163.201471 
+L 192.955106 163.506556 
+L 192.273502 163.80969 
+L 191.591898 164.110898 
+L 190.910295 164.410203 
+L 190.228691 164.70763 
+L 189.547088 165.003203 
+L 188.865484 165.296944 
+L 188.18388 165.588876 
+L 187.502277 165.87902 
+L 186.820673 166.1674 
+L 186.139069 166.454035 
+L 185.457466 166.738948 
+L 184.775862 167.022158 
+L 184.094258 167.303686 
+L 183.412655 167.583552 
+L 182.731051 167.861775 
+L 182.049447 168.138374 
+L 181.367844 168.413369 
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 181.367844 168.3472 
-L 181.033285 168.558371 
-L 180.698725 168.768605 
-L 180.364166 168.97791 
-L 180.029607 169.186296 
-L 179.695047 169.393769 
-L 179.360488 169.600338 
-L 179.025929 169.806011 
-L 178.69137 170.010795 
-L 178.35681 170.214699 
-L 178.022251 170.417729 
-L 177.687692 170.619892 
-L 177.353133 170.821198 
-L 177.018573 171.021652 
-L 176.684014 171.221262 
-L 176.349455 171.420034 
-L 176.014895 171.617977 
-L 175.680336 171.815096 
-L 175.345777 172.011399 
-L 175.011218 172.206893 
-L 174.676658 172.401583 
-L 174.342099 172.595477 
-L 174.00754 172.788581 
-L 173.672981 172.980902 
-L 173.338421 173.172445 
-L 173.003862 173.363218 
-L 172.669303 173.553226 
-L 172.334743 173.742475 
-L 172.000184 173.930971 
-L 171.665625 174.118721 
-L 171.331066 174.30573 
-L 170.996506 174.492004 
-L 170.661947 174.677549 
-L 170.327388 174.86237 
-L 169.992829 175.046474 
-L 169.658269 175.229865 
-L 169.32371 175.41255 
-L 168.989151 175.594533 
-L 168.654591 175.77582 
-L 168.320032 175.956416 
-L 167.985473 176.136327 
-L 167.650914 176.315557 
-L 167.316354 176.494113 
-L 166.981795 176.671998 
-L 166.647236 176.849218 
-L 166.312676 177.025778 
-L 165.978117 177.201683 
-L 165.643558 177.376937 
-L 165.308999 177.551546 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 181.367844 168.413369 
+L 180.938023 168.606927 
+L 180.508202 168.799697 
+L 180.078381 168.991687 
+L 179.64856 169.182903 
+L 179.218739 169.37335 
+L 178.788918 169.563035 
+L 178.359097 169.751963 
+L 177.929276 169.940142 
+L 177.499455 170.127577 
+L 177.069635 170.314273 
+L 176.639814 170.500237 
+L 176.209993 170.685474 
+L 175.780172 170.86999 
+L 175.350351 171.053791 
+L 174.92053 171.236881 
+L 174.490709 171.419268 
+L 174.060888 171.600954 
+L 173.631067 171.781948 
+L 173.201246 171.962252 
+L 172.771425 172.141874 
+L 172.341604 172.320817 
+L 171.911783 172.499087 
+L 171.481962 172.67669 
+L 171.052142 172.853629 
+L 170.622321 173.02991 
+L 170.1925 173.205538 
+L 169.762679 173.380518 
+L 169.332858 173.554854 
+L 168.903037 173.728551 
+L 168.473216 173.901614 
+L 168.043395 174.074048 
+L 167.613574 174.245856 
+L 167.183753 174.417044 
+L 166.753932 174.587616 
+L 166.324111 174.757576 
+L 165.89429 174.926929 
+L 165.464469 175.095679 
+L 165.034649 175.263831 
+L 164.604828 175.431388 
+L 164.175007 175.598354 
+L 163.745186 175.764735 
+L 163.315365 175.930534 
+L 162.885544 176.095754 
+L 162.455723 176.260401 
+L 162.025902 176.424478 
+L 161.596081 176.587989 
+L 161.16626 176.750938 
+L 160.736439 176.913328 
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 165.308999 177.551546 
-L 165.199956 177.700667 
-L 165.090913 177.849321 
-L 164.98187 177.997511 
-L 164.872828 178.145238 
-L 164.763785 178.292506 
-L 164.654742 178.439318 
-L 164.5457 178.585677 
-L 164.436657 178.731586 
-L 164.327614 178.877046 
-L 164.218571 179.022062 
-L 164.109529 179.166635 
-L 164.000486 179.310768 
-L 163.891443 179.454465 
-L 163.782401 179.597727 
-L 163.673358 179.740558 
-L 163.564315 179.882959 
-L 163.455272 180.024934 
-L 163.34623 180.166485 
-L 163.237187 180.307615 
-L 163.128144 180.448325 
-L 163.019101 180.588619 
-L 162.910059 180.728499 
-L 162.801016 180.867968 
-L 162.691973 181.007027 
-L 162.582931 181.14568 
-L 162.473888 181.283928 
-L 162.364845 181.421774 
-L 162.255802 181.55922 
-L 162.14676 181.696269 
-L 162.037717 181.832923 
-L 161.928674 181.969184 
-L 161.819631 182.105054 
-L 161.710589 182.240536 
-L 161.601546 182.375632 
-L 161.492503 182.510343 
-L 161.383461 182.644674 
-L 161.274418 182.778624 
-L 161.165375 182.912197 
-L 161.056332 183.045395 
-L 160.94729 183.178219 
-L 160.838247 183.310672 
-L 160.729204 183.442756 
-L 160.620161 183.574473 
-L 160.511119 183.705825 
-L 160.402076 183.836814 
-L 160.293033 183.967442 
-L 160.183991 184.097711 
-L 160.074948 184.227623 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 160.736439 176.913328 
+L 160.722658 177.080982 
+L 160.708877 177.248044 
+L 160.695096 177.41452 
+L 160.681315 177.580413 
+L 160.667534 177.745727 
+L 160.653753 177.910467 
+L 160.639972 178.074636 
+L 160.626191 178.238239 
+L 160.61241 178.401278 
+L 160.598629 178.563759 
+L 160.584847 178.725685 
+L 160.571066 178.88706 
+L 160.557285 179.047887 
+L 160.543504 179.20817 
+L 160.529723 179.367913 
+L 160.515942 179.527119 
+L 160.502161 179.685793 
+L 160.48838 179.843937 
+L 160.474599 180.001555 
+L 160.460818 180.158651 
+L 160.447037 180.315228 
+L 160.433256 180.471289 
+L 160.419475 180.626838 
+L 160.405694 180.781879 
+L 160.391912 180.936413 
+L 160.378131 181.090446 
+L 160.36435 181.24398 
+L 160.350569 181.397018 
+L 160.336788 181.549563 
+L 160.323007 181.70162 
+L 160.309226 181.853189 
+L 160.295445 182.004276 
+L 160.281664 182.154883 
+L 160.267883 182.305013 
+L 160.254102 182.454668 
+L 160.240321 182.603853 
+L 160.22654 182.752569 
+L 160.212759 182.900821 
+L 160.198977 183.04861 
+L 160.185196 183.19594 
+L 160.171415 183.342813 
+L 160.157634 183.489233 
+L 160.143853 183.635201 
+L 160.130072 183.780722 
+L 160.116291 183.925797 
+L 160.10251 184.070429 
+L 160.088729 184.214622 
+L 160.074948 184.358377 
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 160.074948 184.227623 
-L 160.011502 184.293814 
-L 159.948056 184.359912 
-L 159.88461 184.425918 
-L 159.821164 184.491832 
-L 159.757718 184.557654 
-L 159.694272 184.623386 
-L 159.630826 184.689026 
-L 159.56738 184.754576 
-L 159.503933 184.820035 
-L 159.440487 184.885403 
-L 159.377041 184.950682 
-L 159.313595 185.015871 
-L 159.250149 185.080971 
-L 159.186703 185.145981 
-L 159.123257 185.210902 
-L 159.059811 185.275734 
-L 158.996365 185.340478 
-L 158.932919 185.405133 
-L 158.869473 185.469701 
-L 158.806027 185.53418 
-L 158.742581 185.598572 
-L 158.679135 185.662877 
-L 158.615689 185.727094 
-L 158.552243 185.791225 
-L 158.488797 185.855268 
-L 158.425351 185.919226 
-L 158.361905 185.983097 
-L 158.298459 186.046883 
-L 158.235013 186.110582 
-L 158.171567 186.174196 
-L 158.108121 186.237725 
-L 158.044675 186.301169 
-L 157.981229 186.364528 
-L 157.917783 186.427802 
-L 157.854337 186.490993 
-L 157.790891 186.554099 
-L 157.727444 186.617121 
-L 157.663998 186.680059 
-L 157.600552 186.742914 
-L 157.537106 186.805686 
-L 157.47366 186.868374 
-L 157.410214 186.93098 
-L 157.346768 186.993503 
-L 157.283322 187.055944 
-L 157.219876 187.118303 
-L 157.15643 187.18058 
-L 157.092984 187.242775 
-L 157.029538 187.304888 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 160.074948 184.358377 
+L 160.011502 184.424779 
+L 159.948056 184.491088 
+L 159.88461 184.557304 
+L 159.821164 184.623428 
+L 159.757718 184.68946 
+L 159.694272 184.7554 
+L 159.630826 184.821248 
+L 159.56738 184.887005 
+L 159.503933 184.952671 
+L 159.440487 185.018246 
+L 159.377041 185.08373 
+L 159.313595 185.149124 
+L 159.250149 185.214429 
+L 159.186703 185.279643 
+L 159.123257 185.344767 
+L 159.059811 185.409802 
+L 158.996365 185.474749 
+L 158.932919 185.539606 
+L 158.869473 185.604374 
+L 158.806027 185.669055 
+L 158.742581 185.733647 
+L 158.679135 185.798151 
+L 158.615689 185.862567 
+L 158.552243 185.926897 
+L 158.488797 185.991138 
+L 158.425351 186.055293 
+L 158.361905 186.119362 
+L 158.298459 186.183343 
+L 158.235013 186.247239 
+L 158.171567 186.311048 
+L 158.108121 186.374772 
+L 158.044675 186.43841 
+L 157.981229 186.501963 
+L 157.917783 186.565431 
+L 157.854337 186.628814 
+L 157.790891 186.692112 
+L 157.727444 186.755326 
+L 157.663998 186.818455 
+L 157.600552 186.881501 
+L 157.537106 186.944463 
+L 157.47366 187.007341 
+L 157.410214 187.070136 
+L 157.346768 187.132848 
+L 157.283322 187.195477 
+L 157.219876 187.258024 
+L 157.15643 187.320488 
+L 157.092984 187.382869 
+L 157.029538 187.445169 
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 157.029538 187.304888 
-L 156.877361 187.514035 
-L 156.725185 187.722263 
-L 156.573008 187.92958 
-L 156.420832 188.135994 
-L 156.268655 188.341513 
-L 156.116478 188.546145 
-L 155.964302 188.749897 
-L 155.812125 188.952777 
-L 155.659949 189.154793 
-L 155.507772 189.355951 
-L 155.355595 189.556259 
-L 155.203419 189.755724 
-L 155.051242 189.954353 
-L 154.899065 190.152153 
-L 154.746889 190.349131 
-L 154.594712 190.545294 
-L 154.442536 190.740649 
-L 154.290359 190.935202 
-L 154.138182 191.128959 
-L 153.986006 191.321928 
-L 153.833829 191.514114 
-L 153.681652 191.705524 
-L 153.529476 191.896164 
-L 153.377299 192.086041 
-L 153.225123 192.27516 
-L 153.072946 192.463527 
-L 152.920769 192.651149 
-L 152.768593 192.838031 
-L 152.616416 193.024179 
-L 152.46424 193.209598 
-L 152.312063 193.394296 
-L 152.159886 193.578276 
-L 152.00771 193.761545 
-L 151.855533 193.944108 
-L 151.703356 194.125971 
-L 151.55118 194.307139 
-L 151.399003 194.487617 
-L 151.246827 194.66741 
-L 151.09465 194.846523 
-L 150.942473 195.024963 
-L 150.790297 195.202733 
-L 150.63812 195.379839 
-L 150.485943 195.556286 
-L 150.333767 195.732078 
-L 150.18159 195.907221 
-L 150.029414 196.081719 
-L 149.877237 196.255577 
-L 149.72506 196.428799 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 157.029538 187.445169 
+L 156.877361 187.652475 
+L 156.725185 187.858877 
+L 156.573008 188.064385 
+L 156.420832 188.269006 
+L 156.268655 188.472747 
+L 156.116478 188.675616 
+L 155.964302 188.87762 
+L 155.812125 189.078767 
+L 155.659949 189.279065 
+L 155.507772 189.478519 
+L 155.355595 189.677137 
+L 155.203419 189.874927 
+L 155.051242 190.071895 
+L 154.899065 190.268048 
+L 154.746889 190.463392 
+L 154.594712 190.657934 
+L 154.442536 190.851682 
+L 154.290359 191.04464 
+L 154.138182 191.236817 
+L 153.986006 191.428217 
+L 153.833829 191.618847 
+L 153.681652 191.808714 
+L 153.529476 191.997823 
+L 153.377299 192.186181 
+L 153.225123 192.373793 
+L 153.072946 192.560666 
+L 152.920769 192.746805 
+L 152.768593 192.932215 
+L 152.616416 193.116903 
+L 152.46424 193.300875 
+L 152.312063 193.484135 
+L 152.159886 193.666689 
+L 152.00771 193.848543 
+L 151.855533 194.029702 
+L 151.703356 194.210171 
+L 151.55118 194.389955 
+L 151.399003 194.56906 
+L 151.246827 194.747491 
+L 151.09465 194.925253 
+L 150.942473 195.10235 
+L 150.790297 195.278789 
+L 150.63812 195.454573 
+L 150.485943 195.629707 
+L 150.333767 195.804197 
+L 150.18159 195.978047 
+L 150.029414 196.151261 
+L 149.877237 196.323845 
+L 149.72506 196.495802 
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 149.72506 196.428799 
-L 149.001675 200.314426 
-L 148.27829 203.905513 
-L 147.554905 207.243585 
-L 146.831519 210.36196 
-L 146.108134 213.287781 
-L 145.384749 216.04345 
-L 144.661364 218.647675 
-L 143.937979 221.116239 
-L 143.214593 223.462577 
-L 142.491208 225.698225 
-L 141.767823 227.833157 
-L 141.044438 229.876059 
-L 140.321052 231.834538 
-L 139.597667 233.715294 
-L 138.874282 235.524264 
-L 138.150897 237.266724 
-L 137.427512 238.947394 
-L 136.704126 240.570506 
-L 135.980741 242.139872 
-L 135.257356 243.658938 
-L 134.533971 245.130828 
-L 133.810585 246.558384 
-L 133.0872 247.944199 
-L 132.363815 249.290645 
-L 131.64043 250.599898 
-L 130.917045 251.873956 
-L 130.193659 253.114662 
-L 129.470274 254.323719 
-L 128.746889 255.502701 
-L 128.023504 256.653067 
-L 127.300118 257.776175 
-L 126.576733 258.873285 
-L 125.853348 259.945575 
-L 125.129963 260.994142 
-L 124.406577 262.020014 
-L 123.683192 263.024153 
-L 122.959807 264.007459 
-L 122.236422 264.97078 
-L 121.513037 265.914913 
-L 120.789651 266.840606 
-L 120.066266 267.748566 
-L 119.342881 268.63946 
-L 118.619496 269.513917 
-L 117.89611 270.372534 
-L 117.172725 271.215873 
-L 116.44934 272.044469 
-L 115.725955 272.858829 
-L 115.00257 273.659433 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 149.72506 196.495802 
+L 149.001675 200.392201 
+L 148.27829 203.992487 
+L 147.554905 207.338505 
+L 146.831519 210.463814 
+L 146.108134 213.395737 
+L 145.384749 216.156819 
+L 144.661364 218.765877 
+L 143.937979 221.238782 
+L 143.214593 223.589043 
+L 142.491208 225.828251 
+L 141.767823 227.966431 
+L 141.044438 230.012305 
+L 140.321052 231.973515 
+L 139.597667 233.856791 
+L 138.874282 235.668091 
+L 138.150897 237.412714 
+L 137.427512 239.095395 
+L 136.704126 240.720382 
+L 135.980741 242.291502 
+L 135.257356 243.812211 
+L 134.533971 245.285643 
+L 133.810585 246.71465 
+L 133.0872 248.101832 
+L 132.363815 249.449569 
+L 131.64043 250.760042 
+L 130.917045 252.035255 
+L 130.193659 253.277057 
+L 129.470274 254.487155 
+L 128.746889 255.667126 
+L 128.023504 256.818434 
+L 127.300118 257.942439 
+L 126.576733 259.040406 
+L 125.853348 260.113514 
+L 125.129963 261.162864 
+L 124.406577 262.189485 
+L 123.683192 263.194341 
+L 122.959807 264.178336 
+L 122.236422 265.142317 
+L 121.513037 266.087084 
+L 120.789651 267.013387 
+L 120.066266 267.921934 
+L 119.342881 268.813392 
+L 118.619496 269.688394 
+L 117.89611 270.547535 
+L 117.172725 271.39138 
+L 116.44934 272.220465 
+L 115.725955 273.035297 
+L 115.00257 273.836357 
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.00257 273.659433 
-L 114.685339 274.382285 
-L 114.368108 275.094278 
-L 114.050877 275.795734 
-L 113.733646 276.48696 
-L 113.416415 277.168251 
-L 113.099184 277.839888 
-L 112.781954 278.502141 
-L 112.464723 279.155268 
-L 112.147492 279.799518 
-L 111.830261 280.435128 
-L 111.51303 281.062328 
-L 111.195799 281.681336 
-L 110.878569 282.292365 
-L 110.561338 282.895617 
-L 110.244107 283.491287 
-L 109.926876 284.079565 
-L 109.609645 284.66063 
-L 109.292414 285.234659 
-L 108.975184 285.801819 
-L 108.657953 286.362273 
-L 108.340722 286.916177 
-L 108.023491 287.463682 
-L 107.70626 288.004936 
-L 107.389029 288.540079 
-L 107.071799 289.069247 
-L 106.754568 289.592573 
-L 106.437337 290.110184 
-L 106.120106 290.622203 
-L 105.802875 291.128751 
-L 105.485644 291.629942 
-L 105.168414 292.125889 
-L 104.851183 292.616701 
-L 104.533952 293.102482 
-L 104.216721 293.583335 
-L 103.89949 294.059359 
-L 103.582259 294.53065 
-L 103.265028 294.997301 
-L 102.947798 295.459402 
-L 102.630567 295.917041 
-L 102.313336 296.370305 
-L 101.996105 296.819275 
-L 101.678874 297.264032 
-L 101.361643 297.704654 
-L 101.044413 298.141218 
-L 100.727182 298.573798 
-L 100.409951 299.002466 
-L 100.09272 299.427291 
-L 99.775489 299.848343 
-" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.00257 273.836357 
+L 114.685339 274.57697 
+L 114.368108 275.306188 
+L 114.050877 276.024357 
+L 113.733646 276.731807 
+L 113.416415 277.428853 
+L 113.099184 278.115796 
+L 112.781954 278.792926 
+L 112.464723 279.460519 
+L 112.147492 280.11884 
+L 111.830261 280.768142 
+L 111.51303 281.408669 
+L 111.195799 282.040657 
+L 110.878569 282.664328 
+L 110.561338 283.2799 
+L 110.244107 283.887579 
+L 109.926876 284.487567 
+L 109.609645 285.080054 
+L 109.292414 285.665227 
+L 108.975184 286.243263 
+L 108.657953 286.814335 
+L 108.340722 287.378608 
+L 108.023491 287.936243 
+L 107.70626 288.487393 
+L 107.389029 289.032209 
+L 107.071799 289.570833 
+L 106.754568 290.103405 
+L 106.437337 290.63006 
+L 106.120106 291.150927 
+L 105.802875 291.666133 
+L 105.485644 292.175799 
+L 105.168414 292.680042 
+L 104.851183 293.178978 
+L 104.533952 293.672716 
+L 104.216721 294.161365 
+L 103.89949 294.645027 
+L 103.582259 295.123804 
+L 103.265028 295.597792 
+L 102.947798 296.067088 
+L 102.630567 296.531783 
+L 102.313336 296.991966 
+L 101.996105 297.447725 
+L 101.678874 297.899142 
+L 101.361643 298.346302 
+L 101.044413 298.789282 
+L 100.727182 299.22816 
+L 100.409951 299.663012 
+L 100.09272 300.09391 
+L 99.775489 300.520927 
+" clip-path="url(#p3c6da9ddf3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.448437 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-11T10:44:33Z  ·  Linux chungus2 x86_64  ·  commit c014c7e1  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.058516 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6289,31 +6289,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6413,14 +6388,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6460,109 +6435,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3372.705078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3436.328125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3497.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3561.474609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3593.261719 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3625.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3656.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3688.623047 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3720.410156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3748.193359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3809.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3870.996094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3934.375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3997.851562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4036.714844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4097.896484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4157.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4218.599609 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4259.712891 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4293.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4321.1875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4382.710938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4443.990234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4507.369141 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4570.992188 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4604.683594 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4663.863281 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4727.486328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4759.273438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4822.896484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4886.519531 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4918.306641 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4981.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5018.013672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5056.876953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5111.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5175.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5207.267578 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5239.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5270.841797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5302.628906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5334.416016 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5373.625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5437.003906 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5475.867188 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5537.048828 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5600.427734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5663.904297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5727.283203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5790.759766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5854.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5893.347656 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6008.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6040.710938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6138.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6199.646484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6263.123047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6290.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6352.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6415.564453 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6447.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6499.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6562.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6624.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6864.246094 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6903.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6937.146484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6968.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7010.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7071.326172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7110.535156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7138.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7199.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7231.287109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7259.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7311.169922 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7342.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7406.433594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7467.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7507.166016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7568.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7608.052734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7705.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7733.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7796.626953 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7824.410156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7876.509766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7915.71875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7943.501953 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p0c24897947">
+  <clipPath id="p3c6da9ddf3">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p16c51a6746)">
+   <g clip-path="url(#pd03946ca6d)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/ElEQVR4nO3YwYqkVx2H4aqe7qZnxAFlEodZCu4kuMjG2bj2TnIFLsW91xG9AUFEdCOKGzfiTrILEmIyxnEmdNdUf+UlTIQT/lLv81zB71DU+V7OfvvXh6fduXn12fSCpU6fn9d5drvd7uOf/Gp6wlIf/fX19ITlfvSLH09PWG7/g/enJ6y1v5hesN7LT6YXrHfzeHrBUr/8zs+nJyx3hv8kAICvTgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKTt746/Pk2PWO2026YnLLU/w2a9urienrDUYbudnrDc1d/+PD1hueP3n09PWOq4HaYnLPf6+HJ6wnJPzux6ePP4yfSE5c7vKwsA8D8QQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaZdXr7+Y3rDe3ZfTC9Y6bdML1nv4eHrBUtfTA74Gp5evpycsd/WfF9MTlrrajtMTlnt4jvfd7avpBUtdXZ7fjedlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn74/bb0/SI1U6nbXrCUtuZnWe32+2uLq6nJyx1fzpOT1juwasX0xPW++a70wuWerMdpics9/ntP6YnLPf07nJ6wlLbt55NT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHb5l0//OL1huYvdfnrCUu88ejI9Ybn77Tg9YanrBzfTE5b74Pd/mJ6w3M9++L3pCUsdT9v0hOV++qe/T09Y7vmzb0xPWOqD955PT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDS9m/uf3OaHrHa4f52esJSD/c30xN4i8P+OD1huX/ffTY9Yblv3zydnrDUdtqmJyz3xd2n0xOWe3H3yfSEpb77+L3pCct5GQIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDaftt+d5oeAfwfOh6mF6x3eT29gLe4vf9yesJyNw8eTU/gLbwMAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIO1yd3+c3rDexZk13v7MzrPb7XZvbqcXrHVxOb1gucPFNj1huevpAaudzu83Om6H6QnL/fPwYnrCUu/cPJuesNwZfmUBAL46MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfKmeKG6wY/4kAAAAASUVORK5CYII=" id="imagef8bb2e754b" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/ElEQVR4nO3YwYqkVx2H4aqe7qZnxAFlEodZCu4kuMjG2bj2TnIFLsW91xG9AUFEdCOKGzfiTrILEmIyxnEmdNdUf+UlTIQT/lLv81zB71DU+V7OfvvXh6fduXn12fSCpU6fn9d5drvd7uOf/Gp6wlIf/fX19ITlfvSLH09PWG7/g/enJ6y1v5hesN7LT6YXrHfzeHrBUr/8zs+nJyx3hv8kAICvTgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKTt746/Pk2PWO2026YnLLU/w2a9urienrDUYbudnrDc1d/+PD1hueP3n09PWOq4HaYnLPf6+HJ6wnJPzux6ePP4yfSE5c7vKwsA8D8QQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaZdXr7+Y3rDe3ZfTC9Y6bdML1nv4eHrBUtfTA74Gp5evpycsd/WfF9MTlrrajtMTlnt4jvfd7avpBUtdXZ7fjedlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn74/bb0/SI1U6nbXrCUtuZnWe32+2uLq6nJyx1fzpOT1juwasX0xPW++a70wuWerMdpics9/ntP6YnLPf07nJ6wlLbt55NT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHb5l0//OL1huYvdfnrCUu88ejI9Ybn77Tg9YanrBzfTE5b74Pd/mJ6w3M9++L3pCUsdT9v0hOV++qe/T09Y7vmzb0xPWOqD955PT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDS9m/uf3OaHrHa4f52esJSD/c30xN4i8P+OD1huX/ffTY9Yblv3zydnrDUdtqmJyz3xd2n0xOWe3H3yfSEpb77+L3pCct5GQIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDaftt+d5oeAfwfOh6mF6x3eT29gLe4vf9yesJyNw8eTU/gLbwMAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIO1yd3+c3rDexZk13v7MzrPb7XZvbqcXrHVxOb1gucPFNj1huevpAaudzu83Om6H6QnL/fPwYnrCUu/cPJuesNwZfmUBAL46MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfKmeKG6wY/4kAAAAASUVORK5CYII=" id="image374978a6dc" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m105c745f5e" d="M 0 0 
+       <path id="m5ca78e946d" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m105c745f5e" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ca78e946d" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m105c745f5e" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ca78e946d" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m105c745f5e" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ca78e946d" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m105c745f5e" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ca78e946d" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m105c745f5e" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ca78e946d" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m105c745f5e" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ca78e946d" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m105c745f5e" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ca78e946d" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m105c745f5e" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ca78e946d" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m105c745f5e" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ca78e946d" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m105c745f5e" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ca78e946d" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m105c745f5e" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ca78e946d" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m39ae11d3f0" d="M 0 0 
+       <path id="me8d6de8e68" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m39ae11d3f0" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me8d6de8e68" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m39ae11d3f0" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me8d6de8e68" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m39ae11d3f0" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me8d6de8e68" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m39ae11d3f0" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me8d6de8e68" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m39ae11d3f0" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me8d6de8e68" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m39ae11d3f0" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me8d6de8e68" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m39ae11d3f0" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me8d6de8e68" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m39ae11d3f0" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me8d6de8e68" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image0ead8fd4b4" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagebf81e4ad43" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m96694a7ba4" d="M 0 0 
+       <path id="m20f3bf72aa" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m96694a7ba4" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m20f3bf72aa" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m96694a7ba4" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m20f3bf72aa" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m96694a7ba4" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m20f3bf72aa" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m96694a7ba4" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m20f3bf72aa" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m96694a7ba4" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m20f3bf72aa" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m96694a7ba4" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m20f3bf72aa" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m96694a7ba4" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m20f3bf72aa" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m96694a7ba4" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m20f3bf72aa" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m96694a7ba4" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m20f3bf72aa" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.448437 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-11T10:44:33Z  ·  Linux chungus2 x86_64  ·  commit c014c7e1  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.058516 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2952,14 +2952,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3372.705078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3436.328125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3497.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3561.474609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3593.261719 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3625.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3656.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3688.623047 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3720.410156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3748.193359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3809.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3870.996094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3934.375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3997.851562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4036.714844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4097.896484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4157.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4218.599609 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4259.712891 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4293.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4321.1875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4382.710938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4443.990234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4507.369141 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4570.992188 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4604.683594 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4663.863281 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4727.486328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4759.273438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4822.896484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4886.519531 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4918.306641 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4981.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5018.013672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5056.876953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5111.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5175.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5207.267578 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5239.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5270.841797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5302.628906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5334.416016 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5373.625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5437.003906 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5475.867188 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5537.048828 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5600.427734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5663.904297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5727.283203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5790.759766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5854.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5893.347656 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6008.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6040.710938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6138.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6199.646484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6263.123047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6290.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6352.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6415.564453 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6447.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6499.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6562.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6624.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6864.246094 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6903.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6937.146484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6968.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7010.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7071.326172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7110.535156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7138.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7199.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7231.287109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7259.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7311.169922 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7342.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7406.433594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7467.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7507.166016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7568.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7608.052734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7705.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7733.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7796.626953 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7824.410156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7876.509766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7915.71875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7943.501953 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p16c51a6746">
+  <clipPath id="pd03946ca6d">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.503125pt" height="386.202469pt" viewBox="0 0 573.503125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="574.282969pt" height="386.202469pt" viewBox="0 0 574.282969 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 573.503125 386.202469 
-L 573.503125 0 
+L 574.282969 386.202469 
+L 574.282969 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.876563 104.1264 
-L 293.501563 104.1264 
-L 293.501563 74.7432 
-L 188.876563 74.7432 
+    <path d="M 189.266484 104.1264 
+L 293.891484 104.1264 
+L 293.891484 74.7432 
+L 189.266484 74.7432 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.501563 104.1264 
-L 398.126563 104.1264 
-L 398.126563 74.7432 
-L 293.501563 74.7432 
+    <path d="M 293.891484 104.1264 
+L 398.516484 104.1264 
+L 398.516484 74.7432 
+L 293.891484 74.7432 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 398.126563 104.1264 
-L 502.751563 104.1264 
-L 502.751563 74.7432 
-L 398.126563 74.7432 
+    <path d="M 398.516484 104.1264 
+L 503.141484 104.1264 
+L 503.141484 74.7432 
+L 398.516484 74.7432 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.876563 133.5096 
-L 293.501563 133.5096 
-L 293.501563 104.1264 
-L 188.876563 104.1264 
+    <path d="M 189.266484 133.5096 
+L 293.891484 133.5096 
+L 293.891484 104.1264 
+L 189.266484 104.1264 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.501563 133.5096 
-L 398.126563 133.5096 
-L 398.126563 104.1264 
-L 293.501563 104.1264 
+    <path d="M 293.891484 133.5096 
+L 398.516484 133.5096 
+L 398.516484 104.1264 
+L 293.891484 104.1264 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 398.126563 133.5096 
-L 502.751563 133.5096 
-L 502.751563 104.1264 
-L 398.126563 104.1264 
+    <path d="M 398.516484 133.5096 
+L 503.141484 133.5096 
+L 503.141484 104.1264 
+L 398.516484 104.1264 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.876563 162.8928 
-L 293.501563 162.8928 
-L 293.501563 133.5096 
-L 188.876563 133.5096 
+    <path d="M 189.266484 162.8928 
+L 293.891484 162.8928 
+L 293.891484 133.5096 
+L 189.266484 133.5096 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.501563 162.8928 
-L 398.126563 162.8928 
-L 398.126563 133.5096 
-L 293.501563 133.5096 
+    <path d="M 293.891484 162.8928 
+L 398.516484 162.8928 
+L 398.516484 133.5096 
+L 293.891484 133.5096 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 398.126563 162.8928 
-L 502.751563 162.8928 
-L 502.751563 133.5096 
-L 398.126563 133.5096 
+    <path d="M 398.516484 162.8928 
+L 503.141484 162.8928 
+L 503.141484 133.5096 
+L 398.516484 133.5096 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.876563 192.276 
-L 293.501563 192.276 
-L 293.501563 162.8928 
-L 188.876563 162.8928 
+    <path d="M 189.266484 192.276 
+L 293.891484 192.276 
+L 293.891484 162.8928 
+L 189.266484 162.8928 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.501563 192.276 
-L 398.126563 192.276 
-L 398.126563 162.8928 
-L 293.501563 162.8928 
+    <path d="M 293.891484 192.276 
+L 398.516484 192.276 
+L 398.516484 162.8928 
+L 293.891484 162.8928 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 398.126563 192.276 
-L 502.751563 192.276 
-L 502.751563 162.8928 
-L 398.126563 162.8928 
+    <path d="M 398.516484 192.276 
+L 503.141484 192.276 
+L 503.141484 162.8928 
+L 398.516484 162.8928 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.876563 221.6592 
-L 293.501563 221.6592 
-L 293.501563 192.276 
-L 188.876563 192.276 
+    <path d="M 189.266484 221.6592 
+L 293.891484 221.6592 
+L 293.891484 192.276 
+L 189.266484 192.276 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.501563 221.6592 
-L 398.126563 221.6592 
-L 398.126563 192.276 
-L 293.501563 192.276 
+    <path d="M 293.891484 221.6592 
+L 398.516484 221.6592 
+L 398.516484 192.276 
+L 293.891484 192.276 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 398.126563 221.6592 
-L 502.751563 221.6592 
-L 502.751563 192.276 
-L 398.126563 192.276 
+    <path d="M 398.516484 221.6592 
+L 503.141484 221.6592 
+L 503.141484 192.276 
+L 398.516484 192.276 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.876563 251.0424 
-L 293.501563 251.0424 
-L 293.501563 221.6592 
-L 188.876563 221.6592 
+    <path d="M 189.266484 251.0424 
+L 293.891484 251.0424 
+L 293.891484 221.6592 
+L 189.266484 221.6592 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.501563 251.0424 
-L 398.126563 251.0424 
-L 398.126563 221.6592 
-L 293.501563 221.6592 
+    <path d="M 293.891484 251.0424 
+L 398.516484 251.0424 
+L 398.516484 221.6592 
+L 293.891484 221.6592 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 398.126563 251.0424 
-L 502.751563 251.0424 
-L 502.751563 221.6592 
-L 398.126563 221.6592 
+    <path d="M 398.516484 251.0424 
+L 503.141484 251.0424 
+L 503.141484 221.6592 
+L 398.516484 221.6592 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.876563 280.4256 
-L 293.501563 280.4256 
-L 293.501563 251.0424 
-L 188.876563 251.0424 
+    <path d="M 189.266484 280.4256 
+L 293.891484 280.4256 
+L 293.891484 251.0424 
+L 189.266484 251.0424 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #f5fbb2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #f5fbb2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.501563 280.4256 
-L 398.126563 280.4256 
-L 398.126563 251.0424 
-L 293.501563 251.0424 
+    <path d="M 293.891484 280.4256 
+L 398.516484 280.4256 
+L 398.516484 251.0424 
+L 293.891484 251.0424 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 398.126563 280.4256 
-L 502.751563 280.4256 
-L 502.751563 251.0424 
-L 398.126563 251.0424 
+    <path d="M 398.516484 280.4256 
+L 503.141484 280.4256 
+L 503.141484 251.0424 
+L 398.516484 251.0424 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.876563 309.8088 
-L 293.501563 309.8088 
-L 293.501563 280.4256 
-L 188.876563 280.4256 
+    <path d="M 189.266484 309.8088 
+L 293.891484 309.8088 
+L 293.891484 280.4256 
+L 189.266484 280.4256 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.501563 309.8088 
-L 398.126563 309.8088 
-L 398.126563 280.4256 
-L 293.501563 280.4256 
+    <path d="M 293.891484 309.8088 
+L 398.516484 309.8088 
+L 398.516484 280.4256 
+L 293.891484 280.4256 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.126563 309.8088 
-L 502.751563 309.8088 
-L 502.751563 280.4256 
-L 398.126563 280.4256 
+    <path d="M 398.516484 309.8088 
+L 503.141484 309.8088 
+L 503.141484 280.4256 
+L 398.516484 280.4256 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.876563 339.192 
-L 293.501563 339.192 
-L 293.501563 309.8088 
-L 188.876563 309.8088 
+    <path d="M 189.266484 339.192 
+L 293.891484 339.192 
+L 293.891484 309.8088 
+L 189.266484 309.8088 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.501563 339.192 
-L 398.126563 339.192 
-L 398.126563 309.8088 
-L 293.501563 309.8088 
+    <path d="M 293.891484 339.192 
+L 398.516484 339.192 
+L 398.516484 309.8088 
+L 293.891484 309.8088 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 398.126563 339.192 
-L 502.751563 339.192 
-L 502.751563 309.8088 
-L 398.126563 309.8088 
+    <path d="M 398.516484 339.192 
+L 503.141484 339.192 
+L 503.141484 309.8088 
+L 398.516484 309.8088 
 z
-" clip-path="url(#p46f6e8e4d7)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb615158ac8)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.863828 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.25375 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(229.148047 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.537969 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.720156 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.110078 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.071875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.461797 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.801563 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.191484 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(229.737813 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(338.179063 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.568984 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(442.804063 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.193984 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.439688 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.829609 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(229.737813 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(340.724063 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.113984 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(442.804063 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.193984 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(129.702813 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(130.092734 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(229.737813 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(340.724063 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.113984 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(442.804063 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.193984 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(100.132813 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(100.522734 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(229.737813 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(340.724063 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.113984 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(442.804063 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.193984 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(113.009063 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(113.398984 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(229.737813 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(340.724063 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.113984 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(442.804063 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.193984 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(121.165313 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(121.555234 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(229.737813 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(340.724063 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.113984 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(445.349063 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(445.738984 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.510938 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.900859 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1753,7 +1753,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.299 -->
-    <g transform="translate(228.537188 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.927109 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1844,8 +1844,8 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 32 -->
-    <g transform="translate(340.247813 267.9415) scale(0.08 -0.08)">
+    <!-- 31 -->
+    <g transform="translate(340.637734 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-33" d="M 2981 2516 
 Q 3453 2394 3698 2092 
@@ -1879,14 +1879,28 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 244 -->
-    <g transform="translate(442.089688 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(442.479609 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-34" d="M 2356 3675 
 L 1038 1722 
@@ -1915,7 +1929,7 @@ z
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.625938 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.015859 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1980,7 +1994,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(229.737813 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1990,14 +2004,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(340.724063 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.113984 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(442.804063 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.193984 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2005,7 +2019,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.847188 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.237109 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2016,7 +2030,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(229.737813 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2026,13 +2040,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(343.269063 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.658984 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.439063 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.828984 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2048,7 +2062,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(136.260313 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(136.650234 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2261,7 +2275,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-11T10:44:33Z  ·  Linux chungus2 x86_64  ·  commit c014c7e1  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2402,14 +2416,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2449,110 +2463,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3372.705078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3436.328125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3497.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3561.474609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3593.261719 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3625.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3656.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3688.623047 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3720.410156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3748.193359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3809.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3870.996094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3934.375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3997.851562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4036.714844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4097.896484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4157.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4218.599609 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4259.712891 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4293.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4321.1875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4382.710938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4443.990234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4507.369141 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4570.992188 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4604.683594 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4663.863281 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4727.486328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4759.273438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4822.896484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4886.519531 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4918.306641 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4981.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5018.013672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5056.876953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5111.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5175.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5207.267578 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5239.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5270.841797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5302.628906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5334.416016 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5373.625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5437.003906 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5475.867188 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5537.048828 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5600.427734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5663.904297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5727.283203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5790.759766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5854.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5893.347656 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6008.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6040.710938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6138.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6199.646484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6263.123047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6290.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6352.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6415.564453 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6447.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6499.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6562.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6624.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6864.246094 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6903.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6937.146484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6968.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7010.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7071.326172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7110.535156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7138.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7199.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7231.287109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7259.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7311.169922 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7342.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7406.433594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7467.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7507.166016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7568.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7608.052734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7705.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7733.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7796.626953 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7824.410156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7876.509766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7915.71875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7943.501953 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p46f6e8e4d7">
-   <rect x="84.251563" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pb615158ac8">
+   <rect x="84.641484" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p90636e5c8b)">
+   <g clip-path="url(#p0f22bd9bf9)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ+0lEQVR4nO3YMW5l5R2H4bF9x+Mx0mgYiMUgmtBEUYqISAixjayDKm3WkA2kS5kFpEiTggKJNJRUIDEkEiHJKAyj4ca+trMI9L1/5+h5VvC7+vz5vOcc3fz7D7f3tuzy1fSCtY6OpxesdXOYXrDW1s/vcDm9YK3zx9ML1vrvy+kF/Bgnp9ML1tr63+f9s+kFS2386QcAwF0jQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO0+Ozyb3rDU6f3d9ISl9ofL6QlLPX309vSEpb568fX0hKUOR9fTE5b6+cMn0xOWOjw4m56w1N9f/m16wlIXDy+mJyy1Pz1MT1jq6N6r6QlL+QIKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkdhfnF9Mblnr62rvTE5b69tWz6QlLvbXf9jvSozd+OT1hqdOTs+kJS13fHKYnLLX189v87zve9u/bHb8zPWGps/1+esJS2366AwBw5whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSuwcn59Mblnq+/2Z6wlJbP7/r159MT1jq6/98Nj1hqZdX++kJS73/+vvTE5a6vD1MT1jqqxdfTk9Y6hdv/Gp6wlKffvPJ9ISl3vvJts/PF1AAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1NH1x7+5nR6x1M3N9AJ+jK2f37F3QBiz9fvn/+f/t8NhesFSGz89AADuGgEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqd/Hp59Mbljo5PZmesNS3n/9zesJSv//ovekJS/3ur9s+vw/feTQ9Yak//uXL6QlL/fbXP5uesNSfvvhuesJSP338cHrCUs9/uJqesNQHT8+nJyzlCygAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJA6urr+8+30iJVOri6nJ6x1cjq9YK3DfnrBWruz6QVrneymF6x1ezO9YK2rjd+/o41/gzne9v27Otr2/bt/OExPWGrjtw8AgLtGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNr944dn0xuWenv31vSEpV7cvJiesNSj642/Iz3YTS9Y62o/vWCpf10/n56w1JvXZ9MT1nrtyfSCpa5uLqcnLHX/+23fv3vnj6cXLLXxpzsAAHeNAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAIPU/NoF9xhk32p8AAAAASUVORK5CYII=" id="image3e8153f7e0" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ+UlEQVR4nO3YsY6cVx2HYe/u7Hq9kYzjwApbaaBBiAIFKULcBtdBRZtryA3QpcwFUNCkSIEUmpSpiBQHpJCAlViWs+zO7HIR0Xn/5tPzXMHv05kz8853dPufD+7ubdn1q+kFax0dTy9Y63Y/vWCtrZ/f/np6wVoXj6YXrPXfl9ML+CFOzqYXrLX1z+fp+fSCpTb+6wcAwOtGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNp9un82vWGps9Pd9ISlrvbX0xOWevLw6fSEpb548eX0hKX2R4fpCUv98sHj6QlL7e+fT09Y6p8v/zE9YanLB5fTE5a6OttPT1jq6N6r6QlLeQMKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkdpcXl9Mblnryxs+nJyz19atn0xOW+unVtv8jPXzr19MTljo7OZ+esNThdj89Yamtn9/mn+9428+3O357esJS51dX0xOW2vavOwAArx0BCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAanf/5GJ6w1LPr76anrDU1s/v8Obj6QlLffntp9MTlnp5czU9Yal333x3esJS13f76QlLffHi8+kJS/3qrd9MT1jqk6/+Oj1hqXd+su3z8wYUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAIHV0+PiPd9Mjlrq9nV7AD7H18zv2HxDGbP3++f78/7bfTy9YauOnBwDA60aAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2l1+8tn0hqVOzk6mJyz19WffTE9Y6k9/eGd6wlLv/23b5/e7tx9OT1jqw48+n56w1Hu//8X0hKX+/Pfvpics9bNHD6YnLPX8+5vpCUv99snF9ISlvAEFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSRzeHv9xNj1jp5OZ6esJaJ2fTC9baX00vWGt3Pr1grZPd9IK17m6nF6x1s/H7d7TxdzDH275/N0fbvn+n+/30hKU2fvsAAHjdCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFK7f33/bHrDUk9Pn05PWOq7w7fTE5b60WE3PWGt+xt/vpur6QVL/fvwfHrCUj8+nE9PWOuNx9MLljrc7acnLHX6Ytv3797Fo+kFS3kDCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJD6H6M5fcw3KSE9AAAAAElFTkSuQmCC" id="image1b63ae88ec" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m9a94b1dfac" d="M 0 0 
+       <path id="m306316f6bb" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9a94b1dfac" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m306316f6bb" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m9a94b1dfac" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m306316f6bb" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m9a94b1dfac" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m306316f6bb" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9a94b1dfac" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m306316f6bb" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m9a94b1dfac" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m306316f6bb" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9a94b1dfac" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m306316f6bb" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m9a94b1dfac" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m306316f6bb" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9a94b1dfac" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m306316f6bb" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m9a94b1dfac" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m306316f6bb" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9a94b1dfac" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m306316f6bb" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m9a94b1dfac" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m306316f6bb" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m9a94b1dfac" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m306316f6bb" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m78b4f57abb" d="M 0 0 
+       <path id="m8a2c7c53a2" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m78b4f57abb" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a2c7c53a2" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m78b4f57abb" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a2c7c53a2" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m78b4f57abb" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a2c7c53a2" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m78b4f57abb" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a2c7c53a2" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m78b4f57abb" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a2c7c53a2" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m78b4f57abb" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a2c7c53a2" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m78b4f57abb" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a2c7c53a2" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m78b4f57abb" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a2c7c53a2" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +41 -->
+    <!-- +40 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1175,6 +1175,37 @@ L 313 1709
 L 2253 4666 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -12 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
 L 1825 4091 
@@ -1189,16 +1220,6 @@ L 794 0
 L 794 531 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -12 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
 L 3431 0 
@@ -1230,45 +1251,11 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- +23 -->
+    <!-- +24 -->
     <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_24">
@@ -1312,57 +1299,68 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- +1 -->
+    <!-- +0 -->
     <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- -10 -->
+    <!-- -11 -->
     <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +33 -->
+    <!-- +31 -->
     <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -22 -->
+    <!-- -23 -->
     <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
@@ -1392,11 +1390,11 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- -29 -->
+    <!-- -30 -->
     <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_32">
@@ -2193,18 +2191,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagece5655bc19" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image78fccf981e" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m0acdf9616b" d="M 0 0 
+       <path id="m8a478dbc40" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0acdf9616b" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a478dbc40" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2227,7 +2225,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m0acdf9616b" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a478dbc40" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2241,7 +2239,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m0acdf9616b" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a478dbc40" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2255,7 +2253,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m0acdf9616b" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a478dbc40" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2268,7 +2266,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m0acdf9616b" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a478dbc40" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2281,7 +2279,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m0acdf9616b" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a478dbc40" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2294,7 +2292,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m0acdf9616b" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a478dbc40" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2910,8 +2908,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.448437 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-11T10:44:33Z  ·  Linux chungus2 x86_64  ·  commit c014c7e1  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.058516 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3002,14 +3000,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3049,109 +3047,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3372.705078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3436.328125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3497.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3561.474609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3593.261719 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3625.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3656.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3688.623047 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3720.410156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3748.193359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3809.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3870.996094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3934.375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3997.851562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4036.714844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4097.896484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4157.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4218.599609 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4259.712891 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4293.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4321.1875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4382.710938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4443.990234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4507.369141 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4570.992188 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4604.683594 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4663.863281 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4727.486328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4759.273438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4822.896484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4886.519531 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4918.306641 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4981.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5018.013672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5056.876953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5111.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5175.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5207.267578 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5239.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5270.841797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5302.628906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5334.416016 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5373.625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5437.003906 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5475.867188 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5537.048828 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5600.427734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5663.904297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5727.283203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5790.759766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5854.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5893.347656 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6008.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6040.710938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6138.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6199.646484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6263.123047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6290.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6352.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6415.564453 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6447.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6499.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6562.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6624.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6864.246094 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6903.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6937.146484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6968.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7010.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7071.326172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7110.535156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7138.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7199.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7231.287109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7259.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7311.169922 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7342.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7406.433594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7467.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7507.166016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7568.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7608.052734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7705.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7733.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7796.626953 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7824.410156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7876.509766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7915.71875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7943.501953 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p90636e5c8b">
+  <clipPath id="p0f22bd9bf9">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m1da7862f0d" d="M 0 0 
+       <path id="m0d3f6c74eb" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1da7862f0d" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d3f6c74eb" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m1da7862f0d" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d3f6c74eb" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m1da7862f0d" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d3f6c74eb" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m1da7862f0d" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d3f6c74eb" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m1da7862f0d" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d3f6c74eb" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m1da7862f0d" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d3f6c74eb" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1da7862f0d" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d3f6c74eb" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m8f9023b7f2" d="M 0 0 
+       <path id="m47915006ae" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8f9023b7f2" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47915006ae" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m8f9023b7f2" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47915006ae" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m8f9023b7f2" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47915006ae" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m2e6508a436" d="M 0 0 
+       <path id="m278ab1ee96" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m2e6508a436" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m278ab1ee96" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 108.896302) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 109.292002) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.814287 308.489091) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.814287 309.32634) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m4001f964d7" d="M -2.5 2.5 
+     <path id="m6f6b430d19" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbb573932c3)">
-     <use xlink:href="#m4001f964d7" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4001f964d7" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4001f964d7" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4001f964d7" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4001f964d7" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4001f964d7" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4001f964d7" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4001f964d7" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4001f964d7" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc1c9816156)">
+     <use xlink:href="#m6f6b430d19" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f6b430d19" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f6b430d19" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f6b430d19" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f6b430d19" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f6b430d19" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f6b430d19" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f6b430d19" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f6b430d19" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="ma29183881d" d="M 0 -2.5 
+     <path id="m3291a3c277" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbb573932c3)">
-     <use xlink:href="#ma29183881d" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma29183881d" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma29183881d" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma29183881d" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma29183881d" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma29183881d" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma29183881d" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma29183881d" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma29183881d" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc1c9816156)">
+     <use xlink:href="#m3291a3c277" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3291a3c277" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3291a3c277" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3291a3c277" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3291a3c277" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3291a3c277" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3291a3c277" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3291a3c277" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3291a3c277" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m90a1f84f26" d="M -0 3.535534 
+     <path id="m714fdc4297" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbb573932c3)">
-     <use xlink:href="#m90a1f84f26" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m90a1f84f26" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m90a1f84f26" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m90a1f84f26" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m90a1f84f26" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m90a1f84f26" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m90a1f84f26" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m90a1f84f26" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m90a1f84f26" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m90a1f84f26" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m90a1f84f26" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m90a1f84f26" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc1c9816156)">
+     <use xlink:href="#m714fdc4297" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m714fdc4297" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m714fdc4297" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m714fdc4297" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m714fdc4297" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m714fdc4297" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m714fdc4297" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m714fdc4297" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m714fdc4297" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m714fdc4297" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m714fdc4297" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m714fdc4297" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m17f6f47b15" d="M -0 2.5 
+     <path id="m2627f1dcd1" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbb573932c3)">
-     <use xlink:href="#m17f6f47b15" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc1c9816156)">
+     <use xlink:href="#m2627f1dcd1" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="mf4a12ef7a6" d="M -0.833333 2.5 
+     <path id="mc48bfe1990" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbb573932c3)">
-     <use xlink:href="#mf4a12ef7a6" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4a12ef7a6" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4a12ef7a6" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4a12ef7a6" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4a12ef7a6" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4a12ef7a6" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4a12ef7a6" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4a12ef7a6" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4a12ef7a6" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc1c9816156)">
+     <use xlink:href="#mc48bfe1990" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc48bfe1990" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc48bfe1990" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc48bfe1990" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc48bfe1990" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc48bfe1990" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc48bfe1990" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc48bfe1990" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc48bfe1990" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m208c0842f6" d="M -1.25 2.5 
+     <path id="mb5d485cb04" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbb573932c3)">
-     <use xlink:href="#m208c0842f6" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m208c0842f6" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m208c0842f6" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m208c0842f6" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m208c0842f6" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m208c0842f6" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m208c0842f6" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m208c0842f6" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m208c0842f6" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc1c9816156)">
+     <use xlink:href="#mb5d485cb04" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5d485cb04" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5d485cb04" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5d485cb04" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5d485cb04" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5d485cb04" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5d485cb04" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5d485cb04" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5d485cb04" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="mdcbf56fb2d" d="M 0 -2.5 
+     <path id="mdce8b5ac21" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pbb573932c3)">
-     <use xlink:href="#mdcbf56fb2d" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdcbf56fb2d" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdcbf56fb2d" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdcbf56fb2d" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdcbf56fb2d" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdcbf56fb2d" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdcbf56fb2d" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdcbf56fb2d" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdcbf56fb2d" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pc1c9816156)">
+     <use xlink:href="#mdce8b5ac21" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdce8b5ac21" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdce8b5ac21" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdce8b5ac21" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdce8b5ac21" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdce8b5ac21" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdce8b5ac21" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdce8b5ac21" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdce8b5ac21" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="mc36e2111ec" d="M 0 -2.5 
+     <path id="mb23ad3c044" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbb573932c3)">
-     <use xlink:href="#mc36e2111ec" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc36e2111ec" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc36e2111ec" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc36e2111ec" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc36e2111ec" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc36e2111ec" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc36e2111ec" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc36e2111ec" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc36e2111ec" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc1c9816156)">
+     <use xlink:href="#mb23ad3c044" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb23ad3c044" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb23ad3c044" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb23ad3c044" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb23ad3c044" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb23ad3c044" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb23ad3c044" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb23ad3c044" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb23ad3c044" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="md6d673790f" d="M 0 3.5 
+      <path id="mc4f1e17351" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#md6d673790f" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mc4f1e17351" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m4001f964d7" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6f6b430d19" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#ma29183881d" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3291a3c277" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m90a1f84f26" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m714fdc4297" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m17f6f47b15" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2627f1dcd1" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#mf4a12ef7a6" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc48bfe1990" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m208c0842f6" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb5d485cb04" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#mdcbf56fb2d" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mdce8b5ac21" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#mc36e2111ec" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb23ad3c044" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#pbb573932c3)">
-     <use xlink:href="#md6d673790f" x="319.643112" y="113.896302" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md6d673790f" x="263.489417" y="121.651517" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md6d673790f" x="236.23654" y="129.556055" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md6d673790f" x="192.820547" y="151.29592" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md6d673790f" x="180.389901" y="162.991723" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md6d673790f" x="155.351585" y="172.54048" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md6d673790f" x="149.634124" y="176.907409" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md6d673790f" x="139.514773" y="190.318146" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md6d673790f" x="119.666036" y="285.736411" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md6d673790f" x="97.814287" y="313.489091" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pc1c9816156)">
+     <use xlink:href="#mc4f1e17351" x="319.643112" y="114.292002" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc4f1e17351" x="263.489417" y="121.846688" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc4f1e17351" x="236.23654" y="129.648998" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc4f1e17351" x="192.820547" y="151.649176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc4f1e17351" x="172.068759" y="162.578541" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc4f1e17351" x="155.351585" y="172.759546" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc4f1e17351" x="149.634124" y="176.972957" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc4f1e17351" x="139.514773" y="190.442219" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc4f1e17351" x="119.666036" y="285.513901" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc4f1e17351" x="97.814287" y="314.32634" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 113.896302 
-L 318.473243 114.069737 
-L 317.303375 114.242619 
-L 316.133506 114.41495 
-L 314.963637 114.586734 
-L 313.793769 114.757975 
-L 312.6239 114.928676 
-L 311.454031 115.098841 
-L 310.284163 115.268472 
-L 309.114294 115.437573 
-L 307.944425 115.606147 
-L 306.774557 115.774198 
-L 305.604688 115.94173 
-L 304.43482 116.108744 
-L 303.264951 116.275244 
-L 302.095082 116.441234 
-L 300.925214 116.606717 
-L 299.755345 116.771695 
-L 298.585476 116.936172 
-L 297.415608 117.10015 
-L 296.245739 117.263634 
-L 295.07587 117.426625 
-L 293.906002 117.589127 
-L 292.736133 117.751142 
-L 291.566264 117.912674 
-L 290.396396 118.073725 
-L 289.226527 118.234299 
-L 288.056658 118.394398 
-L 286.88679 118.554024 
-L 285.716921 118.713182 
-L 284.547053 118.871872 
-L 283.377184 119.030099 
-L 282.207315 119.187865 
-L 281.037447 119.345172 
-L 279.867578 119.502023 
-L 278.697709 119.658422 
-L 277.527841 119.814369 
-L 276.357972 119.969869 
-L 275.188103 120.124923 
-L 274.018235 120.279535 
-L 272.848366 120.433706 
-L 271.678497 120.587439 
-L 270.508629 120.740737 
-L 269.33876 120.893602 
-L 268.168891 121.046036 
-L 266.999023 121.198042 
-L 265.829154 121.349623 
-L 264.659286 121.500781 
-L 263.489417 121.651517 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 114.292002 
+L 318.473243 114.460641 
+L 317.303375 114.628755 
+L 316.133506 114.79635 
+L 314.963637 114.963427 
+L 313.793769 115.129989 
+L 312.6239 115.296041 
+L 311.454031 115.461585 
+L 310.284163 115.626624 
+L 309.114294 115.791162 
+L 307.944425 115.955201 
+L 306.774557 116.118745 
+L 305.604688 116.281795 
+L 304.43482 116.444357 
+L 303.264951 116.606431 
+L 302.095082 116.768022 
+L 300.925214 116.929131 
+L 299.755345 117.089763 
+L 298.585476 117.249919 
+L 297.415608 117.409603 
+L 296.245739 117.568817 
+L 295.07587 117.727565 
+L 293.906002 117.885848 
+L 292.736133 118.043669 
+L 291.566264 118.201032 
+L 290.396396 118.357939 
+L 289.226527 118.514392 
+L 288.056658 118.670394 
+L 286.88679 118.825948 
+L 285.716921 118.981057 
+L 284.547053 119.135722 
+L 283.377184 119.289946 
+L 282.207315 119.443732 
+L 281.037447 119.597083 
+L 279.867578 119.75 
+L 278.697709 119.902487 
+L 277.527841 120.054545 
+L 276.357972 120.206178 
+L 275.188103 120.357387 
+L 274.018235 120.508174 
+L 272.848366 120.658543 
+L 271.678497 120.808495 
+L 270.508629 120.958033 
+L 269.33876 121.107159 
+L 268.168891 121.255875 
+L 266.999023 121.404184 
+L 265.829154 121.552088 
+L 264.659286 121.699588 
+L 263.489417 121.846688 
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 263.489417 121.651517 
-L 262.921649 121.828536 
-L 262.35388 122.004978 
-L 261.786112 122.180847 
-L 261.218344 122.356146 
-L 260.650576 122.530879 
-L 260.082807 122.70505 
-L 259.515039 122.878663 
-L 258.947271 123.05172 
-L 258.379503 123.224226 
-L 257.811734 123.396184 
-L 257.243966 123.567597 
-L 256.676198 123.73847 
-L 256.108429 123.908804 
-L 255.540661 124.078605 
-L 254.972893 124.247874 
-L 254.405125 124.416616 
-L 253.837356 124.584833 
-L 253.269588 124.752529 
-L 252.70182 124.919708 
-L 252.134052 125.086371 
-L 251.566283 125.252523 
-L 250.998515 125.418167 
-L 250.430747 125.583305 
-L 249.862979 125.747941 
-L 249.29521 125.912078 
-L 248.727442 126.075718 
-L 248.159674 126.238866 
-L 247.591906 126.401523 
-L 247.024137 126.563693 
-L 246.456369 126.725378 
-L 245.888601 126.886582 
-L 245.320832 127.047307 
-L 244.753064 127.207557 
-L 244.185296 127.367333 
-L 243.617528 127.52664 
-L 243.049759 127.685478 
-L 242.481991 127.843853 
-L 241.914223 128.001765 
-L 241.346455 128.159217 
-L 240.778686 128.316213 
-L 240.210918 128.472756 
-L 239.64315 128.628846 
-L 239.075382 128.784488 
-L 238.507613 128.939684 
-L 237.939845 129.094436 
-L 237.372077 129.248747 
-L 236.804309 129.402619 
-L 236.23654 129.556055 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 263.489417 121.846688 
+L 262.921649 122.021253 
+L 262.35388 122.195256 
+L 261.786112 122.368702 
+L 261.218344 122.541594 
+L 260.650576 122.713936 
+L 260.082807 122.88573 
+L 259.515039 123.056981 
+L 258.947271 123.227692 
+L 258.379503 123.397867 
+L 257.811734 123.567508 
+L 257.243966 123.736619 
+L 256.676198 123.905203 
+L 256.108429 124.073264 
+L 255.540661 124.240805 
+L 254.972893 124.407829 
+L 254.405125 124.574339 
+L 253.837356 124.740339 
+L 253.269588 124.905831 
+L 252.70182 125.070818 
+L 252.134052 125.235305 
+L 251.566283 125.399293 
+L 250.998515 125.562785 
+L 250.430747 125.725786 
+L 249.862979 125.888296 
+L 249.29521 126.050321 
+L 248.727442 126.211862 
+L 248.159674 126.372922 
+L 247.591906 126.533505 
+L 247.024137 126.693613 
+L 246.456369 126.853248 
+L 245.888601 127.012414 
+L 245.320832 127.171114 
+L 244.753064 127.329349 
+L 244.185296 127.487124 
+L 243.617528 127.644439 
+L 243.049759 127.801299 
+L 242.481991 127.957706 
+L 241.914223 128.113662 
+L 241.346455 128.26917 
+L 240.778686 128.424233 
+L 240.210918 128.578853 
+L 239.64315 128.733032 
+L 239.075382 128.886773 
+L 238.507613 129.040079 
+L 237.939845 129.192952 
+L 237.372077 129.345395 
+L 236.804309 129.497409 
+L 236.23654 129.648998 
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 236.23654 129.556055 
-L 235.33204 130.11057 
-L 234.427541 130.659462 
-L 233.523041 131.202845 
-L 232.618541 131.740827 
-L 231.714041 132.273514 
-L 230.809541 132.801011 
-L 229.905041 133.323417 
-L 229.000541 133.84083 
-L 228.096041 134.353344 
-L 227.191542 134.86105 
-L 226.287042 135.36404 
-L 225.382542 135.862398 
-L 224.478042 136.35621 
-L 223.573542 136.845558 
-L 222.669042 137.330521 
-L 221.764542 137.811179 
-L 220.860043 138.287606 
-L 219.955543 138.759876 
-L 219.051043 139.228062 
-L 218.146543 139.692233 
-L 217.242043 140.152458 
-L 216.337543 140.608802 
-L 215.433043 141.061332 
-L 214.528544 141.51011 
-L 213.624044 141.955198 
-L 212.719544 142.396656 
-L 211.815044 142.834543 
-L 210.910544 143.268916 
-L 210.006044 143.699831 
-L 209.101544 144.127343 
-L 208.197044 144.551505 
-L 207.292545 144.97237 
-L 206.388045 145.389987 
-L 205.483545 145.804407 
-L 204.579045 146.215678 
-L 203.674545 146.623849 
-L 202.770045 147.028964 
-L 201.865545 147.43107 
-L 200.961046 147.830212 
-L 200.056546 148.226431 
-L 199.152046 148.619772 
-L 198.247546 149.010275 
-L 197.343046 149.397981 
-L 196.438546 149.78293 
-L 195.534046 150.16516 
-L 194.629546 150.544711 
-L 193.725047 150.921619 
-L 192.820547 151.29592 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 236.23654 129.648998 
+L 235.33204 130.211553 
+L 234.427541 130.768321 
+L 233.523041 131.319421 
+L 232.618541 131.864967 
+L 231.714041 132.40507 
+L 230.809541 132.939837 
+L 229.905041 133.469373 
+L 229.000541 133.993778 
+L 228.096041 134.513152 
+L 227.191542 135.027591 
+L 226.287042 135.537186 
+L 225.382542 136.042028 
+L 224.478042 136.542206 
+L 223.573542 137.037804 
+L 222.669042 137.528906 
+L 221.764542 138.015592 
+L 220.860043 138.497942 
+L 219.955543 138.976032 
+L 219.051043 139.449936 
+L 218.146543 139.919727 
+L 217.242043 140.385475 
+L 216.337543 140.847251 
+L 215.433043 141.305121 
+L 214.528544 141.75915 
+L 213.624044 142.209403 
+L 212.719544 142.655942 
+L 211.815044 143.098827 
+L 210.910544 143.538118 
+L 210.006044 143.973872 
+L 209.101544 144.406147 
+L 208.197044 144.834997 
+L 207.292545 145.260477 
+L 206.388045 145.682638 
+L 205.483545 146.101532 
+L 204.579045 146.517209 
+L 203.674545 146.929719 
+L 202.770045 147.339109 
+L 201.865545 147.745426 
+L 200.961046 148.148716 
+L 200.056546 148.549023 
+L 199.152046 148.946392 
+L 198.247546 149.340865 
+L 197.343046 149.732484 
+L 196.438546 150.12129 
+L 195.534046 150.507324 
+L 194.629546 150.890624 
+L 193.725047 151.271229 
+L 192.820547 151.649176 
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 192.820547 151.29592 
-L 192.561575 151.567228 
-L 192.302603 151.837183 
-L 192.043631 152.105798 
-L 191.78466 152.373086 
-L 191.525688 152.639062 
-L 191.266716 152.903737 
-L 191.007744 153.167124 
-L 190.748773 153.429235 
-L 190.489801 153.690084 
-L 190.230829 153.949682 
-L 189.971857 154.20804 
-L 189.712885 154.465172 
-L 189.453914 154.721087 
-L 189.194942 154.975799 
-L 188.93597 155.229318 
-L 188.676998 155.481654 
-L 188.418027 155.73282 
-L 188.159055 155.982826 
-L 187.900083 156.231683 
-L 187.641111 156.479401 
-L 187.382139 156.72599 
-L 187.123168 156.971461 
-L 186.864196 157.215824 
-L 186.605224 157.459089 
-L 186.346252 157.701266 
-L 186.087281 157.942364 
-L 185.828309 158.182392 
-L 185.569337 158.421362 
-L 185.310365 158.65928 
-L 185.051393 158.896158 
-L 184.792422 159.132004 
-L 184.53345 159.366826 
-L 184.274478 159.600635 
-L 184.015506 159.833437 
-L 183.756535 160.065243 
-L 183.497563 160.29606 
-L 183.238591 160.525898 
-L 182.979619 160.754763 
-L 182.720647 160.982665 
-L 182.461676 161.209612 
-L 182.202704 161.435611 
-L 181.943732 161.66067 
-L 181.68476 161.884798 
-L 181.425789 162.108001 
-L 181.166817 162.330288 
-L 180.907845 162.551666 
-L 180.648873 162.772142 
-L 180.389901 162.991723 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 192.820547 151.649176 
+L 192.388218 151.9009 
+L 191.955889 152.151458 
+L 191.52356 152.400862 
+L 191.091231 152.649123 
+L 190.658902 152.896249 
+L 190.226573 153.142253 
+L 189.794244 153.387144 
+L 189.361916 153.630932 
+L 188.929587 153.873627 
+L 188.497258 154.115238 
+L 188.064929 154.355776 
+L 187.6326 154.59525 
+L 187.200271 154.833669 
+L 186.767942 155.071043 
+L 186.335613 155.30738 
+L 185.903284 155.54269 
+L 185.470955 155.776982 
+L 185.038626 156.010263 
+L 184.606298 156.242544 
+L 184.173969 156.473832 
+L 183.74164 156.704136 
+L 183.309311 156.933465 
+L 182.876982 157.161826 
+L 182.444653 157.389228 
+L 182.012324 157.615678 
+L 181.579995 157.841185 
+L 181.147666 158.065757 
+L 180.715337 158.2894 
+L 180.283008 158.512124 
+L 179.85068 158.733934 
+L 179.418351 158.95484 
+L 178.986022 159.174848 
+L 178.553693 159.393965 
+L 178.121364 159.612199 
+L 177.689035 159.829556 
+L 177.256706 160.046045 
+L 176.824377 160.261671 
+L 176.392048 160.476441 
+L 175.959719 160.690363 
+L 175.52739 160.903442 
+L 175.095062 161.115686 
+L 174.662733 161.327101 
+L 174.230404 161.537694 
+L 173.798075 161.747471 
+L 173.365746 161.956437 
+L 172.933417 162.1646 
+L 172.501088 162.371966 
+L 172.068759 162.578541 
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 180.389901 162.991723 
-L 179.86827 163.208845 
-L 179.346638 163.425098 
-L 178.825007 163.640492 
-L 178.303375 163.855031 
-L 177.781744 164.068724 
-L 177.260112 164.281576 
-L 176.73848 164.493595 
-L 176.216849 164.704786 
-L 175.695217 164.915157 
-L 175.173586 165.124713 
-L 174.651954 165.333461 
-L 174.130322 165.541408 
-L 173.608691 165.748558 
-L 173.087059 165.954919 
-L 172.565428 166.160496 
-L 172.043796 166.365295 
-L 171.522165 166.569323 
-L 171.000533 166.772584 
-L 170.478901 166.975085 
-L 169.95727 167.176831 
-L 169.435638 167.377828 
-L 168.914007 167.578082 
-L 168.392375 167.777597 
-L 167.870743 167.97638 
-L 167.349112 168.174435 
-L 166.82748 168.371769 
-L 166.305849 168.568385 
-L 165.784217 168.76429 
-L 165.262586 168.959489 
-L 164.740954 169.153986 
-L 164.219322 169.347787 
-L 163.697691 169.540897 
-L 163.176059 169.73332 
-L 162.654428 169.925061 
-L 162.132796 170.116126 
-L 161.611164 170.306519 
-L 161.089533 170.496244 
-L 160.567901 170.685307 
-L 160.04627 170.873712 
-L 159.524638 171.061463 
-L 159.003007 171.248565 
-L 158.481375 171.435023 
-L 157.959743 171.620841 
-L 157.438112 171.806023 
-L 156.91648 171.990574 
-L 156.394849 172.174497 
-L 155.873217 172.357798 
-L 155.351585 172.54048 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 172.068759 162.578541 
+L 171.720485 162.811401 
+L 171.37221 163.043264 
+L 171.023936 163.274138 
+L 170.675661 163.504032 
+L 170.327387 163.732954 
+L 169.979112 163.960911 
+L 169.630838 164.187913 
+L 169.282564 164.413966 
+L 168.934289 164.63908 
+L 168.586015 164.863261 
+L 168.23774 165.086517 
+L 167.889466 165.308857 
+L 167.541191 165.530287 
+L 167.192917 165.750815 
+L 166.844642 165.970448 
+L 166.496368 166.189194 
+L 166.148093 166.407059 
+L 165.799819 166.624051 
+L 165.451545 166.840176 
+L 165.10327 167.055442 
+L 164.754996 167.269856 
+L 164.406721 167.483423 
+L 164.058447 167.696151 
+L 163.710172 167.908047 
+L 163.361898 168.119116 
+L 163.013623 168.329365 
+L 162.665349 168.538801 
+L 162.317074 168.74743 
+L 161.9688 168.955258 
+L 161.620526 169.162291 
+L 161.272251 169.368535 
+L 160.923977 169.573996 
+L 160.575702 169.77868 
+L 160.227428 169.982594 
+L 159.879153 170.185742 
+L 159.530879 170.38813 
+L 159.182604 170.589765 
+L 158.83433 170.790651 
+L 158.486056 170.990795 
+L 158.137781 171.190201 
+L 157.789507 171.388875 
+L 157.441232 171.586823 
+L 157.092958 171.78405 
+L 156.744683 171.980561 
+L 156.396409 172.17636 
+L 156.048134 172.371455 
+L 155.69986 172.565848 
+L 155.351585 172.759546 
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 155.351585 172.54048 
-L 155.232472 172.635146 
-L 155.113358 172.729646 
-L 154.994244 172.823981 
-L 154.87513 172.918152 
-L 154.756017 173.01216 
-L 154.636903 173.106005 
-L 154.517789 173.199687 
-L 154.398675 173.293207 
-L 154.279561 173.386566 
-L 154.160448 173.479765 
-L 154.041334 173.572803 
-L 153.92222 173.665682 
-L 153.803106 173.758401 
-L 153.683992 173.850962 
-L 153.564879 173.943365 
-L 153.445765 174.035611 
-L 153.326651 174.127699 
-L 153.207537 174.219631 
-L 153.088424 174.311408 
-L 152.96931 174.403029 
-L 152.850196 174.494495 
-L 152.731082 174.585807 
-L 152.611968 174.676965 
-L 152.492855 174.767969 
-L 152.373741 174.858822 
-L 152.254627 174.949521 
-L 152.135513 175.04007 
-L 152.016399 175.130466 
-L 151.897286 175.220713 
-L 151.778172 175.310809 
-L 151.659058 175.400755 
-L 151.539944 175.490552 
-L 151.420831 175.580201 
-L 151.301717 175.669701 
-L 151.182603 175.759053 
-L 151.063489 175.848258 
-L 150.944375 175.937317 
-L 150.825262 176.026229 
-L 150.706148 176.114995 
-L 150.587034 176.203616 
-L 150.46792 176.292092 
-L 150.348806 176.380424 
-L 150.229693 176.468612 
-L 150.110579 176.556656 
-L 149.991465 176.644558 
-L 149.872351 176.732317 
-L 149.753238 176.819934 
-L 149.634124 176.907409 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 155.351585 172.759546 
+L 155.232472 172.850755 
+L 155.113358 172.941811 
+L 154.994244 173.032714 
+L 154.87513 173.123464 
+L 154.756017 173.214063 
+L 154.636903 173.30451 
+L 154.517789 173.394806 
+L 154.398675 173.484952 
+L 154.279561 173.574948 
+L 154.160448 173.664795 
+L 154.041334 173.754492 
+L 153.92222 173.844042 
+L 153.803106 173.933443 
+L 153.683992 174.022697 
+L 153.564879 174.111804 
+L 153.445765 174.200765 
+L 153.326651 174.28958 
+L 153.207537 174.378249 
+L 153.088424 174.466773 
+L 152.96931 174.555153 
+L 152.850196 174.643389 
+L 152.731082 174.731481 
+L 152.611968 174.81943 
+L 152.492855 174.907236 
+L 152.373741 174.9949 
+L 152.254627 175.082422 
+L 152.135513 175.169803 
+L 152.016399 175.257044 
+L 151.897286 175.344143 
+L 151.778172 175.431103 
+L 151.659058 175.517924 
+L 151.539944 175.604605 
+L 151.420831 175.691148 
+L 151.301717 175.777553 
+L 151.182603 175.86382 
+L 151.063489 175.949949 
+L 150.944375 176.035942 
+L 150.825262 176.121799 
+L 150.706148 176.207519 
+L 150.587034 176.293104 
+L 150.46792 176.378554 
+L 150.348806 176.46387 
+L 150.229693 176.549051 
+L 150.110579 176.634098 
+L 149.991465 176.719012 
+L 149.872351 176.803792 
+L 149.753238 176.888441 
+L 149.634124 176.972957 
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 149.634124 176.907409 
-L 149.423304 177.223528 
-L 149.212484 177.537811 
-L 149.001664 177.85028 
-L 148.790845 178.160955 
-L 148.580025 178.469858 
-L 148.369205 178.777008 
-L 148.158385 179.082425 
-L 147.947565 179.386128 
-L 147.736745 179.688137 
-L 147.525926 179.98847 
-L 147.315106 180.287146 
-L 147.104286 180.584184 
-L 146.893466 180.8796 
-L 146.682646 181.173412 
-L 146.471827 181.465639 
-L 146.261007 181.756296 
-L 146.050187 182.045402 
-L 145.839367 182.332971 
-L 145.628547 182.61902 
-L 145.417728 182.903566 
-L 145.206908 183.186624 
-L 144.996088 183.46821 
-L 144.785268 183.748338 
-L 144.574448 184.027025 
-L 144.363629 184.304283 
-L 144.152809 184.580129 
-L 143.941989 184.854577 
-L 143.731169 185.12764 
-L 143.520349 185.399332 
-L 143.30953 185.669667 
-L 143.09871 185.938659 
-L 142.88789 186.206322 
-L 142.67707 186.472667 
-L 142.46625 186.737708 
-L 142.25543 187.001457 
-L 142.044611 187.263928 
-L 141.833791 187.525132 
-L 141.622971 187.785082 
-L 141.412151 188.043789 
-L 141.201331 188.301266 
-L 140.990512 188.557524 
-L 140.779692 188.812575 
-L 140.568872 189.066429 
-L 140.358052 189.319099 
-L 140.147232 189.570594 
-L 139.936413 189.820927 
-L 139.725593 190.070107 
-L 139.514773 190.318146 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 149.634124 176.972957 
+L 149.423304 177.290629 
+L 149.212484 177.606448 
+L 149.001664 177.920435 
+L 148.790845 178.232611 
+L 148.580025 178.542997 
+L 148.369205 178.851614 
+L 148.158385 179.158481 
+L 147.947565 179.463618 
+L 147.736745 179.767045 
+L 147.525926 180.06878 
+L 147.315106 180.368843 
+L 147.104286 180.667252 
+L 146.893466 180.964024 
+L 146.682646 181.259179 
+L 146.471827 181.552733 
+L 146.261007 181.844703 
+L 146.050187 182.135107 
+L 145.839367 182.423962 
+L 145.628547 182.711283 
+L 145.417728 182.997087 
+L 145.206908 183.281391 
+L 144.996088 183.564208 
+L 144.785268 183.845556 
+L 144.574448 184.125449 
+L 144.363629 184.403903 
+L 144.152809 184.680931 
+L 143.941989 184.956549 
+L 143.731169 185.23077 
+L 143.520349 185.503609 
+L 143.30953 185.77508 
+L 143.09871 186.045197 
+L 142.88789 186.313972 
+L 142.67707 186.581419 
+L 142.46625 186.847552 
+L 142.25543 187.112382 
+L 142.044611 187.375923 
+L 141.833791 187.638187 
+L 141.622971 187.899186 
+L 141.412151 188.158934 
+L 141.201331 188.41744 
+L 140.990512 188.674718 
+L 140.779692 188.93078 
+L 140.568872 189.185635 
+L 140.358052 189.439296 
+L 140.147232 189.691774 
+L 139.936413 189.94308 
+L 139.725593 190.193225 
+L 139.514773 190.442219 
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 139.514773 190.318146 
-L 139.101258 195.506382 
-L 138.687742 200.240552 
-L 138.274227 204.593778 
-L 137.860712 208.622827 
-L 137.447196 212.372652 
-L 137.033681 215.87946 
-L 136.620165 219.172841 
-L 136.20665 222.277291 
-L 135.793135 225.213314 
-L 135.379619 227.998251 
-L 134.966104 230.646892 
-L 134.552589 233.171958 
-L 134.139073 235.584468 
-L 133.725558 237.894029 
-L 133.312043 240.10907 
-L 132.898527 242.237024 
-L 132.485012 244.28448 
-L 132.071496 246.257308 
-L 131.657981 248.160756 
-L 131.244466 249.99954 
-L 130.83095 251.777909 
-L 130.417435 253.499707 
-L 130.00392 255.168422 
-L 129.590404 256.787231 
-L 129.176889 258.35903 
-L 128.763374 259.886475 
-L 128.349858 261.371999 
-L 127.936343 262.817842 
-L 127.522827 264.22607 
-L 127.109312 265.598589 
-L 126.695797 266.937167 
-L 126.282281 268.243441 
-L 125.868766 269.518933 
-L 125.455251 270.765062 
-L 125.041735 271.983149 
-L 124.62822 273.174428 
-L 124.214705 274.340053 
-L 123.801189 275.481107 
-L 123.387674 276.598604 
-L 122.974158 277.693497 
-L 122.560643 278.766683 
-L 122.147128 279.819005 
-L 121.733612 280.851259 
-L 121.320097 281.864196 
-L 120.906582 282.858526 
-L 120.493066 283.83492 
-L 120.079551 284.794015 
-L 119.666036 285.736411 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 139.514773 190.442219 
+L 139.101258 195.592327 
+L 138.687742 200.294735 
+L 138.274227 204.621092 
+L 137.860712 208.627116 
+L 137.447196 212.356991 
+L 137.033681 215.846345 
+L 136.620165 219.124328 
+L 136.20665 222.215093 
+L 135.793135 225.138873 
+L 135.379619 227.912792 
+L 134.966104 230.551466 
+L 134.552589 233.067472 
+L 134.139073 235.47171 
+L 133.725558 237.77369 
+L 133.312043 239.981756 
+L 132.898527 242.103272 
+L 132.485012 244.144767 
+L 132.071496 246.11206 
+L 131.657981 248.010356 
+L 131.244466 249.844331 
+L 130.83095 251.618202 
+L 130.417435 253.335782 
+L 130.00392 255.000536 
+L 129.590404 256.615616 
+L 129.176889 258.183901 
+L 128.763374 259.708026 
+L 128.349858 261.19041 
+L 127.936343 262.633278 
+L 127.522827 264.038684 
+L 127.109312 265.408522 
+L 126.695797 266.74455 
+L 126.282281 268.048395 
+L 125.868766 269.321572 
+L 125.455251 270.565491 
+L 125.041735 271.781465 
+L 124.62822 272.970724 
+L 124.214705 274.134415 
+L 123.801189 275.273616 
+L 123.387674 276.389335 
+L 122.974158 277.482521 
+L 122.560643 278.554067 
+L 122.147128 279.604812 
+L 121.733612 280.635549 
+L 121.320097 281.647025 
+L 120.906582 282.639948 
+L 120.493066 283.614985 
+L 120.079551 284.572769 
+L 119.666036 285.513901 
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 119.666036 285.736411 
-L 119.210791 286.486525 
-L 118.755546 287.226385 
-L 118.300301 287.95627 
-L 117.845056 288.676444 
-L 117.389812 289.387163 
-L 116.934567 290.08867 
-L 116.479322 290.781203 
-L 116.024077 291.464988 
-L 115.568833 292.140242 
-L 115.113588 292.807177 
-L 114.658343 293.465995 
-L 114.203098 294.116891 
-L 113.747854 294.760053 
-L 113.292609 295.395663 
-L 112.837364 296.023896 
-L 112.382119 296.644922 
-L 111.926875 297.258903 
-L 111.47163 297.865999 
-L 111.016385 298.466361 
-L 110.56114 299.060138 
-L 110.105895 299.647472 
-L 109.650651 300.228502 
-L 109.195406 300.803361 
-L 108.740161 301.37218 
-L 108.284916 301.935083 
-L 107.829672 302.492193 
-L 107.374427 303.043628 
-L 106.919182 303.589502 
-L 106.463937 304.129926 
-L 106.008693 304.665008 
-L 105.553448 305.194852 
-L 105.098203 305.719561 
-L 104.642958 306.239232 
-L 104.187713 306.753961 
-L 103.732469 307.263842 
-L 103.277224 307.768966 
-L 102.821979 308.269419 
-L 102.366734 308.765288 
-L 101.91149 309.256655 
-L 101.456245 309.743602 
-L 101.001 310.226208 
-L 100.545755 310.70455 
-L 100.090511 311.178701 
-L 99.635266 311.648735 
-L 99.180021 312.114723 
-L 98.724776 312.576734 
-L 98.269531 313.034834 
-L 97.814287 313.489091 
-" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.666036 285.513901 
+L 119.210791 286.300719 
+L 118.755546 287.076264 
+L 118.300301 287.840854 
+L 117.845056 288.594795 
+L 117.389812 289.338379 
+L 116.934567 290.071887 
+L 116.479322 290.795588 
+L 116.024077 291.509742 
+L 115.568833 292.214596 
+L 115.113588 292.91039 
+L 114.658343 293.597353 
+L 114.203098 294.275708 
+L 113.747854 294.945667 
+L 113.292609 295.607435 
+L 112.837364 296.261211 
+L 112.382119 296.907185 
+L 111.926875 297.545541 
+L 111.47163 298.176456 
+L 111.016385 298.800103 
+L 110.56114 299.416647 
+L 110.105895 300.026247 
+L 109.650651 300.629058 
+L 109.195406 301.225231 
+L 108.740161 301.814909 
+L 108.284916 302.398232 
+L 107.829672 302.975337 
+L 107.374427 303.546353 
+L 106.919182 304.111409 
+L 106.463937 304.670628 
+L 106.008693 305.224128 
+L 105.553448 305.772026 
+L 105.098203 306.314434 
+L 104.642958 306.851461 
+L 104.187713 307.383212 
+L 103.732469 307.90979 
+L 103.277224 308.431295 
+L 102.821979 308.947824 
+L 102.366734 309.459471 
+L 101.91149 309.966327 
+L 101.456245 310.468481 
+L 101.001 310.966019 
+L 100.545755 311.459026 
+L 100.090511 311.947584 
+L 99.635266 312.431771 
+L 99.180021 312.911666 
+L 98.724776 313.387343 
+L 98.269531 313.858878 
+L 97.814287 314.32634 
+" clip-path="url(#pc1c9816156)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.448437 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-11T10:44:33Z  ·  Linux chungus2 x86_64  ·  commit c014c7e1  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.058516 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6201,31 +6201,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6325,14 +6300,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6372,109 +6347,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3372.705078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3436.328125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3497.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3561.474609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3593.261719 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3625.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3656.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3688.623047 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3720.410156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3748.193359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3809.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3870.996094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3934.375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3997.851562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4036.714844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4097.896484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4157.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4218.599609 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4259.712891 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4293.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4321.1875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4382.710938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4443.990234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4507.369141 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4570.992188 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4604.683594 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4663.863281 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4727.486328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4759.273438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4822.896484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4886.519531 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4918.306641 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4981.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5018.013672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5056.876953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5111.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5175.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5207.267578 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5239.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5270.841797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5302.628906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5334.416016 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5373.625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5437.003906 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5475.867188 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5537.048828 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5600.427734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5663.904297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5727.283203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5790.759766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5854.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5893.347656 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6008.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6040.710938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6138.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6199.646484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6263.123047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6290.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6352.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6415.564453 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6447.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6499.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6562.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6624.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6864.246094 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6903.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6937.146484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6968.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7010.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7071.326172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7110.535156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7138.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7199.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7231.287109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7259.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7311.169922 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7342.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7406.433594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7467.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7507.166016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7568.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7608.052734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7705.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7733.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7796.626953 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7824.410156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7876.509766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7915.71875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7943.501953 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pbb573932c3">
+  <clipPath id="pc1c9816156">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="ma2dbaddb45" d="M 0 0 
+       <path id="m78579128ab" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma2dbaddb45" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78579128ab" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma2dbaddb45" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78579128ab" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#ma2dbaddb45" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78579128ab" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma2dbaddb45" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78579128ab" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#ma2dbaddb45" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78579128ab" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#ma2dbaddb45" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78579128ab" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma2dbaddb45" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78579128ab" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.323447 
 L 637.2 391.323447 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mc2cfd28e84" d="M 0 0 
+       <path id="m71cf420cab" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc2cfd28e84" x="49.078125" y="391.323447" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71cf420cab" x="49.078125" y="391.323447" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 263.552396 
 L 637.2 263.552396 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc2cfd28e84" x="49.078125" y="263.552396" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71cf420cab" x="49.078125" y="263.552396" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 263.552396
      <g id="line2d_19">
       <path d="M 49.078125 135.781345 
 L 637.2 135.781345 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc2cfd28e84" x="49.078125" y="135.781345" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71cf420cab" x="49.078125" y="135.781345" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 135.781345
      <g id="line2d_21">
       <path d="M 49.078125 411.115433 
 L 637.2 411.115433 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m305e82df09" d="M 0 0 
+       <path id="m0088c5874c" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="411.115433" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="411.115433" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 403.705741 
 L 637.2 403.705741 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="403.705741" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="403.705741" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 403.705741
      <g id="line2d_25">
       <path d="M 49.078125 397.16993 
 L 637.2 397.16993 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="397.16993" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="397.16993" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.16993
      <g id="line2d_27">
       <path d="M 49.078125 352.860528 
 L 637.2 352.860528 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="352.860528" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="352.860528" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 352.860528
      <g id="line2d_29">
       <path d="M 49.078125 330.361163 
 L 637.2 330.361163 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="330.361163" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="330.361163" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 330.361163
      <g id="line2d_31">
       <path d="M 49.078125 314.397609 
 L 637.2 314.397609 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="314.397609" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="314.397609" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 314.397609
      <g id="line2d_33">
       <path d="M 49.078125 302.015315 
 L 637.2 302.015315 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="302.015315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="302.015315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 302.015315
      <g id="line2d_35">
       <path d="M 49.078125 291.898244 
 L 637.2 291.898244 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="291.898244" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="291.898244" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 291.898244
      <g id="line2d_37">
       <path d="M 49.078125 283.344382 
 L 637.2 283.344382 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="283.344382" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="283.344382" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.344382
      <g id="line2d_39">
       <path d="M 49.078125 275.93469 
 L 637.2 275.93469 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="275.93469" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="275.93469" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 275.93469
      <g id="line2d_41">
       <path d="M 49.078125 269.398879 
 L 637.2 269.398879 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="269.398879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="269.398879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.398879
      <g id="line2d_43">
       <path d="M 49.078125 225.089477 
 L 637.2 225.089477 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="225.089477" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="225.089477" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 225.089477
      <g id="line2d_45">
       <path d="M 49.078125 202.590112 
 L 637.2 202.590112 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="202.590112" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="202.590112" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 202.590112
      <g id="line2d_47">
       <path d="M 49.078125 186.626558 
 L 637.2 186.626558 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="186.626558" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="186.626558" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 186.626558
      <g id="line2d_49">
       <path d="M 49.078125 174.244264 
 L 637.2 174.244264 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="174.244264" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="174.244264" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 174.244264
      <g id="line2d_51">
       <path d="M 49.078125 164.127193 
 L 637.2 164.127193 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="164.127193" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="164.127193" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 164.127193
      <g id="line2d_53">
       <path d="M 49.078125 155.573332 
 L 637.2 155.573332 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="155.573332" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="155.573332" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 155.573332
      <g id="line2d_55">
       <path d="M 49.078125 148.16364 
 L 637.2 148.16364 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="148.16364" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="148.16364" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 148.16364
      <g id="line2d_57">
       <path d="M 49.078125 141.627828 
 L 637.2 141.627828 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="141.627828" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="141.627828" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 141.627828
      <g id="line2d_59">
       <path d="M 49.078125 97.318426 
 L 637.2 97.318426 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="97.318426" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="97.318426" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 97.318426
      <g id="line2d_61">
       <path d="M 49.078125 74.819061 
 L 637.2 74.819061 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="74.819061" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="74.819061" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 74.819061
      <g id="line2d_63">
       <path d="M 49.078125 58.855508 
 L 637.2 58.855508 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m305e82df09" x="49.078125" y="58.855508" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0088c5874c" x="49.078125" y="58.855508" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1386,7 +1386,7 @@ z
    <g id="line2d_65">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p5e056e5ead)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p213d377e96)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1750,78 +1750,78 @@ z
    </g>
    <g id="line2d_66">
     <defs>
-     <path id="m105df03160" d="M -2.5 2.5 
+     <path id="m7d4b770505" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5e056e5ead)">
-     <use xlink:href="#m105df03160" x="75.810937" y="261.499418" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m105df03160" x="105.634056" y="267.789789" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m105df03160" x="204.490635" y="300.141767" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m105df03160" x="234.479899" y="305.825518" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m105df03160" x="242.537956" y="315.036638" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m105df03160" x="300.771958" y="297.144782" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m105df03160" x="303.26414" y="308.187059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m105df03160" x="304.261013" y="317.962594" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m105df03160" x="313.897453" y="317.915276" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m105df03160" x="414.166268" y="334.703269" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m105df03160" x="587.289889" y="327.69079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m105df03160" x="610.467187" y="318.226537" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p213d377e96)">
+     <use xlink:href="#m7d4b770505" x="75.810937" y="261.499418" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d4b770505" x="105.634056" y="267.789789" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d4b770505" x="204.490635" y="300.141767" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d4b770505" x="234.479899" y="305.825518" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d4b770505" x="242.537956" y="315.036638" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d4b770505" x="300.771958" y="297.144782" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d4b770505" x="303.26414" y="308.187059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d4b770505" x="304.261013" y="317.962594" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d4b770505" x="313.897453" y="317.915276" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d4b770505" x="414.166268" y="334.703269" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d4b770505" x="587.289889" y="327.69079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d4b770505" x="610.467187" y="318.226537" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m4665cdf377" d="M 0 -2.5 
+     <path id="mf9b502c761" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5e056e5ead)">
-     <use xlink:href="#m4665cdf377" x="75.810937" y="260.530934" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4665cdf377" x="105.634056" y="253.086833" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4665cdf377" x="204.490635" y="298.70349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4665cdf377" x="234.479899" y="296.22935" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4665cdf377" x="242.537956" y="305.176737" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4665cdf377" x="300.771958" y="285.410956" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4665cdf377" x="303.26414" y="298.378247" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4665cdf377" x="304.261013" y="313.133077" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4665cdf377" x="313.897453" y="305.293171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4665cdf377" x="414.166268" y="324.077479" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4665cdf377" x="587.289889" y="327.012757" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4665cdf377" x="610.467187" y="316.190866" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p213d377e96)">
+     <use xlink:href="#mf9b502c761" x="75.810937" y="260.530934" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9b502c761" x="105.634056" y="253.086833" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9b502c761" x="204.490635" y="298.70349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9b502c761" x="234.479899" y="296.22935" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9b502c761" x="242.537956" y="305.176737" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9b502c761" x="300.771958" y="285.410956" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9b502c761" x="303.26414" y="298.378247" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9b502c761" x="304.261013" y="313.133077" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9b502c761" x="313.897453" y="305.293171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9b502c761" x="414.166268" y="324.077479" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9b502c761" x="587.289889" y="327.012757" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9b502c761" x="610.467187" y="316.190866" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="mefe39920c9" d="M -0 3.535534 
+     <path id="m912a43443e" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5e056e5ead)">
-     <use xlink:href="#mefe39920c9" x="75.810937" y="227.388814" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mefe39920c9" x="105.634056" y="230.25942" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mefe39920c9" x="204.490635" y="258.634614" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mefe39920c9" x="234.479899" y="259.9616" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mefe39920c9" x="242.537956" y="271.375201" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mefe39920c9" x="300.771958" y="257.414579" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mefe39920c9" x="303.26414" y="268.600048" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mefe39920c9" x="304.261013" y="280.21882" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mefe39920c9" x="313.897453" y="276.166151" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mefe39920c9" x="414.166268" y="294.866345" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mefe39920c9" x="587.289889" y="301.289826" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mefe39920c9" x="610.467187" y="295.675174" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p213d377e96)">
+     <use xlink:href="#m912a43443e" x="75.810937" y="227.388814" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m912a43443e" x="105.634056" y="230.25942" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m912a43443e" x="204.490635" y="258.634614" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m912a43443e" x="234.479899" y="259.9616" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m912a43443e" x="242.537956" y="271.375201" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m912a43443e" x="300.771958" y="257.414579" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m912a43443e" x="303.26414" y="268.600048" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m912a43443e" x="304.261013" y="280.21882" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m912a43443e" x="313.897453" y="276.166151" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m912a43443e" x="414.166268" y="294.866345" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m912a43443e" x="587.289889" y="301.289826" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m912a43443e" x="610.467187" y="295.675174" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="mf6075972d2" d="M -0.833333 2.5 
+     <path id="m0955ca2eeb" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1836,24 +1836,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5e056e5ead)">
-     <use xlink:href="#mf6075972d2" x="75.810937" y="285.710438" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6075972d2" x="105.634056" y="293.592247" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6075972d2" x="204.490635" y="326.133408" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6075972d2" x="234.479899" y="337.73493" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6075972d2" x="242.537956" y="340.932892" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6075972d2" x="300.771958" y="336.31256" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6075972d2" x="303.26414" y="344.605532" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6075972d2" x="304.261013" y="344.457488" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6075972d2" x="313.897453" y="351.398372" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6075972d2" x="414.166268" y="363.200005" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6075972d2" x="587.289889" y="368.07815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6075972d2" x="610.467187" y="356.863633" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p213d377e96)">
+     <use xlink:href="#m0955ca2eeb" x="75.810937" y="285.710438" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0955ca2eeb" x="105.634056" y="293.592247" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0955ca2eeb" x="204.490635" y="326.133408" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0955ca2eeb" x="234.479899" y="337.73493" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0955ca2eeb" x="242.537956" y="340.932892" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0955ca2eeb" x="300.771958" y="336.31256" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0955ca2eeb" x="303.26414" y="344.605532" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0955ca2eeb" x="304.261013" y="344.457488" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0955ca2eeb" x="313.897453" y="351.398372" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0955ca2eeb" x="414.166268" y="363.200005" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0955ca2eeb" x="587.289889" y="368.07815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0955ca2eeb" x="610.467187" y="356.863633" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="mebec333f34" d="M -1.25 2.5 
+     <path id="mc6e7c0fed4" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1868,24 +1868,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5e056e5ead)">
-     <use xlink:href="#mebec333f34" x="75.810937" y="327.525336" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebec333f34" x="105.634056" y="342.492009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebec333f34" x="204.490635" y="362.75387" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebec333f34" x="234.479899" y="371.266849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebec333f34" x="242.537956" y="367.162311" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebec333f34" x="300.771958" y="359.922516" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebec333f34" x="303.26414" y="374.621262" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebec333f34" x="304.261013" y="357.345835" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebec333f34" x="313.897453" y="374.526887" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebec333f34" x="414.166268" y="384.995187" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebec333f34" x="587.289889" y="394.327659" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebec333f34" x="610.467187" y="391.234733" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p213d377e96)">
+     <use xlink:href="#mc6e7c0fed4" x="75.810937" y="327.525336" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6e7c0fed4" x="105.634056" y="342.492009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6e7c0fed4" x="204.490635" y="362.75387" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6e7c0fed4" x="234.479899" y="371.266849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6e7c0fed4" x="242.537956" y="367.162311" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6e7c0fed4" x="300.771958" y="359.922516" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6e7c0fed4" x="303.26414" y="374.621262" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6e7c0fed4" x="304.261013" y="357.345835" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6e7c0fed4" x="313.897453" y="374.526887" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6e7c0fed4" x="414.166268" y="384.995187" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6e7c0fed4" x="587.289889" y="394.327659" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6e7c0fed4" x="610.467187" y="391.234733" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m87d9b8ba24" d="M 0 -2.5 
+     <path id="m54e6756e3d" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1898,24 +1898,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p5e056e5ead)">
-     <use xlink:href="#m87d9b8ba24" x="75.810937" y="273.42452" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m87d9b8ba24" x="105.634056" y="285.910165" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m87d9b8ba24" x="204.490635" y="319.387555" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m87d9b8ba24" x="234.479899" y="320.971757" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m87d9b8ba24" x="242.537956" y="325.718465" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m87d9b8ba24" x="300.771958" y="332.867753" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m87d9b8ba24" x="303.26414" y="336.779875" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m87d9b8ba24" x="304.261013" y="345.614079" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m87d9b8ba24" x="313.897453" y="336.582957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m87d9b8ba24" x="414.166268" y="357.342827" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m87d9b8ba24" x="587.289889" y="366.194267" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m87d9b8ba24" x="610.467187" y="360.776693" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p213d377e96)">
+     <use xlink:href="#m54e6756e3d" x="75.810937" y="273.42452" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m54e6756e3d" x="105.634056" y="285.910165" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m54e6756e3d" x="204.490635" y="319.387555" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m54e6756e3d" x="234.479899" y="320.971757" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m54e6756e3d" x="242.537956" y="325.718465" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m54e6756e3d" x="300.771958" y="332.867753" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m54e6756e3d" x="303.26414" y="336.779875" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m54e6756e3d" x="304.261013" y="345.614079" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m54e6756e3d" x="313.897453" y="336.582957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m54e6756e3d" x="414.166268" y="357.342827" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m54e6756e3d" x="587.289889" y="366.194267" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m54e6756e3d" x="610.467187" y="360.776693" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="mc5c3248a37" d="M 0 -2.5 
+     <path id="m2431f4e408" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1924,19 +1924,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5e056e5ead)">
-     <use xlink:href="#mc5c3248a37" x="75.810937" y="347.034581" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5c3248a37" x="105.634056" y="348.566824" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5c3248a37" x="204.490635" y="367.234161" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5c3248a37" x="234.479899" y="372.966525" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5c3248a37" x="242.537956" y="379.953597" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5c3248a37" x="300.771958" y="370.457094" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5c3248a37" x="303.26414" y="375.315519" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5c3248a37" x="304.261013" y="382.991991" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5c3248a37" x="313.897453" y="385.183642" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5c3248a37" x="414.166268" y="391.635066" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5c3248a37" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5c3248a37" x="610.467187" y="383.674277" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p213d377e96)">
+     <use xlink:href="#m2431f4e408" x="75.810937" y="347.034581" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2431f4e408" x="105.634056" y="348.566824" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2431f4e408" x="204.490635" y="367.234161" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2431f4e408" x="234.479899" y="372.966525" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2431f4e408" x="242.537956" y="379.953597" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2431f4e408" x="300.771958" y="370.457094" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2431f4e408" x="303.26414" y="375.315519" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2431f4e408" x="304.261013" y="382.991991" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2431f4e408" x="313.897453" y="385.183642" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2431f4e408" x="414.166268" y="391.635066" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2431f4e408" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2431f4e408" x="610.467187" y="383.674277" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1955,7 +1955,7 @@ z
     </g>
     <g id="line2d_73">
      <defs>
-      <path id="m31cac17edf" d="M 0 3.5 
+      <path id="mf48605d6d7" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1968,7 +1968,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m31cac17edf" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mf48605d6d7" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2027,7 +2027,7 @@ z
     </g>
     <g id="line2d_74">
      <g>
-      <use xlink:href="#m105df03160" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7d4b770505" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2041,7 +2041,7 @@ z
     </g>
     <g id="line2d_75">
      <g>
-      <use xlink:href="#m4665cdf377" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf9b502c761" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2086,7 +2086,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#mefe39920c9" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m912a43443e" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2106,7 +2106,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#mf6075972d2" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0955ca2eeb" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2133,7 +2133,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#mebec333f34" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc6e7c0fed4" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2198,7 +2198,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m87d9b8ba24" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m54e6756e3d" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2236,7 +2236,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#mc5c3248a37" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2431f4e408" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2306,19 +2306,19 @@ z
     </g>
    </g>
    <g id="line2d_81">
-    <g clip-path="url(#p5e056e5ead)">
-     <use xlink:href="#m31cac17edf" x="75.810937" y="271.412271" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m31cac17edf" x="105.634056" y="288.483705" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m31cac17edf" x="204.490635" y="322.051997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m31cac17edf" x="234.479899" y="323.836862" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m31cac17edf" x="242.537956" y="323.417459" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m31cac17edf" x="300.771958" y="312.420349" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m31cac17edf" x="303.26414" y="331.455799" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m31cac17edf" x="304.261013" y="352.291902" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m31cac17edf" x="313.897453" y="337.639947" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m31cac17edf" x="414.166268" y="356.780198" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m31cac17edf" x="587.289889" y="359.564452" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m31cac17edf" x="610.467187" y="343.056471" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p213d377e96)">
+     <use xlink:href="#mf48605d6d7" x="75.810937" y="271.412271" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf48605d6d7" x="105.634056" y="288.483705" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf48605d6d7" x="204.490635" y="322.051997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf48605d6d7" x="234.479899" y="323.836862" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf48605d6d7" x="242.537956" y="323.417459" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf48605d6d7" x="300.771958" y="312.420349" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf48605d6d7" x="303.26414" y="331.455799" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf48605d6d7" x="304.261013" y="352.291902" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf48605d6d7" x="313.897453" y="337.639947" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf48605d6d7" x="414.166268" y="356.780198" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf48605d6d7" x="587.289889" y="359.564452" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf48605d6d7" x="610.467187" y="343.056471" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3172,7 +3172,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p5e056e5ead">
+  <clipPath id="p213d377e96">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 292.711764 308.04375 
 L 292.711764 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="md9be1940e7" d="M 0 0 
+       <path id="mf354089350" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md9be1940e7" x="292.711764" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf354089350" x="292.711764" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 450.890649 308.04375 
 L 450.890649 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#md9be1940e7" x="450.890649" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf354089350" x="450.890649" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 182.149468 308.04375 
 L 182.149468 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m0508e6abe1" d="M 0 0 
+       <path id="m96549aa7ad" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m0508e6abe1" x="182.149468" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="182.149468" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 210.003387 308.04375 
 L 210.003387 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m0508e6abe1" x="210.003387" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="210.003387" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 210.003387 56.7075
      <g id="line2d_9">
       <path d="M 229.766057 308.04375 
 L 229.766057 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m0508e6abe1" x="229.766057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="229.766057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 229.766057 56.7075
      <g id="line2d_11">
       <path d="M 245.095175 308.04375 
 L 245.095175 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m0508e6abe1" x="245.095175" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="245.095175" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 245.095175 56.7075
      <g id="line2d_13">
       <path d="M 257.619976 308.04375 
 L 257.619976 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m0508e6abe1" x="257.619976" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="257.619976" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 257.619976 56.7075
      <g id="line2d_15">
       <path d="M 268.209544 308.04375 
 L 268.209544 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m0508e6abe1" x="268.209544" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="268.209544" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 268.209544 56.7075
      <g id="line2d_17">
       <path d="M 277.382646 308.04375 
 L 277.382646 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m0508e6abe1" x="277.382646" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="277.382646" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 277.382646 56.7075
      <g id="line2d_19">
       <path d="M 285.473895 308.04375 
 L 285.473895 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m0508e6abe1" x="285.473895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="285.473895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 285.473895 56.7075
      <g id="line2d_21">
       <path d="M 340.328353 308.04375 
 L 340.328353 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m0508e6abe1" x="340.328353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="340.328353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 340.328353 56.7075
      <g id="line2d_23">
       <path d="M 368.182272 308.04375 
 L 368.182272 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m0508e6abe1" x="368.182272" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="368.182272" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 368.182272 56.7075
      <g id="line2d_25">
       <path d="M 387.944942 308.04375 
 L 387.944942 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m0508e6abe1" x="387.944942" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="387.944942" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 387.944942 56.7075
      <g id="line2d_27">
       <path d="M 403.27406 308.04375 
 L 403.27406 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m0508e6abe1" x="403.27406" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="403.27406" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 403.27406 56.7075
      <g id="line2d_29">
       <path d="M 415.798861 308.04375 
 L 415.798861 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m0508e6abe1" x="415.798861" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="415.798861" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 415.798861 56.7075
      <g id="line2d_31">
       <path d="M 426.38843 308.04375 
 L 426.38843 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m0508e6abe1" x="426.38843" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="426.38843" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 426.38843 56.7075
      <g id="line2d_33">
       <path d="M 435.561531 308.04375 
 L 435.561531 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m0508e6abe1" x="435.561531" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="435.561531" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 435.561531 56.7075
      <g id="line2d_35">
       <path d="M 443.65278 308.04375 
 L 443.65278 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m0508e6abe1" x="443.65278" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="443.65278" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 443.65278 56.7075
      <g id="line2d_37">
       <path d="M 498.507238 308.04375 
 L 498.507238 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m0508e6abe1" x="498.507238" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="498.507238" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 498.507238 56.7075
      <g id="line2d_39">
       <path d="M 526.361157 308.04375 
 L 526.361157 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m0508e6abe1" x="526.361157" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="526.361157" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 526.361157 56.7075
      <g id="line2d_41">
       <path d="M 546.123827 308.04375 
 L 546.123827 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m0508e6abe1" x="546.123827" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="546.123827" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 546.123827 56.7075
      <g id="line2d_43">
       <path d="M 561.452945 308.04375 
 L 561.452945 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m0508e6abe1" x="561.452945" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m96549aa7ad" x="561.452945" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1016,12 +1016,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="mba2c1d3836" d="M 0 0 
+       <path id="m8fdec62f3a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mba2c1d3836" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fdec62f3a" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1093,7 +1093,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mba2c1d3836" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fdec62f3a" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1160,7 +1160,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#mba2c1d3836" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fdec62f3a" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1216,7 +1216,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mba2c1d3836" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fdec62f3a" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1263,7 +1263,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#mba2c1d3836" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fdec62f3a" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1376,7 +1376,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mba2c1d3836" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fdec62f3a" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1392,7 +1392,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#mba2c1d3836" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fdec62f3a" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1439,7 +1439,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mba2c1d3836" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fdec62f3a" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1462,47 +1462,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.689587 296.619375 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 161.205974 263.978304 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 200.830675 231.337232 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.626886 198.696161 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 213.069162 166.055089 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 240.46049 133.414018 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 249.06205 100.772946 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 286.244503 68.131875 
-" clip-path="url(#p002b517547)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.08563 308.04375 
 L 542.08563 56.7075 
-" clip-path="url(#p002b517547)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p50a3fc6c2a)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1905,7 +1905,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m1e52893163" d="M 0 3 
+     <path id="m473fd775b3" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1917,13 +1917,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p002b517547)">
-     <use xlink:href="#m1e52893163" x="154.689587" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p50a3fc6c2a)">
+     <use xlink:href="#m473fd775b3" x="154.689587" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m56d5462e60" d="M 0 3 
+     <path id="mee388cff8a" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1935,13 +1935,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p002b517547)">
-     <use xlink:href="#m56d5462e60" x="161.205974" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p50a3fc6c2a)">
+     <use xlink:href="#mee388cff8a" x="161.205974" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m962e90e686" d="M 0 3 
+     <path id="mc36467f506" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1953,13 +1953,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p002b517547)">
-     <use xlink:href="#m962e90e686" x="200.830675" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p50a3fc6c2a)">
+     <use xlink:href="#mc36467f506" x="200.830675" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m8cb54728b1" d="M 0 3 
+     <path id="me590737834" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1971,13 +1971,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p002b517547)">
-     <use xlink:href="#m8cb54728b1" x="208.626886" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p50a3fc6c2a)">
+     <use xlink:href="#me590737834" x="208.626886" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="ma70151365a" d="M 0 5 
+     <path id="m36e45a6bd5" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1989,13 +1989,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p002b517547)">
-     <use xlink:href="#ma70151365a" x="213.069162" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p50a3fc6c2a)">
+     <use xlink:href="#m36e45a6bd5" x="213.069162" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m4ab44bc3f0" d="M 0 3 
+     <path id="mb10bbb2e32" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2007,13 +2007,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p002b517547)">
-     <use xlink:href="#m4ab44bc3f0" x="240.46049" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p50a3fc6c2a)">
+     <use xlink:href="#mb10bbb2e32" x="240.46049" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m82aa36b1de" d="M 0 3 
+     <path id="m5b33c6840c" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2025,13 +2025,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p002b517547)">
-     <use xlink:href="#m82aa36b1de" x="249.06205" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p50a3fc6c2a)">
+     <use xlink:href="#m5b33c6840c" x="249.06205" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m84d144b693" d="M 0 3 
+     <path id="me2480b2080" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2043,8 +2043,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p002b517547)">
-     <use xlink:href="#m84d144b693" x="286.244503" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p50a3fc6c2a)">
+     <use xlink:href="#me2480b2080" x="286.244503" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2984,7 +2984,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p002b517547">
+  <clipPath id="p50a3fc6c2a">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pac92c90bb9)">
+   <g clip-path="url(#p198bd80986)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ80lEQVR4nO3YO44dZhnH4TOe8UUe22NbECICAuGIghAoUSioUiEoWAMroKGiQuyAig3QoYjSTUqkcCdURISLuMgaYnzBcuzxzBxW8CtQ9OlFR8+zgr80Z97zO9/e+b0fbTc76OTHd6cnLHHxzdenJyyz99Inpycssf3t76YnLLH3pdemJyyxffp4esIyx999a3rCEi/94BvTE5bYu/2J6QlrnDydXrDM+c93895fmB4AAMD/L7EIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDa+8/JW9vpESsc/vt4esISH9y4Oj1hmQ9Pn0xPWOLTj06mJyzx6OMvT09Y4nx7Pj1hmVsHt6cnrHH/L9MLlnh8azf/Xtf//IfpCctsP/+V6QlLeFkEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACAdHN6/N71hjas3pxcssd2eTE9Y5lNv/3J6whpvfn16wRJHH/xzesIa56fTC9Y53NH7cfna9IIlbvxrN7+fH3zmzvSEZW797d3pCUt4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADS3ouzu9vpESvsH/9pesIS965fmp6wzJMXD6cnLHHnrw+nJyxx+sWvTk9Y4unp4+kJyxzt35yesMT2/V9MT1ji2eden56wxJV335mesMzzL78xPWEJL4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2vvp+9/ZTo9Y4faVw+kJS7z38P70hGW+/cNfT09Y4jff/+b0hCWOLh9NT1jiez/71fSEZb72ypXpCUt8684b0xOWePvv70xPWOLaxd38HG42m81P/vhgesISXhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfi7O52esQKD54fT09Y4vDgxvSEZd57+PvpCUu8evO16QlLbLfn0xOWuHa6u7+h/3G+m3fxlcNXpycs8ezs6fSEJXb1dmw2m83+hYPpCUvs7lUEAOAjE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAOtjfO5jesMTH9m9PT1hj/9L0gmWOLh9NT1ji8ODG9IQlzran0xOWOL+4u7+hX95enZ7A/2BXv59Pts+mJyzz+Pnx9IQldvcqAgDwkYlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADSwWZ7Pr1hiUfbJ9MTljg4uzQ9YZnPXv/C9IQlzran0xOW+PB0N//Hrm2uTE9Y5tmF3bz3+9MDFrm4v5v3fv/CwfSEZQ73rk5PWMLLIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJD+C2EVlmm8G2EiAAAAAElFTkSuQmCC" id="imaged8c3aef41e" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ80lEQVR4nO3YO44dZhnH4TOe8UUe22NbECICAuGIghAoUSioUiEoWAMroKGiQuyAig3QoYjSTUqkcCdURISLuMgaYnzBcuzxzBxW8CtQ9OlFR8+zgr80Z97zO9/e+b0fbTc76OTHd6cnLHHxzdenJyyz99Inpycssf3t76YnLLH3pdemJyyxffp4esIyx999a3rCEi/94BvTE5bYu/2J6QlrnDydXrDM+c93895fmB4AAMD/L7EIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDa+8/JW9vpESsc/vt4esISH9y4Oj1hmQ9Pn0xPWOLTj06mJyzx6OMvT09Y4nx7Pj1hmVsHt6cnrHH/L9MLlnh8azf/Xtf//IfpCctsP/+V6QlLeFkEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACAdHN6/N71hjas3pxcssd2eTE9Y5lNv/3J6whpvfn16wRJHH/xzesIa56fTC9Y53NH7cfna9IIlbvxrN7+fH3zmzvSEZW797d3pCUt4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADS3ouzu9vpESvsH/9pesIS965fmp6wzJMXD6cnLHHnrw+nJyxx+sWvTk9Y4unp4+kJyxzt35yesMT2/V9MT1ji2eden56wxJV335mesMzzL78xPWEJL4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2vvp+9/ZTo9Y4faVw+kJS7z38P70hGW+/cNfT09Y4jff/+b0hCWOLh9NT1jiez/71fSEZb72ypXpCUt8684b0xOWePvv70xPWOLaxd38HG42m81P/vhgesISXhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfi7O52esQKD54fT09Y4vDgxvSEZd57+PvpCUu8evO16QlLbLfn0xOWuHa6u7+h/3G+m3fxlcNXpycs8ezs6fSEJXb1dmw2m83+hYPpCUvs7lUEAOAjE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAOtjfO5jesMTH9m9PT1hj/9L0gmWOLh9NT1ji8ODG9IQlzran0xOWOL+4u7+hX95enZ7A/2BXv59Pts+mJyzz+Pnx9IQldvcqAgDwkYlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADSwWZ7Pr1hiUfbJ9MTljg4uzQ9YZnPXv/C9IQlzran0xOW+PB0N//Hrm2uTE9Y5tmF3bz3+9MDFrm4v5v3fv/CwfSEZQ73rk5PWMLLIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJD+C2EVlmm8G2EiAAAAAElFTkSuQmCC" id="image415c6576fa" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m714fa5b87f" d="M 0 0 
+       <path id="m9fc6f4d184" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m714fa5b87f" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc6f4d184" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m714fa5b87f" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc6f4d184" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m714fa5b87f" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc6f4d184" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m714fa5b87f" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc6f4d184" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m714fa5b87f" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc6f4d184" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m714fa5b87f" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc6f4d184" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m714fa5b87f" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc6f4d184" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m714fa5b87f" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc6f4d184" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m714fa5b87f" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc6f4d184" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m714fa5b87f" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc6f4d184" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m714fa5b87f" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc6f4d184" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m714fa5b87f" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc6f4d184" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mae493d92a5" d="M 0 0 
+       <path id="mdc60a616eb" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mae493d92a5" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc60a616eb" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mae493d92a5" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc60a616eb" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mae493d92a5" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc60a616eb" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mae493d92a5" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc60a616eb" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mae493d92a5" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc60a616eb" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mae493d92a5" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc60a616eb" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mae493d92a5" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc60a616eb" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mae493d92a5" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc60a616eb" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagee83f230946" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imageb24a65fb23" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m3d30db1bf7" d="M 0 0 
+       <path id="m5449d9831a" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3d30db1bf7" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5449d9831a" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m3d30db1bf7" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5449d9831a" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m3d30db1bf7" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5449d9831a" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3d30db1bf7" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5449d9831a" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m3d30db1bf7" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5449d9831a" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.448437 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-11T10:44:33Z  ·  Linux chungus2 x86_64  ·  commit c014c7e1  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.058516 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2870,14 +2870,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2917,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3372.705078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3436.328125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3497.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3561.474609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3593.261719 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3625.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3656.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3688.623047 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3720.410156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3748.193359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3809.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3870.996094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3934.375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3997.851562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4036.714844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4097.896484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4157.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4218.599609 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4259.712891 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4293.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4321.1875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4382.710938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4443.990234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4507.369141 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4570.992188 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4604.683594 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4663.863281 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4727.486328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4759.273438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4822.896484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4886.519531 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4918.306641 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4981.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5018.013672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5056.876953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5111.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5175.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5207.267578 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5239.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5270.841797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5302.628906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5334.416016 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5373.625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5437.003906 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5475.867188 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5537.048828 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5600.427734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5663.904297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5727.283203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5790.759766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5854.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5893.347656 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6008.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6040.710938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6138.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6199.646484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6263.123047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6290.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6352.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6415.564453 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6447.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6499.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6562.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6624.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6864.246094 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6903.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6937.146484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6968.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7010.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7071.326172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7110.535156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7138.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7199.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7231.287109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7259.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7311.169922 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7342.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7406.433594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7467.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7507.166016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7568.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7608.052734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7705.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7733.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7796.626953 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7824.410156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7876.509766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7915.71875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7943.501953 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pac92c90bb9">
+  <clipPath id="p198bd80986">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.503125pt" height="386.202469pt" viewBox="0 0 573.503125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="574.282969pt" height="386.202469pt" viewBox="0 0 574.282969 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 573.503125 386.202469 
-L 573.503125 0 
+L 574.282969 386.202469 
+L 574.282969 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.876563 104.1264 
-L 293.501563 104.1264 
-L 293.501563 74.7432 
-L 188.876563 74.7432 
+    <path d="M 189.266484 104.1264 
+L 293.891484 104.1264 
+L 293.891484 74.7432 
+L 189.266484 74.7432 
 z
-" clip-path="url(#p9be7089005)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.501563 104.1264 
-L 398.126563 104.1264 
-L 398.126563 74.7432 
-L 293.501563 74.7432 
+    <path d="M 293.891484 104.1264 
+L 398.516484 104.1264 
+L 398.516484 74.7432 
+L 293.891484 74.7432 
 z
-" clip-path="url(#p9be7089005)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 398.126563 104.1264 
-L 502.751563 104.1264 
-L 502.751563 74.7432 
-L 398.126563 74.7432 
+    <path d="M 398.516484 104.1264 
+L 503.141484 104.1264 
+L 503.141484 74.7432 
+L 398.516484 74.7432 
 z
-" clip-path="url(#p9be7089005)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.876563 133.5096 
-L 293.501563 133.5096 
-L 293.501563 104.1264 
-L 188.876563 104.1264 
+    <path d="M 189.266484 133.5096 
+L 293.891484 133.5096 
+L 293.891484 104.1264 
+L 189.266484 104.1264 
 z
-" clip-path="url(#p9be7089005)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.501563 133.5096 
-L 398.126563 133.5096 
-L 398.126563 104.1264 
-L 293.501563 104.1264 
+    <path d="M 293.891484 133.5096 
+L 398.516484 133.5096 
+L 398.516484 104.1264 
+L 293.891484 104.1264 
 z
-" clip-path="url(#p9be7089005)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 398.126563 133.5096 
-L 502.751563 133.5096 
-L 502.751563 104.1264 
-L 398.126563 104.1264 
+    <path d="M 398.516484 133.5096 
+L 503.141484 133.5096 
+L 503.141484 104.1264 
+L 398.516484 104.1264 
 z
-" clip-path="url(#p9be7089005)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.876563 162.8928 
-L 293.501563 162.8928 
-L 293.501563 133.5096 
-L 188.876563 133.5096 
+    <path d="M 189.266484 162.8928 
+L 293.891484 162.8928 
+L 293.891484 133.5096 
+L 189.266484 133.5096 
 z
-" clip-path="url(#p9be7089005)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.501563 162.8928 
-L 398.126563 162.8928 
-L 398.126563 133.5096 
-L 293.501563 133.5096 
+    <path d="M 293.891484 162.8928 
+L 398.516484 162.8928 
+L 398.516484 133.5096 
+L 293.891484 133.5096 
 z
-" clip-path="url(#p9be7089005)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 398.126563 162.8928 
-L 502.751563 162.8928 
-L 502.751563 133.5096 
-L 398.126563 133.5096 
+    <path d="M 398.516484 162.8928 
+L 503.141484 162.8928 
+L 503.141484 133.5096 
+L 398.516484 133.5096 
 z
-" clip-path="url(#p9be7089005)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.876563 192.276 
-L 293.501563 192.276 
-L 293.501563 162.8928 
-L 188.876563 162.8928 
+    <path d="M 189.266484 192.276 
+L 293.891484 192.276 
+L 293.891484 162.8928 
+L 189.266484 162.8928 
 z
-" clip-path="url(#p9be7089005)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.501563 192.276 
-L 398.126563 192.276 
-L 398.126563 162.8928 
-L 293.501563 162.8928 
+    <path d="M 293.891484 192.276 
+L 398.516484 192.276 
+L 398.516484 162.8928 
+L 293.891484 162.8928 
 z
-" clip-path="url(#p9be7089005)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 398.126563 192.276 
-L 502.751563 192.276 
-L 502.751563 162.8928 
-L 398.126563 162.8928 
+    <path d="M 398.516484 192.276 
+L 503.141484 192.276 
+L 503.141484 162.8928 
+L 398.516484 162.8928 
 z
-" clip-path="url(#p9be7089005)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.876563 221.6592 
-L 293.501563 221.6592 
-L 293.501563 192.276 
-L 188.876563 192.276 
+    <path d="M 189.266484 221.6592 
+L 293.891484 221.6592 
+L 293.891484 192.276 
+L 189.266484 192.276 
 z
-" clip-path="url(#p9be7089005)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.501563 221.6592 
-L 398.126563 221.6592 
-L 398.126563 192.276 
-L 293.501563 192.276 
+    <path d="M 293.891484 221.6592 
+L 398.516484 221.6592 
+L 398.516484 192.276 
+L 293.891484 192.276 
 z
-" clip-path="url(#p9be7089005)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 398.126563 221.6592 
-L 502.751563 221.6592 
-L 502.751563 192.276 
-L 398.126563 192.276 
+    <path d="M 398.516484 221.6592 
+L 503.141484 221.6592 
+L 503.141484 192.276 
+L 398.516484 192.276 
 z
-" clip-path="url(#p9be7089005)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.876563 251.0424 
-L 293.501563 251.0424 
-L 293.501563 221.6592 
-L 188.876563 221.6592 
+    <path d="M 189.266484 251.0424 
+L 293.891484 251.0424 
+L 293.891484 221.6592 
+L 189.266484 221.6592 
 z
-" clip-path="url(#p9be7089005)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.501563 251.0424 
-L 398.126563 251.0424 
-L 398.126563 221.6592 
-L 293.501563 221.6592 
+    <path d="M 293.891484 251.0424 
+L 398.516484 251.0424 
+L 398.516484 221.6592 
+L 293.891484 221.6592 
 z
-" clip-path="url(#p9be7089005)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 398.126563 251.0424 
-L 502.751563 251.0424 
-L 502.751563 221.6592 
-L 398.126563 221.6592 
+    <path d="M 398.516484 251.0424 
+L 503.141484 251.0424 
+L 503.141484 221.6592 
+L 398.516484 221.6592 
 z
-" clip-path="url(#p9be7089005)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.876563 280.4256 
-L 293.501563 280.4256 
-L 293.501563 251.0424 
-L 188.876563 251.0424 
+    <path d="M 189.266484 280.4256 
+L 293.891484 280.4256 
+L 293.891484 251.0424 
+L 189.266484 251.0424 
 z
-" clip-path="url(#p9be7089005)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.501563 280.4256 
-L 398.126563 280.4256 
-L 398.126563 251.0424 
-L 293.501563 251.0424 
+    <path d="M 293.891484 280.4256 
+L 398.516484 280.4256 
+L 398.516484 251.0424 
+L 293.891484 251.0424 
 z
-" clip-path="url(#p9be7089005)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 398.126563 280.4256 
-L 502.751563 280.4256 
-L 502.751563 251.0424 
-L 398.126563 251.0424 
+    <path d="M 398.516484 280.4256 
+L 503.141484 280.4256 
+L 503.141484 251.0424 
+L 398.516484 251.0424 
 z
-" clip-path="url(#p9be7089005)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.876563 309.8088 
-L 293.501563 309.8088 
-L 293.501563 280.4256 
-L 188.876563 280.4256 
+    <path d="M 189.266484 309.8088 
+L 293.891484 309.8088 
+L 293.891484 280.4256 
+L 189.266484 280.4256 
 z
-" clip-path="url(#p9be7089005)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.501563 309.8088 
-L 398.126563 309.8088 
-L 398.126563 280.4256 
-L 293.501563 280.4256 
+    <path d="M 293.891484 309.8088 
+L 398.516484 309.8088 
+L 398.516484 280.4256 
+L 293.891484 280.4256 
 z
-" clip-path="url(#p9be7089005)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.126563 309.8088 
-L 502.751563 309.8088 
-L 502.751563 280.4256 
-L 398.126563 280.4256 
+    <path d="M 398.516484 309.8088 
+L 503.141484 309.8088 
+L 503.141484 280.4256 
+L 398.516484 280.4256 
 z
-" clip-path="url(#p9be7089005)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.876563 339.192 
-L 293.501563 339.192 
-L 293.501563 309.8088 
-L 188.876563 309.8088 
+    <path d="M 189.266484 339.192 
+L 293.891484 339.192 
+L 293.891484 309.8088 
+L 189.266484 309.8088 
 z
-" clip-path="url(#p9be7089005)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.501563 339.192 
-L 398.126563 339.192 
-L 398.126563 309.8088 
-L 293.501563 309.8088 
+    <path d="M 293.891484 339.192 
+L 398.516484 339.192 
+L 398.516484 309.8088 
+L 293.891484 309.8088 
 z
-" clip-path="url(#p9be7089005)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 398.126563 339.192 
-L 502.751563 339.192 
-L 502.751563 309.8088 
-L 398.126563 309.8088 
+    <path d="M 398.516484 339.192 
+L 503.141484 339.192 
+L 503.141484 309.8088 
+L 398.516484 309.8088 
 z
-" clip-path="url(#p9be7089005)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p70c4c0779a)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.863828 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.25375 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(229.148047 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.537969 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.720156 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.110078 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.071875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.461797 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.801563 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.191484 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(229.737813 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(338.179063 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.568984 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(442.804063 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.193984 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.439688 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.829609 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(229.737813 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(340.724063 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.113984 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(442.804063 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.193984 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(100.132813 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(100.522734 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(229.737813 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(340.724063 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.113984 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(442.804063 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.193984 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(121.165313 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(121.555234 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(229.737813 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(340.724063 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.113984 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(442.804063 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.193984 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(129.702813 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(130.092734 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(229.737813 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,14 +1550,14 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(340.724063 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.113984 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(442.804063 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.193984 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
@@ -1565,7 +1565,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.510938 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(99.900859 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1674,7 +1674,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(228.537188 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.927109 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1768,7 +1768,7 @@ z
    </g>
    <g id="text_27">
     <!-- 37 -->
-    <g transform="translate(340.247813 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.637734 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-37" d="M 428 4666 
 L 3944 4666 
@@ -1786,8 +1786,8 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- 292 -->
-    <g transform="translate(442.089688 238.5583) scale(0.08 -0.08)">
+    <!-- 297 -->
+    <g transform="translate(442.479609 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1822,12 +1822,12 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- miniz_oxide -->
-    <g transform="translate(113.009063 267.83025) scale(0.08 -0.08)">
+    <g transform="translate(113.398984 267.83025) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1886,7 +1886,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.322 -->
-    <g transform="translate(229.737813 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1896,14 +1896,14 @@ z
    </g>
    <g id="text_31">
     <!-- 36 -->
-    <g transform="translate(340.724063 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(341.113984 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 527 -->
-    <g transform="translate(442.804063 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(443.193984 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1911,7 +1911,7 @@ z
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.625938 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.015859 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1976,7 +1976,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(229.737813 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1986,21 +1986,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(340.724063 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.113984 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(445.349063 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(445.738984 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.847188 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.237109 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2011,7 +2011,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(229.737813 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.127734 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2021,13 +2021,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(343.269063 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.658984 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.439063 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.828984 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2043,7 +2043,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(153.353281 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(153.743203 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2187,7 +2187,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-11T10:44:33Z  ·  Linux chungus2 x86_64  ·  commit c014c7e1  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2328,14 +2328,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2375,110 +2375,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3372.705078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3436.328125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3497.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3561.474609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3593.261719 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3625.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3656.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3688.623047 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3720.410156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3748.193359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3809.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3870.996094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3934.375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3997.851562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4036.714844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4097.896484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4157.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4218.599609 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4259.712891 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4293.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4321.1875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4382.710938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4443.990234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4507.369141 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4570.992188 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4604.683594 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4663.863281 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4727.486328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4759.273438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4822.896484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4886.519531 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4918.306641 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4981.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5018.013672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5056.876953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5111.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5175.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5207.267578 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5239.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5270.841797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5302.628906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5334.416016 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5373.625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5437.003906 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5475.867188 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5537.048828 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5600.427734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5663.904297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5727.283203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5790.759766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5854.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5893.347656 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6008.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6040.710938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6138.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6199.646484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6263.123047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6290.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6352.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6415.564453 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6447.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6499.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6562.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6624.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6864.246094 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6903.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6937.146484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6968.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7010.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7071.326172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7110.535156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7138.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7199.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7231.287109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7259.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7311.169922 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7342.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7406.433594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7467.957031 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7507.166016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7568.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7608.052734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7705.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7733.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7796.626953 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7824.410156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7876.509766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7915.71875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7943.501953 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p9be7089005">
-   <rect x="84.251563" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p70c4c0779a">
+   <rect x="84.641484" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-11T04:15:02Z",
+  "date": "2026-07-11T10:44:33Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "e802670f",
+  "git_commit": "c014c7e1",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -15,7 +15,7 @@
    "out_size": 60455,
    "ratio": 0.3975,
    "compress_mbps": 87.12,
-   "decompress_mbps": 213.99
+   "decompress_mbps": 212.77
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 57095,
    "ratio": 0.3754,
-   "compress_mbps": 72.13,
-   "decompress_mbps": 243.5
+   "compress_mbps": 72.06,
+   "decompress_mbps": 243.76
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 56050,
    "ratio": 0.3685,
-   "compress_mbps": 61.65,
-   "decompress_mbps": 265.83
+   "compress_mbps": 61.72,
+   "decompress_mbps": 265.62
   },
   {
    "compressor": "native",
@@ -44,18 +44,18 @@
    "level": 4,
    "out_size": 54357,
    "ratio": 0.3574,
-   "compress_mbps": 38.68,
-   "decompress_mbps": 271.59
+   "compress_mbps": 38.54,
+   "decompress_mbps": 270.51
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 5,
-   "out_size": 54078,
-   "ratio": 0.3556,
-   "compress_mbps": 31.06,
-   "decompress_mbps": 272.66
+   "out_size": 54620,
+   "ratio": 0.3591,
+   "compress_mbps": 37.93,
+   "decompress_mbps": 271.24
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54593,
    "ratio": 0.359,
-   "compress_mbps": 32.15,
-   "decompress_mbps": 279.03
+   "compress_mbps": 32.02,
+   "decompress_mbps": 277.7
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54469,
    "ratio": 0.3581,
-   "compress_mbps": 29.02,
-   "decompress_mbps": 279.28
+   "compress_mbps": 28.84,
+   "decompress_mbps": 278.09
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54216,
    "ratio": 0.3565,
-   "compress_mbps": 23.0,
-   "decompress_mbps": 279.68
+   "compress_mbps": 22.93,
+   "decompress_mbps": 278.01
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.31,
-   "decompress_mbps": 277.8
+   "compress_mbps": 4.33,
+   "decompress_mbps": 279.22
   },
   {
    "compressor": "native",
@@ -104,7 +104,7 @@
    "level": 10,
    "out_size": 52078,
    "ratio": 0.3424,
-   "compress_mbps": 2.4,
+   "compress_mbps": 2.38,
    "decompress_mbps": null
   },
   {
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 79.76,
-   "decompress_mbps": 205.57
+   "compress_mbps": 79.35,
+   "decompress_mbps": 205.27
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50676,
    "ratio": 0.4048,
-   "compress_mbps": 66.76,
-   "decompress_mbps": 224.06
+   "compress_mbps": 66.59,
+   "decompress_mbps": 223.79
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 3,
    "out_size": 50023,
    "ratio": 0.3996,
-   "compress_mbps": 58.25,
-   "decompress_mbps": 243.76
+   "compress_mbps": 58.04,
+   "decompress_mbps": 243.27
   },
   {
    "compressor": "native",
@@ -144,18 +144,18 @@
    "level": 4,
    "out_size": 48687,
    "ratio": 0.3889,
-   "compress_mbps": 36.04,
-   "decompress_mbps": 247.42
+   "compress_mbps": 36.15,
+   "decompress_mbps": 247.21
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 5,
-   "out_size": 48586,
-   "ratio": 0.3881,
-   "compress_mbps": 31.01,
-   "decompress_mbps": 247.58
+   "out_size": 48697,
+   "ratio": 0.389,
+   "compress_mbps": 35.07,
+   "decompress_mbps": 248.08
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 6,
    "out_size": 49005,
    "ratio": 0.3915,
-   "compress_mbps": 30.61,
-   "decompress_mbps": 252.15
+   "compress_mbps": 30.7,
+   "decompress_mbps": 252.82
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 7,
    "out_size": 48910,
    "ratio": 0.3907,
-   "compress_mbps": 27.69,
-   "decompress_mbps": 252.06
+   "compress_mbps": 27.86,
+   "decompress_mbps": 251.76
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 8,
    "out_size": 48839,
    "ratio": 0.3902,
-   "compress_mbps": 24.79,
-   "decompress_mbps": 253.25
+   "compress_mbps": 24.88,
+   "decompress_mbps": 253.69
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 9,
    "out_size": 47433,
    "ratio": 0.3789,
-   "compress_mbps": 4.61,
-   "decompress_mbps": 254.13
+   "compress_mbps": 4.63,
+   "decompress_mbps": 253.26
   },
   {
    "compressor": "native",
@@ -204,7 +204,7 @@
    "level": 10,
    "out_size": 46866,
    "ratio": 0.3744,
-   "compress_mbps": 2.81,
+   "compress_mbps": 2.78,
    "decompress_mbps": null
   },
   {
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 74.04,
-   "decompress_mbps": 265.91
+   "compress_mbps": 74.12,
+   "decompress_mbps": 266.91
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 2,
    "out_size": 8249,
    "ratio": 0.3353,
-   "compress_mbps": 68.74,
-   "decompress_mbps": 274.93
+   "compress_mbps": 68.65,
+   "decompress_mbps": 277.11
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 3,
    "out_size": 8112,
    "ratio": 0.3297,
-   "compress_mbps": 63.3,
-   "decompress_mbps": 281.37
+   "compress_mbps": 63.49,
+   "decompress_mbps": 278.39
   },
   {
    "compressor": "native",
@@ -244,18 +244,18 @@
    "level": 4,
    "out_size": 7948,
    "ratio": 0.3231,
-   "compress_mbps": 50.14,
-   "decompress_mbps": 291.22
+   "compress_mbps": 49.86,
+   "decompress_mbps": 287.85
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 5,
-   "out_size": 7899,
-   "ratio": 0.3211,
-   "compress_mbps": 42.56,
-   "decompress_mbps": 297.39
+   "out_size": 7970,
+   "ratio": 0.3239,
+   "compress_mbps": 46.88,
+   "decompress_mbps": 296.56
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 6,
    "out_size": 7962,
    "ratio": 0.3236,
-   "compress_mbps": 37.45,
-   "decompress_mbps": 295.38
+   "compress_mbps": 37.65,
+   "decompress_mbps": 293.53
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 7,
    "out_size": 7950,
    "ratio": 0.3231,
-   "compress_mbps": 35.58,
-   "decompress_mbps": 302.49
+   "compress_mbps": 35.52,
+   "decompress_mbps": 302.85
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7934,
    "ratio": 0.3225,
-   "compress_mbps": 32.42,
-   "decompress_mbps": 303.23
+   "compress_mbps": 32.12,
+   "decompress_mbps": 302.26
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 5.02,
-   "decompress_mbps": 302.07
+   "compress_mbps": 4.99,
+   "decompress_mbps": 303.15
   },
   {
    "compressor": "native",
@@ -304,7 +304,7 @@
    "level": 10,
    "out_size": 7737,
    "ratio": 0.3145,
-   "compress_mbps": 2.96,
+   "compress_mbps": 2.92,
    "decompress_mbps": null
   },
   {
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 54.46,
-   "decompress_mbps": 187.44
+   "compress_mbps": 53.92,
+   "decompress_mbps": 186.66
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 2,
    "out_size": 3317,
    "ratio": 0.2975,
-   "compress_mbps": 51.59,
-   "decompress_mbps": 189.95
+   "compress_mbps": 51.5,
+   "decompress_mbps": 189.26
   },
   {
    "compressor": "native",
@@ -335,7 +335,7 @@
    "out_size": 3227,
    "ratio": 0.2894,
    "compress_mbps": 48.98,
-   "decompress_mbps": 193.85
+   "decompress_mbps": 192.86
   },
   {
    "compressor": "native",
@@ -344,18 +344,18 @@
    "level": 4,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 40.99,
-   "decompress_mbps": 198.23
+   "compress_mbps": 40.56,
+   "decompress_mbps": 197.59
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 5,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 36.65,
-   "decompress_mbps": 198.25
+   "out_size": 3150,
+   "ratio": 0.2825,
+   "compress_mbps": 39.74,
+   "decompress_mbps": 196.19
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 6,
    "out_size": 3136,
    "ratio": 0.2813,
-   "compress_mbps": 34.47,
-   "decompress_mbps": 197.87
+   "compress_mbps": 34.34,
+   "decompress_mbps": 198.72
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 7,
    "out_size": 3122,
    "ratio": 0.28,
-   "compress_mbps": 33.18,
-   "decompress_mbps": 198.92
+   "compress_mbps": 32.98,
+   "decompress_mbps": 198.4
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 8,
    "out_size": 3117,
    "ratio": 0.2796,
-   "compress_mbps": 30.93,
-   "decompress_mbps": 199.11
+   "compress_mbps": 30.78,
+   "decompress_mbps": 198.74
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 5.54,
-   "decompress_mbps": 199.23
+   "compress_mbps": 5.46,
+   "decompress_mbps": 198.32
   },
   {
    "compressor": "native",
@@ -404,7 +404,7 @@
    "level": 10,
    "out_size": 3031,
    "ratio": 0.2718,
-   "compress_mbps": 3.08,
+   "compress_mbps": 3.04,
    "decompress_mbps": null
   },
   {
@@ -414,7 +414,7 @@
    "level": 1,
    "out_size": 1283,
    "ratio": 0.3448,
-   "compress_mbps": 26.36,
+   "compress_mbps": 26.31,
    "decompress_mbps": 86.04
   },
   {
@@ -424,8 +424,8 @@
    "level": 2,
    "out_size": 1234,
    "ratio": 0.3316,
-   "compress_mbps": 26.11,
-   "decompress_mbps": 86.89
+   "compress_mbps": 25.97,
+   "decompress_mbps": 87.55
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 3,
    "out_size": 1223,
    "ratio": 0.3287,
-   "compress_mbps": 25.6,
-   "decompress_mbps": 86.79
+   "compress_mbps": 25.61,
+   "decompress_mbps": 87.05
   },
   {
    "compressor": "native",
@@ -444,18 +444,18 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 22.22,
-   "decompress_mbps": 87.29
+   "compress_mbps": 22.16,
+   "decompress_mbps": 87.81
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
    "level": 5,
-   "out_size": 1209,
-   "ratio": 0.3249,
-   "compress_mbps": 21.77,
-   "decompress_mbps": 87.33
+   "out_size": 1210,
+   "ratio": 0.3252,
+   "compress_mbps": 21.47,
+   "decompress_mbps": 88.04
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 6,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 19.99,
-   "decompress_mbps": 87.5
+   "compress_mbps": 19.66,
+   "decompress_mbps": 87.61
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 7,
    "out_size": 1219,
    "ratio": 0.3276,
-   "compress_mbps": 19.82,
-   "decompress_mbps": 87.65
+   "compress_mbps": 19.58,
+   "decompress_mbps": 88.14
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 8,
    "out_size": 1219,
    "ratio": 0.3276,
-   "compress_mbps": 19.57,
-   "decompress_mbps": 87.84
+   "compress_mbps": 19.52,
+   "decompress_mbps": 88.04
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 4.96,
-   "decompress_mbps": 87.76
+   "compress_mbps": 4.93,
+   "decompress_mbps": 87.49
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.98,
+   "compress_mbps": 2.92,
    "decompress_mbps": null
   },
   {
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 176.48,
-   "decompress_mbps": 390.21
+   "compress_mbps": 178.61,
+   "decompress_mbps": 388.02
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 244112,
    "ratio": 0.2371,
-   "compress_mbps": 145.22,
-   "decompress_mbps": 380.68
+   "compress_mbps": 145.46,
+   "decompress_mbps": 378.62
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 3,
    "out_size": 242564,
    "ratio": 0.2356,
-   "compress_mbps": 120.86,
-   "decompress_mbps": 408.83
+   "compress_mbps": 121.09,
+   "decompress_mbps": 405.76
   },
   {
    "compressor": "native",
@@ -544,18 +544,18 @@
    "level": 4,
    "out_size": 239953,
    "ratio": 0.233,
-   "compress_mbps": 101.7,
-   "decompress_mbps": 452.75
+   "compress_mbps": 101.62,
+   "decompress_mbps": 449.84
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 5,
-   "out_size": 218565,
-   "ratio": 0.2123,
-   "compress_mbps": 54.92,
-   "decompress_mbps": 450.38
+   "out_size": 202780,
+   "ratio": 0.1969,
+   "compress_mbps": 48.82,
+   "decompress_mbps": 447.27
   },
   {
    "compressor": "native",
@@ -565,7 +565,7 @@
    "out_size": 202437,
    "ratio": 0.1966,
    "compress_mbps": 40.68,
-   "decompress_mbps": 470.08
+   "decompress_mbps": 467.33
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 7,
    "out_size": 201821,
    "ratio": 0.196,
-   "compress_mbps": 37.89,
-   "decompress_mbps": 472.73
+   "compress_mbps": 37.8,
+   "decompress_mbps": 470.23
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 8,
    "out_size": 200869,
    "ratio": 0.1951,
-   "compress_mbps": 21.67,
-   "decompress_mbps": 488.49
+   "compress_mbps": 21.61,
+   "decompress_mbps": 485.74
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182511,
    "ratio": 0.1772,
-   "compress_mbps": 3.49,
-   "decompress_mbps": 487.64
+   "compress_mbps": 3.46,
+   "decompress_mbps": 486.1
   },
   {
    "compressor": "native",
@@ -604,7 +604,7 @@
    "level": 10,
    "out_size": 178069,
    "ratio": 0.1729,
-   "compress_mbps": 1.48,
+   "compress_mbps": 1.46,
    "decompress_mbps": null
   },
   {
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 95.8,
-   "decompress_mbps": 221.44
+   "compress_mbps": 95.78,
+   "decompress_mbps": 222.03
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 2,
    "out_size": 151578,
    "ratio": 0.3552,
-   "compress_mbps": 78.7,
-   "decompress_mbps": 239.81
+   "compress_mbps": 78.93,
+   "decompress_mbps": 240.67
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 3,
    "out_size": 148848,
    "ratio": 0.3488,
-   "compress_mbps": 66.25,
-   "decompress_mbps": 267.59
+   "compress_mbps": 66.39,
+   "decompress_mbps": 268.08
   },
   {
    "compressor": "native",
@@ -645,16 +645,16 @@
    "out_size": 144750,
    "ratio": 0.3392,
    "compress_mbps": 42.37,
-   "decompress_mbps": 271.8
+   "decompress_mbps": 271.59
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 5,
-   "out_size": 144408,
-   "ratio": 0.3384,
-   "compress_mbps": 33.95,
+   "out_size": 145139,
+   "ratio": 0.3401,
+   "compress_mbps": 40.83,
    "decompress_mbps": 274.65
   },
   {
@@ -664,8 +664,8 @@
    "level": 6,
    "out_size": 144872,
    "ratio": 0.3395,
-   "compress_mbps": 31.82,
-   "decompress_mbps": 278.47
+   "compress_mbps": 31.85,
+   "decompress_mbps": 278.9
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 7,
    "out_size": 144583,
    "ratio": 0.3388,
-   "compress_mbps": 28.93,
-   "decompress_mbps": 279.11
+   "compress_mbps": 28.89,
+   "decompress_mbps": 280.12
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 8,
    "out_size": 144045,
    "ratio": 0.3375,
-   "compress_mbps": 23.98,
-   "decompress_mbps": 280.58
+   "compress_mbps": 23.94,
+   "decompress_mbps": 280.38
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 9,
    "out_size": 140323,
    "ratio": 0.3288,
-   "compress_mbps": 4.28,
-   "decompress_mbps": 280.09
+   "compress_mbps": 4.31,
+   "decompress_mbps": 280.74
   },
   {
    "compressor": "native",
@@ -704,7 +704,7 @@
    "level": 10,
    "out_size": 138833,
    "ratio": 0.3253,
-   "compress_mbps": 2.53,
+   "compress_mbps": 2.5,
    "decompress_mbps": null
   },
   {
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 81.01,
-   "decompress_mbps": 189.8
+   "compress_mbps": 81.19,
+   "decompress_mbps": 190.64
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 202277,
    "ratio": 0.4198,
-   "compress_mbps": 66.53,
-   "decompress_mbps": 212.94
+   "compress_mbps": 66.38,
+   "decompress_mbps": 209.36
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 3,
    "out_size": 199922,
    "ratio": 0.4149,
-   "compress_mbps": 57.36,
-   "decompress_mbps": 233.84
+   "compress_mbps": 57.16,
+   "decompress_mbps": 228.05
   },
   {
    "compressor": "native",
@@ -744,18 +744,18 @@
    "level": 4,
    "out_size": 193783,
    "ratio": 0.4022,
-   "compress_mbps": 32.67,
-   "decompress_mbps": 238.8
+   "compress_mbps": 32.42,
+   "decompress_mbps": 239.33
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 5,
-   "out_size": 193223,
-   "ratio": 0.401,
-   "compress_mbps": 27.25,
-   "decompress_mbps": 235.61
+   "out_size": 195459,
+   "ratio": 0.4056,
+   "compress_mbps": 35.23,
+   "decompress_mbps": 222.64
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 6,
    "out_size": 195643,
    "ratio": 0.406,
-   "compress_mbps": 27.98,
-   "decompress_mbps": 239.73
+   "compress_mbps": 27.83,
+   "decompress_mbps": 240.63
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 7,
    "out_size": 195104,
    "ratio": 0.4049,
-   "compress_mbps": 25.06,
-   "decompress_mbps": 240.56
+   "compress_mbps": 25.18,
+   "decompress_mbps": 240.53
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 8,
    "out_size": 194355,
    "ratio": 0.4033,
-   "compress_mbps": 20.45,
-   "decompress_mbps": 240.49
+   "compress_mbps": 20.55,
+   "decompress_mbps": 240.8
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 9,
    "out_size": 189368,
    "ratio": 0.393,
-   "compress_mbps": 4.07,
-   "decompress_mbps": 241.19
+   "compress_mbps": 4.05,
+   "decompress_mbps": 240.82
   },
   {
    "compressor": "native",
@@ -804,7 +804,7 @@
    "level": 10,
    "out_size": 186146,
    "ratio": 0.3863,
-   "compress_mbps": 2.46,
+   "compress_mbps": 2.43,
    "decompress_mbps": null
   },
   {
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 267.97,
-   "decompress_mbps": 580.16
+   "compress_mbps": 268.28,
+   "decompress_mbps": 581.32
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58606,
    "ratio": 0.1142,
-   "compress_mbps": 239.53,
-   "decompress_mbps": 605.65
+   "compress_mbps": 240.19,
+   "decompress_mbps": 607.51
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 3,
    "out_size": 57685,
    "ratio": 0.1124,
-   "compress_mbps": 197.95,
-   "decompress_mbps": 631.59
+   "compress_mbps": 199.67,
+   "decompress_mbps": 629.82
   },
   {
    "compressor": "native",
@@ -844,18 +844,18 @@
    "level": 4,
    "out_size": 55586,
    "ratio": 0.1083,
-   "compress_mbps": 122.59,
-   "decompress_mbps": 647.96
+   "compress_mbps": 125.0,
+   "decompress_mbps": 647.38
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 5,
-   "out_size": 55097,
-   "ratio": 0.1074,
-   "compress_mbps": 91.43,
-   "decompress_mbps": 670.15
+   "out_size": 55375,
+   "ratio": 0.1079,
+   "compress_mbps": 84.91,
+   "decompress_mbps": 670.68
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 6,
    "out_size": 55674,
    "ratio": 0.1085,
-   "compress_mbps": 75.2,
-   "decompress_mbps": 690.49
+   "compress_mbps": 75.16,
+   "decompress_mbps": 688.53
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 7,
    "out_size": 55495,
    "ratio": 0.1081,
-   "compress_mbps": 67.49,
-   "decompress_mbps": 703.66
+   "compress_mbps": 67.55,
+   "decompress_mbps": 703.71
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 8,
    "out_size": 53384,
    "ratio": 0.104,
-   "compress_mbps": 42.64,
-   "decompress_mbps": 728.68
+   "compress_mbps": 42.99,
+   "decompress_mbps": 728.59
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 9,
    "out_size": 52603,
    "ratio": 0.1025,
-   "compress_mbps": 5.87,
-   "decompress_mbps": 743.18
+   "compress_mbps": 5.9,
+   "decompress_mbps": 742.5
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52236,
    "ratio": 0.1018,
-   "compress_mbps": 3.81,
+   "compress_mbps": 3.8,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 67.34,
-   "decompress_mbps": 225.85
+   "compress_mbps": 67.42,
+   "decompress_mbps": 227.98
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13835,
    "ratio": 0.3618,
-   "compress_mbps": 62.49,
-   "decompress_mbps": 232.12
+   "compress_mbps": 62.54,
+   "decompress_mbps": 232.59
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 13760,
    "ratio": 0.3598,
-   "compress_mbps": 59.67,
-   "decompress_mbps": 229.02
+   "compress_mbps": 59.83,
+   "decompress_mbps": 229.57
   },
   {
    "compressor": "native",
@@ -944,18 +944,18 @@
    "level": 4,
    "out_size": 13290,
    "ratio": 0.3475,
-   "compress_mbps": 46.31,
-   "decompress_mbps": 238.35
+   "compress_mbps": 46.3,
+   "decompress_mbps": 239.94
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 5,
-   "out_size": 13244,
-   "ratio": 0.3463,
-   "compress_mbps": 39.82,
-   "decompress_mbps": 246.27
+   "out_size": 13004,
+   "ratio": 0.3401,
+   "compress_mbps": 23.27,
+   "decompress_mbps": 247.53
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 12675,
    "ratio": 0.3315,
-   "compress_mbps": 21.09,
-   "decompress_mbps": 248.58
+   "compress_mbps": 21.14,
+   "decompress_mbps": 250.99
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 12653,
    "ratio": 0.3309,
-   "compress_mbps": 20.45,
-   "decompress_mbps": 251.19
+   "compress_mbps": 20.4,
+   "decompress_mbps": 252.78
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 12632,
    "ratio": 0.3303,
-   "compress_mbps": 16.88,
-   "decompress_mbps": 257.35
+   "compress_mbps": 17.07,
+   "decompress_mbps": 254.18
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 5.49,
-   "decompress_mbps": 257.63
+   "compress_mbps": 5.44,
+   "decompress_mbps": 259.89
   },
   {
    "compressor": "native",
@@ -1004,7 +1004,7 @@
    "level": 10,
    "out_size": 12273,
    "ratio": 0.3209,
-   "compress_mbps": 3.15,
+   "compress_mbps": 3.09,
    "decompress_mbps": null
   },
   {
@@ -1014,8 +1014,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 27.93,
-   "decompress_mbps": 94.19
+   "compress_mbps": 28.28,
+   "decompress_mbps": 94.39
   },
   {
    "compressor": "native",
@@ -1024,8 +1024,8 @@
    "level": 2,
    "out_size": 1756,
    "ratio": 0.4154,
-   "compress_mbps": 27.74,
-   "decompress_mbps": 94.12
+   "compress_mbps": 27.81,
+   "decompress_mbps": 94.49
   },
   {
    "compressor": "native",
@@ -1034,8 +1034,8 @@
    "level": 3,
    "out_size": 1741,
    "ratio": 0.4119,
-   "compress_mbps": 27.5,
-   "decompress_mbps": 93.96
+   "compress_mbps": 27.4,
+   "decompress_mbps": 94.4
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1726,
    "ratio": 0.4083,
-   "compress_mbps": 23.92,
-   "decompress_mbps": 95.85
+   "compress_mbps": 23.76,
+   "decompress_mbps": 95.99
   },
   {
    "compressor": "native",
@@ -1054,8 +1054,8 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 23.76,
-   "decompress_mbps": 95.73
+   "compress_mbps": 22.58,
+   "decompress_mbps": 96.04
   },
   {
    "compressor": "native",
@@ -1064,8 +1064,8 @@
    "level": 6,
    "out_size": 1735,
    "ratio": 0.4105,
-   "compress_mbps": 20.93,
-   "decompress_mbps": 95.58
+   "compress_mbps": 20.69,
+   "decompress_mbps": 95.88
   },
   {
    "compressor": "native",
@@ -1074,8 +1074,8 @@
    "level": 7,
    "out_size": 1734,
    "ratio": 0.4102,
-   "compress_mbps": 20.97,
-   "decompress_mbps": 95.53
+   "compress_mbps": 20.72,
+   "decompress_mbps": 95.51
   },
   {
    "compressor": "native",
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1734,
    "ratio": 0.4102,
-   "compress_mbps": 21.02,
-   "decompress_mbps": 95.42
+   "compress_mbps": 20.62,
+   "decompress_mbps": 96.04
   },
   {
    "compressor": "native",
@@ -1094,8 +1094,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 5.51,
-   "decompress_mbps": 95.11
+   "compress_mbps": 5.44,
+   "decompress_mbps": 95.64
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.35,
+   "compress_mbps": 3.25,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 84.13,
-   "decompress_mbps": 193.47
+   "compress_mbps": 84.65,
+   "decompress_mbps": 197.65
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 4029026,
    "ratio": 0.3953,
-   "compress_mbps": 69.5,
-   "decompress_mbps": 212.6
+   "compress_mbps": 67.1,
+   "decompress_mbps": 216.43
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 3,
    "out_size": 3970599,
    "ratio": 0.3896,
-   "compress_mbps": 59.05,
-   "decompress_mbps": 235.78
+   "compress_mbps": 58.71,
+   "decompress_mbps": 238.84
   },
   {
    "compressor": "native",
@@ -4444,18 +4444,18 @@
    "level": 4,
    "out_size": 3851998,
    "ratio": 0.3779,
-   "compress_mbps": 35.87,
-   "decompress_mbps": 237.93
+   "compress_mbps": 34.9,
+   "decompress_mbps": 238.46
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 5,
-   "out_size": 3840481,
-   "ratio": 0.3768,
-   "compress_mbps": 29.45,
-   "decompress_mbps": 235.75
+   "out_size": 3884977,
+   "ratio": 0.3812,
+   "compress_mbps": 38.35,
+   "decompress_mbps": 248.17
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 6,
    "out_size": 3878125,
    "ratio": 0.3805,
-   "compress_mbps": 29.79,
-   "decompress_mbps": 240.91
+   "compress_mbps": 29.7,
+   "decompress_mbps": 240.51
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 7,
    "out_size": 3868436,
    "ratio": 0.3795,
-   "compress_mbps": 26.52,
-   "decompress_mbps": 241.0
+   "compress_mbps": 26.55,
+   "decompress_mbps": 243.77
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 8,
    "out_size": 3854820,
    "ratio": 0.3782,
-   "compress_mbps": 21.49,
-   "decompress_mbps": 242.69
+   "compress_mbps": 21.4,
+   "decompress_mbps": 242.67
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766619,
    "ratio": 0.3696,
-   "compress_mbps": 4.15,
-   "decompress_mbps": 252.66
+   "compress_mbps": 4.22,
+   "decompress_mbps": 253.58
   },
   {
    "compressor": "native",
@@ -4504,7 +4504,7 @@
    "level": 10,
    "out_size": 3711208,
    "ratio": 0.3641,
-   "compress_mbps": 2.48,
+   "compress_mbps": 2.44,
    "decompress_mbps": null
   },
   {
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 102.28,
-   "decompress_mbps": 215.52
+   "compress_mbps": 102.4,
+   "decompress_mbps": 211.92
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20833417,
    "ratio": 0.4067,
-   "compress_mbps": 91.39,
-   "decompress_mbps": 228.59
+   "compress_mbps": 90.73,
+   "decompress_mbps": 226.56
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 20636431,
    "ratio": 0.4029,
-   "compress_mbps": 82.15,
-   "decompress_mbps": 235.42
+   "compress_mbps": 80.85,
+   "decompress_mbps": 235.34
   },
   {
    "compressor": "native",
@@ -4544,18 +4544,18 @@
    "level": 4,
    "out_size": 20356893,
    "ratio": 0.3974,
-   "compress_mbps": 56.48,
-   "decompress_mbps": 245.09
+   "compress_mbps": 56.08,
+   "decompress_mbps": 244.48
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 5,
-   "out_size": 20209289,
-   "ratio": 0.3946,
-   "compress_mbps": 42.45,
-   "decompress_mbps": 255.61
+   "out_size": 19251947,
+   "ratio": 0.3759,
+   "compress_mbps": 33.87,
+   "decompress_mbps": 253.25
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 18875267,
    "ratio": 0.3685,
-   "compress_mbps": 30.22,
-   "decompress_mbps": 253.24
+   "compress_mbps": 30.35,
+   "decompress_mbps": 252.06
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 18835212,
    "ratio": 0.3677,
-   "compress_mbps": 28.19,
-   "decompress_mbps": 259.41
+   "compress_mbps": 28.25,
+   "decompress_mbps": 260.68
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 18777212,
    "ratio": 0.3666,
-   "compress_mbps": 19.64,
-   "decompress_mbps": 259.34
+   "compress_mbps": 19.46,
+   "decompress_mbps": 259.0
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 18688252,
    "ratio": 0.3649,
-   "compress_mbps": 4.45,
-   "decompress_mbps": 261.63
+   "compress_mbps": 4.43,
+   "decompress_mbps": 260.52
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18541040,
    "ratio": 0.362,
-   "compress_mbps": 2.36,
+   "compress_mbps": 2.34,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 105.63,
-   "decompress_mbps": 243.05
+   "compress_mbps": 104.49,
+   "decompress_mbps": 232.2
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3772158,
    "ratio": 0.3783,
-   "compress_mbps": 89.67,
-   "decompress_mbps": 244.74
+   "compress_mbps": 91.07,
+   "decompress_mbps": 242.7
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 3,
    "out_size": 3733442,
    "ratio": 0.3744,
-   "compress_mbps": 78.6,
-   "decompress_mbps": 255.81
+   "compress_mbps": 78.38,
+   "decompress_mbps": 258.81
   },
   {
    "compressor": "native",
@@ -4644,18 +4644,18 @@
    "level": 4,
    "out_size": 3683603,
    "ratio": 0.3694,
-   "compress_mbps": 42.47,
-   "decompress_mbps": 245.24
+   "compress_mbps": 42.38,
+   "decompress_mbps": 244.03
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 5,
-   "out_size": 3677014,
-   "ratio": 0.3688,
-   "compress_mbps": 33.85,
-   "decompress_mbps": 239.75
+   "out_size": 3612139,
+   "ratio": 0.3623,
+   "compress_mbps": 40.09,
+   "decompress_mbps": 241.69
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 6,
    "out_size": 3646607,
    "ratio": 0.3657,
-   "compress_mbps": 32.36,
-   "decompress_mbps": 248.57
+   "compress_mbps": 32.56,
+   "decompress_mbps": 259.55
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 7,
    "out_size": 3642579,
    "ratio": 0.3653,
-   "compress_mbps": 29.64,
-   "decompress_mbps": 248.96
+   "compress_mbps": 29.69,
+   "decompress_mbps": 249.73
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 8,
    "out_size": 3634763,
    "ratio": 0.3645,
-   "compress_mbps": 22.66,
-   "decompress_mbps": 255.57
+   "compress_mbps": 22.67,
+   "decompress_mbps": 253.74
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 9,
    "out_size": 3581643,
    "ratio": 0.3592,
-   "compress_mbps": 4.83,
-   "decompress_mbps": 270.66
+   "compress_mbps": 4.9,
+   "decompress_mbps": 271.3
   },
   {
    "compressor": "native",
@@ -4704,7 +4704,7 @@
    "level": 10,
    "out_size": 3513006,
    "ratio": 0.3523,
-   "compress_mbps": 2.97,
+   "compress_mbps": 2.92,
    "decompress_mbps": null
   },
   {
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 319.41,
-   "decompress_mbps": 675.28
+   "compress_mbps": 319.75,
+   "decompress_mbps": 673.36
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3601032,
    "ratio": 0.1073,
-   "compress_mbps": 268.28,
-   "decompress_mbps": 753.55
+   "compress_mbps": 269.35,
+   "decompress_mbps": 721.02
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 3,
    "out_size": 3447001,
    "ratio": 0.1027,
-   "compress_mbps": 206.83,
-   "decompress_mbps": 829.51
+   "compress_mbps": 207.01,
+   "decompress_mbps": 793.9
   },
   {
    "compressor": "native",
@@ -4744,18 +4744,18 @@
    "level": 4,
    "out_size": 3201209,
    "ratio": 0.0954,
-   "compress_mbps": 141.21,
-   "decompress_mbps": 851.21
+   "compress_mbps": 141.43,
+   "decompress_mbps": 849.35
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 5,
-   "out_size": 3091564,
-   "ratio": 0.0921,
-   "compress_mbps": 97.16,
-   "decompress_mbps": 929.69
+   "out_size": 3202816,
+   "ratio": 0.0955,
+   "compress_mbps": 115.23,
+   "decompress_mbps": 928.22
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 6,
    "out_size": 3205217,
    "ratio": 0.0955,
-   "compress_mbps": 92.08,
-   "decompress_mbps": 937.6
+   "compress_mbps": 91.98,
+   "decompress_mbps": 989.56
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 7,
    "out_size": 3146242,
    "ratio": 0.0938,
-   "compress_mbps": 82.16,
-   "decompress_mbps": 982.4
+   "compress_mbps": 81.63,
+   "decompress_mbps": 990.34
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 8,
    "out_size": 3078031,
    "ratio": 0.0917,
-   "compress_mbps": 51.2,
-   "decompress_mbps": 1004.39
+   "compress_mbps": 51.42,
+   "decompress_mbps": 999.32
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 9,
    "out_size": 3031645,
    "ratio": 0.0904,
-   "compress_mbps": 3.56,
-   "decompress_mbps": 1007.49
+   "compress_mbps": 3.55,
+   "decompress_mbps": 1003.27
   },
   {
    "compressor": "native",
@@ -4804,7 +4804,7 @@
    "level": 10,
    "out_size": 2902212,
    "ratio": 0.0865,
-   "compress_mbps": 2.03,
+   "compress_mbps": 2.0,
    "decompress_mbps": null
   },
   {
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 72.16,
-   "decompress_mbps": 149.15
+   "compress_mbps": 71.14,
+   "decompress_mbps": 148.07
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 2,
    "out_size": 3292412,
    "ratio": 0.5352,
-   "compress_mbps": 63.05,
-   "decompress_mbps": 142.35
+   "compress_mbps": 62.56,
+   "decompress_mbps": 148.78
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 3,
    "out_size": 3273720,
    "ratio": 0.5321,
-   "compress_mbps": 59.02,
-   "decompress_mbps": 157.5
+   "compress_mbps": 58.33,
+   "decompress_mbps": 158.3
   },
   {
    "compressor": "native",
@@ -4844,18 +4844,18 @@
    "level": 4,
    "out_size": 3228052,
    "ratio": 0.5247,
-   "compress_mbps": 42.04,
-   "decompress_mbps": 165.21
+   "compress_mbps": 41.63,
+   "decompress_mbps": 164.79
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 5,
-   "out_size": 3223415,
-   "ratio": 0.5239,
-   "compress_mbps": 37.85,
-   "decompress_mbps": 172.25
+   "out_size": 3168684,
+   "ratio": 0.515,
+   "compress_mbps": 29.81,
+   "decompress_mbps": 170.58
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 6,
    "out_size": 3087517,
    "ratio": 0.5019,
-   "compress_mbps": 26.67,
-   "decompress_mbps": 175.04
+   "compress_mbps": 26.52,
+   "decompress_mbps": 174.59
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 7,
    "out_size": 3082738,
    "ratio": 0.5011,
-   "compress_mbps": 25.26,
-   "decompress_mbps": 179.48
+   "compress_mbps": 25.19,
+   "decompress_mbps": 175.28
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 8,
    "out_size": 3078530,
    "ratio": 0.5004,
-   "compress_mbps": 22.46,
-   "decompress_mbps": 175.02
+   "compress_mbps": 22.58,
+   "decompress_mbps": 175.16
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 9,
    "out_size": 3049028,
    "ratio": 0.4956,
-   "compress_mbps": 5.15,
-   "decompress_mbps": 184.02
+   "compress_mbps": 5.16,
+   "decompress_mbps": 182.69
   },
   {
    "compressor": "native",
@@ -4904,7 +4904,7 @@
    "level": 10,
    "out_size": 3022127,
    "ratio": 0.4912,
-   "compress_mbps": 3.22,
+   "compress_mbps": 3.16,
    "decompress_mbps": null
   },
   {
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 116.42,
-   "decompress_mbps": 259.94
+   "compress_mbps": 114.95,
+   "decompress_mbps": 260.02
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3790968,
    "ratio": 0.3759,
-   "compress_mbps": 100.26,
-   "decompress_mbps": 274.32
+   "compress_mbps": 100.88,
+   "decompress_mbps": 258.51
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 3,
    "out_size": 3760350,
    "ratio": 0.3728,
-   "compress_mbps": 86.75,
-   "decompress_mbps": 278.36
+   "compress_mbps": 87.22,
+   "decompress_mbps": 275.58
   },
   {
    "compressor": "native",
@@ -4944,18 +4944,18 @@
    "level": 4,
    "out_size": 3648458,
    "ratio": 0.3617,
-   "compress_mbps": 71.46,
-   "decompress_mbps": 293.18
+   "compress_mbps": 71.1,
+   "decompress_mbps": 277.83
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 5,
-   "out_size": 3648472,
-   "ratio": 0.3617,
-   "compress_mbps": 65.38,
-   "decompress_mbps": 276.86
+   "out_size": 3651652,
+   "ratio": 0.3621,
+   "compress_mbps": 55.18,
+   "decompress_mbps": 276.55
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 6,
    "out_size": 3661305,
    "ratio": 0.363,
-   "compress_mbps": 44.54,
-   "decompress_mbps": 287.49
+   "compress_mbps": 44.36,
+   "decompress_mbps": 289.56
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 7,
    "out_size": 3659614,
    "ratio": 0.3629,
-   "compress_mbps": 43.47,
-   "decompress_mbps": 291.63
+   "compress_mbps": 42.96,
+   "decompress_mbps": 290.96
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 8,
    "out_size": 3659136,
    "ratio": 0.3628,
-   "compress_mbps": 43.15,
-   "decompress_mbps": 288.86
+   "compress_mbps": 42.71,
+   "decompress_mbps": 307.04
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 9,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 6.09,
-   "decompress_mbps": 305.52
+   "compress_mbps": 6.14,
+   "decompress_mbps": 305.93
   },
   {
    "compressor": "native",
@@ -5004,7 +5004,7 @@
    "level": 10,
    "out_size": 3647385,
    "ratio": 0.3616,
-   "compress_mbps": 3.51,
+   "compress_mbps": 3.41,
    "decompress_mbps": null
   },
   {
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 108.54,
-   "decompress_mbps": 245.42
+   "compress_mbps": 105.81,
+   "decompress_mbps": 243.75
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2090589,
    "ratio": 0.3155,
-   "compress_mbps": 89.23,
-   "decompress_mbps": 265.51
+   "compress_mbps": 89.32,
+   "decompress_mbps": 247.01
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 3,
    "out_size": 2018042,
    "ratio": 0.3045,
-   "compress_mbps": 70.89,
-   "decompress_mbps": 303.3
+   "compress_mbps": 70.75,
+   "decompress_mbps": 299.49
   },
   {
    "compressor": "native",
@@ -5044,18 +5044,18 @@
    "level": 4,
    "out_size": 1890729,
    "ratio": 0.2853,
-   "compress_mbps": 35.98,
-   "decompress_mbps": 295.62
+   "compress_mbps": 35.8,
+   "decompress_mbps": 292.05
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 5,
-   "out_size": 1858234,
-   "ratio": 0.2804,
-   "compress_mbps": 22.84,
-   "decompress_mbps": 308.96
+   "out_size": 1909615,
+   "ratio": 0.2881,
+   "compress_mbps": 44.16,
+   "decompress_mbps": 306.69
   },
   {
    "compressor": "native",
@@ -5064,8 +5064,8 @@
    "level": 6,
    "out_size": 1869426,
    "ratio": 0.2821,
-   "compress_mbps": 30.34,
-   "decompress_mbps": 298.9
+   "compress_mbps": 29.98,
+   "decompress_mbps": 300.4
   },
   {
    "compressor": "native",
@@ -5074,8 +5074,8 @@
    "level": 7,
    "out_size": 1860657,
    "ratio": 0.2808,
-   "compress_mbps": 25.57,
-   "decompress_mbps": 306.71
+   "compress_mbps": 25.56,
+   "decompress_mbps": 305.12
   },
   {
    "compressor": "native",
@@ -5084,8 +5084,8 @@
    "level": 8,
    "out_size": 1826296,
    "ratio": 0.2756,
-   "compress_mbps": 14.07,
-   "decompress_mbps": 300.95
+   "compress_mbps": 14.08,
+   "decompress_mbps": 306.82
   },
   {
    "compressor": "native",
@@ -5095,7 +5095,7 @@
    "out_size": 1773469,
    "ratio": 0.2676,
    "compress_mbps": 2.97,
-   "decompress_mbps": 327.2
+   "decompress_mbps": 324.51
   },
   {
    "compressor": "native",
@@ -5104,7 +5104,7 @@
    "level": 10,
    "out_size": 1718509,
    "ratio": 0.2593,
-   "compress_mbps": 1.6,
+   "compress_mbps": 1.58,
    "decompress_mbps": null
   },
   {
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 142.7,
-   "decompress_mbps": 338.95
+   "compress_mbps": 141.21,
+   "decompress_mbps": 336.53
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6136026,
    "ratio": 0.284,
-   "compress_mbps": 124.84,
-   "decompress_mbps": 358.32
+   "compress_mbps": 124.09,
+   "decompress_mbps": 356.54
   },
   {
    "compressor": "native",
@@ -5134,8 +5134,8 @@
    "level": 3,
    "out_size": 6008304,
    "ratio": 0.2781,
-   "compress_mbps": 105.81,
-   "decompress_mbps": 376.05
+   "compress_mbps": 105.45,
+   "decompress_mbps": 371.52
   },
   {
    "compressor": "native",
@@ -5144,18 +5144,18 @@
    "level": 4,
    "out_size": 5880892,
    "ratio": 0.2722,
-   "compress_mbps": 70.94,
-   "decompress_mbps": 392.52
+   "compress_mbps": 70.62,
+   "decompress_mbps": 388.47
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 5,
-   "out_size": 5834363,
-   "ratio": 0.27,
-   "compress_mbps": 54.85,
-   "decompress_mbps": 398.49
+   "out_size": 5443935,
+   "ratio": 0.252,
+   "compress_mbps": 53.23,
+   "decompress_mbps": 395.34
   },
   {
    "compressor": "native",
@@ -5164,8 +5164,8 @@
    "level": 6,
    "out_size": 5418390,
    "ratio": 0.2508,
-   "compress_mbps": 44.23,
-   "decompress_mbps": 405.08
+   "compress_mbps": 43.79,
+   "decompress_mbps": 399.32
   },
   {
    "compressor": "native",
@@ -5174,8 +5174,8 @@
    "level": 7,
    "out_size": 5406915,
    "ratio": 0.2502,
-   "compress_mbps": 40.41,
-   "decompress_mbps": 402.53
+   "compress_mbps": 40.4,
+   "decompress_mbps": 405.29
   },
   {
    "compressor": "native",
@@ -5184,8 +5184,8 @@
    "level": 8,
    "out_size": 5387415,
    "ratio": 0.2493,
-   "compress_mbps": 32.28,
-   "decompress_mbps": 410.06
+   "compress_mbps": 32.09,
+   "decompress_mbps": 408.74
   },
   {
    "compressor": "native",
@@ -5194,8 +5194,8 @@
    "level": 9,
    "out_size": 5236015,
    "ratio": 0.2423,
-   "compress_mbps": 4.84,
-   "decompress_mbps": 410.03
+   "compress_mbps": 4.88,
+   "decompress_mbps": 409.89
   },
   {
    "compressor": "native",
@@ -5204,7 +5204,7 @@
    "level": 10,
    "out_size": 5177683,
    "ratio": 0.2396,
-   "compress_mbps": 2.63,
+   "compress_mbps": 2.62,
    "decompress_mbps": null
   },
   {
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 58.79,
-   "decompress_mbps": 149.3
+   "compress_mbps": 58.41,
+   "decompress_mbps": 149.37
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5553137,
    "ratio": 0.7657,
-   "compress_mbps": 52.31,
-   "decompress_mbps": 155.47
+   "compress_mbps": 52.04,
+   "decompress_mbps": 155.88
   },
   {
    "compressor": "native",
@@ -5234,8 +5234,8 @@
    "level": 3,
    "out_size": 5533873,
    "ratio": 0.7631,
-   "compress_mbps": 47.36,
-   "decompress_mbps": 160.3
+   "compress_mbps": 47.96,
+   "decompress_mbps": 160.12
   },
   {
    "compressor": "native",
@@ -5244,18 +5244,18 @@
    "level": 4,
    "out_size": 5494383,
    "ratio": 0.7576,
-   "compress_mbps": 35.0,
-   "decompress_mbps": 165.86
+   "compress_mbps": 34.86,
+   "decompress_mbps": 166.23
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 5,
-   "out_size": 5489807,
-   "ratio": 0.757,
-   "compress_mbps": 33.06,
-   "decompress_mbps": 162.39
+   "out_size": 5488710,
+   "ratio": 0.7569,
+   "compress_mbps": 27.2,
+   "decompress_mbps": 162.88
   },
   {
    "compressor": "native",
@@ -5264,8 +5264,8 @@
    "level": 6,
    "out_size": 5346796,
    "ratio": 0.7373,
-   "compress_mbps": 22.82,
-   "decompress_mbps": 165.18
+   "compress_mbps": 22.86,
+   "decompress_mbps": 163.87
   },
   {
    "compressor": "native",
@@ -5274,8 +5274,8 @@
    "level": 7,
    "out_size": 5336745,
    "ratio": 0.7359,
-   "compress_mbps": 21.84,
-   "decompress_mbps": 166.08
+   "compress_mbps": 22.09,
+   "decompress_mbps": 161.72
   },
   {
    "compressor": "native",
@@ -5284,8 +5284,8 @@
    "level": 8,
    "out_size": 5330972,
    "ratio": 0.7351,
-   "compress_mbps": 20.58,
-   "decompress_mbps": 165.16
+   "compress_mbps": 20.83,
+   "decompress_mbps": 162.25
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284606,
    "ratio": 0.7287,
-   "compress_mbps": 5.27,
-   "decompress_mbps": 163.67
+   "compress_mbps": 5.31,
+   "decompress_mbps": 164.64
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262387,
    "ratio": 0.7257,
-   "compress_mbps": 3.78,
+   "compress_mbps": 3.7,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 108.3,
-   "decompress_mbps": 251.34
+   "compress_mbps": 107.5,
+   "decompress_mbps": 249.76
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12920739,
    "ratio": 0.3117,
-   "compress_mbps": 92.14,
-   "decompress_mbps": 272.0
+   "compress_mbps": 91.87,
+   "decompress_mbps": 272.58
   },
   {
    "compressor": "native",
@@ -5334,8 +5334,8 @@
    "level": 3,
    "out_size": 12582079,
    "ratio": 0.3035,
-   "compress_mbps": 78.82,
-   "decompress_mbps": 291.35
+   "compress_mbps": 79.41,
+   "decompress_mbps": 293.7
   },
   {
    "compressor": "native",
@@ -5344,18 +5344,18 @@
    "level": 4,
    "out_size": 12177338,
    "ratio": 0.2937,
-   "compress_mbps": 50.54,
-   "decompress_mbps": 296.04
+   "compress_mbps": 50.83,
+   "decompress_mbps": 296.87
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 5,
-   "out_size": 12051075,
-   "ratio": 0.2907,
-   "compress_mbps": 38.89,
-   "decompress_mbps": 301.07
+   "out_size": 12263198,
+   "ratio": 0.2958,
+   "compress_mbps": 51.05,
+   "decompress_mbps": 300.5
   },
   {
    "compressor": "native",
@@ -5364,8 +5364,8 @@
    "level": 6,
    "out_size": 12220199,
    "ratio": 0.2948,
-   "compress_mbps": 39.03,
-   "decompress_mbps": 309.25
+   "compress_mbps": 38.89,
+   "decompress_mbps": 308.55
   },
   {
    "compressor": "native",
@@ -5374,8 +5374,8 @@
    "level": 7,
    "out_size": 12178598,
    "ratio": 0.2938,
-   "compress_mbps": 35.7,
-   "decompress_mbps": 310.63
+   "compress_mbps": 35.56,
+   "decompress_mbps": 310.85
   },
   {
    "compressor": "native",
@@ -5384,8 +5384,8 @@
    "level": 8,
    "out_size": 12096772,
    "ratio": 0.2918,
-   "compress_mbps": 26.56,
-   "decompress_mbps": 312.25
+   "compress_mbps": 26.43,
+   "decompress_mbps": 295.54
   },
   {
    "compressor": "native",
@@ -5395,7 +5395,7 @@
    "out_size": 11806641,
    "ratio": 0.2848,
    "compress_mbps": 3.91,
-   "decompress_mbps": 312.53
+   "decompress_mbps": 313.06
   },
   {
    "compressor": "native",
@@ -5404,7 +5404,7 @@
    "level": 10,
    "out_size": 11636945,
    "ratio": 0.2807,
-   "compress_mbps": 2.03,
+   "compress_mbps": 2.02,
    "decompress_mbps": null
   },
   {
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 52.66,
-   "decompress_mbps": 144.5
+   "compress_mbps": 52.38,
+   "decompress_mbps": 144.79
   },
   {
    "compressor": "native",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 6392132,
    "ratio": 0.7543,
-   "compress_mbps": 51.1,
-   "decompress_mbps": 145.61
+   "compress_mbps": 50.78,
+   "decompress_mbps": 145.37
   },
   {
    "compressor": "native",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 50.89,
-   "decompress_mbps": 137.27
+   "compress_mbps": 50.69,
+   "decompress_mbps": 147.1
   },
   {
    "compressor": "native",
@@ -5444,18 +5444,18 @@
    "level": 4,
    "out_size": 6360604,
    "ratio": 0.7506,
-   "compress_mbps": 43.09,
-   "decompress_mbps": 133.4
+   "compress_mbps": 42.67,
+   "decompress_mbps": 133.28
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 5,
-   "out_size": 6360567,
-   "ratio": 0.7506,
-   "compress_mbps": 43.15,
-   "decompress_mbps": 135.55
+   "out_size": 6271694,
+   "ratio": 0.7401,
+   "compress_mbps": 20.7,
+   "decompress_mbps": 136.46
   },
   {
    "compressor": "native",
@@ -5464,8 +5464,8 @@
    "level": 6,
    "out_size": 6036758,
    "ratio": 0.7124,
-   "compress_mbps": 24.75,
-   "decompress_mbps": 136.88
+   "compress_mbps": 24.48,
+   "decompress_mbps": 137.55
   },
   {
    "compressor": "native",
@@ -5474,8 +5474,8 @@
    "level": 7,
    "out_size": 6036620,
    "ratio": 0.7123,
-   "compress_mbps": 24.69,
-   "decompress_mbps": 137.13
+   "compress_mbps": 24.7,
+   "decompress_mbps": 136.98
   },
   {
    "compressor": "native",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 6036614,
    "ratio": 0.7123,
-   "compress_mbps": 24.68,
-   "decompress_mbps": 137.18
+   "compress_mbps": 24.56,
+   "decompress_mbps": 137.27
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952975,
    "ratio": 0.7025,
-   "compress_mbps": 6.31,
-   "decompress_mbps": 140.19
+   "compress_mbps": 6.28,
+   "decompress_mbps": 140.17
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5849157,
    "ratio": 0.6902,
-   "compress_mbps": 4.56,
+   "compress_mbps": 4.49,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 234.04,
-   "decompress_mbps": 508.03
+   "compress_mbps": 233.31,
+   "decompress_mbps": 501.45
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 798553,
    "ratio": 0.1494,
-   "compress_mbps": 200.46,
-   "decompress_mbps": 570.84
+   "compress_mbps": 200.6,
+   "decompress_mbps": 569.4
   },
   {
    "compressor": "native",
@@ -5534,8 +5534,8 @@
    "level": 3,
    "out_size": 762011,
    "ratio": 0.1426,
-   "compress_mbps": 160.08,
-   "decompress_mbps": 567.36
+   "compress_mbps": 159.87,
+   "decompress_mbps": 631.05
   },
   {
    "compressor": "native",
@@ -5544,18 +5544,18 @@
    "level": 4,
    "out_size": 717301,
    "ratio": 0.1342,
-   "compress_mbps": 104.69,
-   "decompress_mbps": 567.55
+   "compress_mbps": 103.57,
+   "decompress_mbps": 610.62
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 5,
-   "out_size": 701552,
-   "ratio": 0.1312,
-   "compress_mbps": 78.65,
-   "decompress_mbps": 617.36
+   "out_size": 701605,
+   "ratio": 0.1313,
+   "compress_mbps": 91.4,
+   "decompress_mbps": 666.47
   },
   {
    "compressor": "native",
@@ -5564,8 +5564,8 @@
    "level": 6,
    "out_size": 689796,
    "ratio": 0.129,
-   "compress_mbps": 71.05,
-   "decompress_mbps": 644.67
+   "compress_mbps": 70.31,
+   "decompress_mbps": 707.13
   },
   {
    "compressor": "native",
@@ -5574,8 +5574,8 @@
    "level": 7,
    "out_size": 680793,
    "ratio": 0.1274,
-   "compress_mbps": 63.97,
-   "decompress_mbps": 739.05
+   "compress_mbps": 63.61,
+   "decompress_mbps": 731.5
   },
   {
    "compressor": "native",
@@ -5584,8 +5584,8 @@
    "level": 8,
    "out_size": 662896,
    "ratio": 0.124,
-   "compress_mbps": 44.75,
-   "decompress_mbps": 743.54
+   "compress_mbps": 44.26,
+   "decompress_mbps": 726.25
   },
   {
    "compressor": "native",
@@ -5594,8 +5594,8 @@
    "level": 9,
    "out_size": 659422,
    "ratio": 0.1234,
-   "compress_mbps": 4.55,
-   "decompress_mbps": 649.87
+   "compress_mbps": 4.57,
+   "decompress_mbps": 663.28
   },
   {
    "compressor": "native",
@@ -5604,7 +5604,7 @@
    "level": 10,
    "out_size": 643101,
    "ratio": 0.1203,
-   "compress_mbps": 3.07,
+   "compress_mbps": 3.0,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR re-position L5, which had become a dead vertex: the recent landings moved L4 and L6 but left L5 (single-block, chain 128) sitting 15.6% inside the L4↔L6 mixing line on weighted Silesia. The gate-sweep grid (extended with a single-block mode; certification row byte-identical to production L5 on all 12 files) shows the whole single-block family is dead in this band and the frontier peaks one step past the original grid edge at a light split config: L5 becomes (chain 24, goodMatch 64, niceLen 65, lazyDepth /4, split tier on, singleton off), moving the split-tier boundary in `deflateRaw` from `6 ≤ level` to `5 ≤ level` (`useH3Level` stays 6-8; the roundtrip proofs case-split symbolically on the dispatch, so the boundary move is proof-transparent). Weighted Silesia: 0.3302 @ 46.4 → **0.3249 @ 46.2** — −0.53pp ratio at equal corpus speed, **+4.05% above the L4↔L6 blend** at its own ratio (threshold ≥3%; confirmed under both dashboard-scaled and in-harness anchors). Per-file, speed redistributes: few-cut files get much faster (dickens L5 +29%), match-rich heterogeneous ones trade ~20% speed for 5-7% smaller output (mozilla −4.74% size); worst ratio regressions nci +3.6%, reymont +2.8% against samba −6.7%, mozilla −4.7% wins. Levels 1-4 and 6-10 are sha256-identical to master on all 12 files (108/108); `lake exe test` green.

🤖 Prepared with Claude Code