### PR TITLE
feat: rolling lazy2 deferral, rung 1 — generalized boxed base + contracts (#2837)

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -1388,6 +1388,175 @@ theorem lazyAcceptCost_lt {len1 dist1 len2 dist2 : Nat}
   simp only [lazyAcceptCost, Bool.and_eq_true, decide_eq_true_eq] at h
   exact h.1
 
+/-- Chain depth for a rolling-lazy2 follow-up probe (`rollDefer`). Mirrors the
+    certified spike's mode-0 ladder (`bench/ZipLazyRollSweep.lean`, #2837): a
+    constant `maxChain / 4` after the main loop's own full-depth `pos+1` probe,
+    floored at 1 so a probe never runs at zero fuel. A pure heuristic — depth
+    never enters a validity proof (`chainWalk_spec` holds for any fuel). -/
+@[inline] def lazy2ProbeDepth (maxChain : Nat) : Nat :=
+  max 1 (maxChain / 4)
+
+/-! Rolling multi-step deferral for `lz77ChainLazy` (rung 1 of #2837). `mainLoop`
+    is the boxed lazy matcher extended with a `lazy2Steps` knob: when the accept
+    rule fires and steps remain (`1 < lazy2Steps`), it emits the pending
+    match-start byte as a literal and enters `rollDefer`, which keeps deferring
+    while each next position strictly improves the pending match (libdeflate's
+    `deflate_compress_lazy2` loop). `lazy2Steps = 1` never enters `rollDefer` — it
+    is the original single-deferral behavior verbatim, so every downstream `_eq`
+    holds at the default. Match-finding stays opaque to correctness
+    (`chainWalk_spec` for any chain state), and every emitted reference is
+    re-verified at emission, so the roll's chain state never enters a proof. -/
+mutual
+
+def lz77ChainLazy.mainLoop (data : ByteArray) (windowSize hashSize maxChain : Nat) (useH3 : Bool)
+    (hashTable : Array Nat) (prev h3tab : Array Nat) (pos insertCap goodMatch niceLen lazyDepth lazy2Steps : Nat) : List LZ77Token :=
+  if hlt : pos + 2 < data.size then
+    let h := lz77Greedy.hash3 data pos hashSize hlt
+    let head := headProbeGuarded hashTable h
+    let hashTable := guardedSet hashTable h pos
+    let prev := guardedSet prev (pos &&& 0x7FFF) head
+    let seed := h3Seed useH3 data h3tab windowSize pos hlt
+    let h3tab := if useH3 then guardedSet h3tab (hash3Single data pos hlt) pos else h3tab
+    let maxLen := min 258 (data.size - pos)
+    have hmaxLenP : pos + maxLen ≤ data.size := by omega
+    let m := lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hmaxLenP head maxChain (seed % 512) (seed / 512)
+    let matchLen := m.1
+    let matchPos := m.2
+    if hge : matchLen ≥ 3 then
+      if hle : pos + matchLen ≤ data.size then
+        if h3lt : pos + 3 < data.size then
+          if matchLen < goodMatch then
+            let h2 := lz77Greedy.hash3 data (pos + 1) hashSize (by omega)
+            let head2 := headProbeGuarded hashTable h2
+            let maxLen2 := min 258 (data.size - (pos + 1))
+            have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
+            let m2 :=
+              lz77Chain.chainWalk data prev windowSize (pos + 1) maxLen2 niceLen hmaxLen2P head2 lazyDepth 0 0
+            let matchLen2 := m2.1
+            let matchPos2 := m2.2
+            if lazyAcceptCost matchLen (pos - matchPos) matchLen2 (pos + 1 - matchPos2) then
+              if hle2 : pos + 1 + matchLen2 ≤ data.size then
+                if h1 : 1 < lazy2Steps then
+                  -- Rolling deferral (rung 1 of #2837): emit the pending
+                  -- match-start byte as a literal, roll the pending match `M'`
+                  -- forward into `rollDefer` at `pos+1`, step 1.
+                  if hpl2 : 3 ≤ matchLen2 then
+                    .literal (data[pos]'(by omega)) ::
+                      lz77ChainLazy.rollDefer data windowSize hashSize maxChain useH3
+                        hashTable prev h3tab (pos + 1) matchLen2 matchPos2 1
+                        insertCap goodMatch niceLen lazyDepth lazy2Steps hle2 hpl2
+                  else
+                    -- Unreachable (accept ⇒ matchLen2 > matchLen ≥ 3); the
+                    -- single-deferral result keeps the function total.
+                    let (hashTable, prev) :=
+                      lz77Chain.updateHashes data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
+                    let h3tab := if useH3 then updateHash3 data h3tab pos 1 (matchLen2 + 1) insertCap else h3tab
+                    .literal (data[pos]'(by omega)) ::
+                      .reference matchLen2 (pos + 1 - matchPos2) ::
+                        lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + 1 + matchLen2) insertCap goodMatch niceLen lazyDepth lazy2Steps
+                else
+                  -- Single deferral (`lazy2Steps ≤ 1`): the original lazy behavior.
+                  have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
+                  let (hashTable, prev) :=
+                    lz77Chain.updateHashes data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
+                  let h3tab := if useH3 then updateHash3 data h3tab pos 1 (matchLen2 + 1) insertCap else h3tab
+                  .literal (data[pos]'(by omega)) ::
+                    .reference matchLen2 (pos + 1 - matchPos2) ::
+                      lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + 1 + matchLen2) insertCap goodMatch niceLen lazyDepth lazy2Steps
+              else
+                have : data.size - (pos + matchLen) < data.size - pos := by omega
+                let (hashTable, prev) :=
+                  lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
+                let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
+                .reference matchLen (pos - matchPos) ::
+                  lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + matchLen) insertCap goodMatch niceLen lazyDepth lazy2Steps
+            else
+              have : data.size - (pos + matchLen) < data.size - pos := by omega
+              let (hashTable, prev) :=
+                lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
+              let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
+              .reference matchLen (pos - matchPos) ::
+                lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + matchLen) insertCap goodMatch niceLen lazyDepth lazy2Steps
+          else
+            -- Gated: long first match, skip the lookahead; still insert interior hashes.
+            have : data.size - (pos + matchLen) < data.size - pos := by omega
+            let (hashTable, prev) :=
+              lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
+            let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
+            .reference matchLen (pos - matchPos) ::
+              lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + matchLen) insertCap goodMatch niceLen lazyDepth lazy2Steps
+        else
+          -- Near end of data: keep match at pos
+          have : data.size - (pos + matchLen) < data.size - pos := by omega
+          .reference matchLen (pos - matchPos) ::
+            lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + matchLen) insertCap goodMatch niceLen lazyDepth lazy2Steps
+      else
+        .literal (data[pos]'(by omega)) ::
+          lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + 1) insertCap goodMatch niceLen lazyDepth lazy2Steps
+    else
+      .literal (data[pos]'(by omega)) ::
+        lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + 1) insertCap goodMatch niceLen lazyDepth lazy2Steps
+  else
+    lz77Greedy.trailing data pos
+termination_by data.size - pos
+decreasing_by all_goals omega
+
+/-- Rolling sub-recursion: a pending match `(pLen, pMatchPos)` starts at `mp`;
+    positions `< mp` are already decided. If a defer remains (`step < lazy2Steps`,
+    room, and the pending match is short) and re-probing `mp+1` at
+    `lazy2ProbeDepth` strictly improves it (`lazyAcceptCost`), emit `lit(mp)` and
+    roll to the new match at `mp+1`, step `+1`. Otherwise commit the pending match
+    at `mp`. The no-more-defers commit uses the production batch
+    `updateHashes (mp-1) 1 (pLen+1)`, so `mainLoop`'s `lazy2Steps = 1` entry (which
+    never reaches here) matches production exactly. `hmp`/`hpl` carry the pending
+    match's length bounds for termination; the emitted reference's validity is
+    re-established at emission (see `LZ77ChainLazyCorrect`). -/
+def lz77ChainLazy.rollDefer (data : ByteArray) (windowSize hashSize maxChain : Nat) (useH3 : Bool)
+    (hashTable : Array Nat) (prev h3tab : Array Nat)
+    (mp pLen pMatchPos step insertCap goodMatch niceLen lazyDepth lazy2Steps : Nat)
+    (hmp : mp + pLen ≤ data.size) (hpl : 3 ≤ pLen) : List LZ77Token :=
+  if hcan : step < lazy2Steps ∧ mp + 3 < data.size ∧ pLen < goodMatch then
+    -- Insert `mp` (loop-top style) so `mp+1` can match against it.
+    let hmh := lz77Greedy.hash3 data mp hashSize (by omega)
+    let headmp := headProbeGuarded hashTable hmh
+    let hashTable := guardedSet hashTable hmh mp
+    let prev := guardedSet prev (mp &&& 0x7FFF) headmp
+    let h3tab := if useH3 then guardedSet h3tab (hash3Single data mp (by omega)) mp else h3tab
+    -- Probe `mp+1` at the ladder depth. Unseeded (0,0): a length seed only changes
+    -- a rejected result, and acceptance needs `len' > pLen` strictly (matches the
+    -- seeded spike's accepted output exactly), so this stays validity-provable.
+    let h2 := lz77Greedy.hash3 data (mp + 1) hashSize (by omega)
+    let head2 := headProbeGuarded hashTable h2
+    let maxLen2 := min 258 (data.size - (mp + 1))
+    have hmaxLen2P : (mp + 1) + maxLen2 ≤ data.size := by omega
+    let m2 := lz77Chain.chainWalk data prev windowSize (mp + 1) maxLen2 niceLen hmaxLen2P head2 (lazy2ProbeDepth maxChain) 0 0
+    let len' := m2.1
+    let pos' := m2.2
+    if hacc : lazyAcceptCost pLen (mp - pMatchPos) len' (mp + 1 - pos') = true ∧ (mp + 1) + len' ≤ data.size then
+      have hlen' : 3 ≤ len' := by have := lazyAcceptCost_lt hacc.1; omega
+      .literal (data[mp]'(by omega)) ::
+        lz77ChainLazy.rollDefer data windowSize hashSize maxChain useH3
+          hashTable prev h3tab (mp + 1) len' pos' (step + 1)
+          insertCap goodMatch niceLen lazyDepth lazy2Steps hacc.2 hlen'
+    else
+      -- No improvement: commit the pending match at `mp`. `mp` already inserted
+      -- above, so insert only the interior `mp+1 .. mp+pLen-1`.
+      let (hashTable, prev) := lz77Chain.updateHashes data hashSize hashTable prev mp 1 pLen insertCap
+      let h3tab := if useH3 then updateHash3 data h3tab mp 1 pLen insertCap else h3tab
+      .reference pLen (mp - pMatchPos) ::
+        lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (mp + pLen) insertCap goodMatch niceLen lazyDepth lazy2Steps
+  else
+    -- No more defers: commit the pending match at `mp` via the production batch
+    -- `updateHashes (mp-1) 1 (pLen+1)` (inserts `mp .. mp+pLen-1`).
+    let (hashTable, prev) := lz77Chain.updateHashes data hashSize hashTable prev (mp - 1) 1 (pLen + 1) insertCap
+    let h3tab := if useH3 then updateHash3 data h3tab (mp - 1) 1 (pLen + 1) insertCap else h3tab
+    .reference pLen (mp - pMatchPos) ::
+      lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (mp + pLen) insertCap goodMatch niceLen lazyDepth lazy2Steps
+termination_by data.size - mp
+decreasing_by all_goals omega
+
+end
+
 /-- Lazy (one-byte-lookahead, zlib `deflate_slow`-style) variant of `lz77Chain`.
     At each position it finds the best chain match `M` at `pos`; before emitting it
     runs a *second* `chainWalk` at `pos+1` for `M'`. It defers — emits a literal at
@@ -1416,94 +1585,15 @@ theorem lazyAcceptCost_lt {len1 dist1 len2 dist2 : Nat}
     `LZ77ChainLazyCorrect`. -/
 def lz77ChainLazy (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
     (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258)
-    (lazyDepth : Nat := maxChain) (useH3 : Bool := false) :
+    (lazyDepth : Nat := maxChain) (useH3 : Bool := false) (lazy2Steps : Nat := 1) :
     Array LZ77Token :=
   if data.size < 3 then
     (lz77Greedy.trailing data 0).toArray
   else
     let hashSize := 65536
-    (mainLoop data windowSize hashSize maxChain useH3
+    (lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3
       (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size)
-      (.replicate 32768 data.size) 0 insertCap goodMatch niceLen lazyDepth).toArray
-where
-  mainLoop (data : ByteArray) (windowSize hashSize maxChain : Nat) (useH3 : Bool)
-      (hashTable : Array Nat) (prev h3tab : Array Nat) (pos insertCap goodMatch niceLen lazyDepth : Nat) : List LZ77Token :=
-    if hlt : pos + 2 < data.size then
-      let h := lz77Greedy.hash3 data pos hashSize hlt
-      let head := headProbeGuarded hashTable h
-      let hashTable := guardedSet hashTable h pos
-      let prev := guardedSet prev (pos &&& 0x7FFF) head
-      let seed := h3Seed useH3 data h3tab windowSize pos hlt
-      let h3tab := if useH3 then guardedSet h3tab (hash3Single data pos hlt) pos else h3tab
-      let maxLen := min 258 (data.size - pos)
-      have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let m := lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hmaxLenP head maxChain (seed % 512) (seed / 512)
-      let matchLen := m.1
-      let matchPos := m.2
-      if hge : matchLen ≥ 3 then
-        if hle : pos + matchLen ≤ data.size then
-          -- Lazy: probe pos+1 for a cost-accepted deferral (`lazyAcceptCost`)
-          if h3lt : pos + 3 < data.size then
-            -- Lazy gate (zlib `good_match`): probe pos+1 only when the first match is
-            -- short. `goodMatch = 259` (> 258) restores the ungated lazy matcher.
-            if matchLen < goodMatch then
-              let h2 := lz77Greedy.hash3 data (pos + 1) hashSize (by omega)
-              let head2 := headProbeGuarded hashTable h2
-              let maxLen2 := min 258 (data.size - (pos + 1))
-              have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
-              let m2 :=
-                lz77Chain.chainWalk data prev windowSize (pos + 1) maxLen2 niceLen hmaxLen2P head2 lazyDepth 0 0
-              let matchLen2 := m2.1
-              let matchPos2 := m2.2
-              if lazyAcceptCost matchLen (pos - matchPos) matchLen2 (pos + 1 - matchPos2) then
-                if hle2 : pos + 1 + matchLen2 ≤ data.size then
-                  -- Cost-accepted match at pos+1: emit literal at pos + reference at pos+1
-                  have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
-                  let (hashTable, prev) :=
-                    lz77Chain.updateHashes data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
-                  let h3tab := if useH3 then updateHash3 data h3tab pos 1 (matchLen2 + 1) insertCap else h3tab
-                  .literal (data[pos]'(by omega)) ::
-                    .reference matchLen2 (pos + 1 - matchPos2) ::
-                    mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + 1 + matchLen2) insertCap goodMatch niceLen lazyDepth
-                else
-                  -- matchLen2 spills past data: keep match at pos
-                  have : data.size - (pos + matchLen) < data.size - pos := by omega
-                  let (hashTable, prev) :=
-                    lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
-                  let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
-                  .reference matchLen (pos - matchPos) ::
-                    mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + matchLen) insertCap goodMatch niceLen lazyDepth
-              else
-                -- No better match at pos+1: keep match at pos
-                have : data.size - (pos + matchLen) < data.size - pos := by omega
-                let (hashTable, prev) :=
-                  lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
-                let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
-                .reference matchLen (pos - matchPos) ::
-                  mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + matchLen) insertCap goodMatch niceLen lazyDepth
-            else
-              -- Gated: long first match, skip the lookahead; still insert interior hashes.
-              have : data.size - (pos + matchLen) < data.size - pos := by omega
-              let (hashTable, prev) :=
-                lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
-              let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
-              .reference matchLen (pos - matchPos) ::
-                mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + matchLen) insertCap goodMatch niceLen lazyDepth
-          else
-            -- Near end of data: keep match at pos
-            have : data.size - (pos + matchLen) < data.size - pos := by omega
-            .reference matchLen (pos - matchPos) ::
-              mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + matchLen) insertCap goodMatch niceLen lazyDepth
-        else
-          .literal (data[pos]'(by omega)) ::
-            mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + 1) insertCap goodMatch niceLen lazyDepth
-      else
-        .literal (data[pos]'(by omega)) ::
-          mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + 1) insertCap goodMatch niceLen lazyDepth
-    else
-      lz77Greedy.trailing data pos
-  termination_by data.size - pos
-  decreasing_by all_goals omega
+      (.replicate 32768 data.size) 0 insertCap goodMatch niceLen lazyDepth lazy2Steps).toArray
 
 /-- Iterative (tail-recursive, `Array`-accumulating) version of `lz77ChainLazy`.
     Same output, no stack overflow on large inputs. Reuses `lz77Chain`'s

--- a/Zip/Spec/LZ77ChainLazyCorrect.lean
+++ b/Zip/Spec/LZ77ChainLazyCorrect.lean
@@ -20,14 +20,30 @@ open Zip.Native.Deflate (lz77ChainLazy lz77Chain lz77Greedy)
 
 /-! ## Validity -/
 
+/-- The pending-match invariant carried through `rollDefer`: exactly
+    `chainWalk_spec`'s `Q` at position `mp` with `maxLen = min 258 (data.size - mp)`
+    and `(bestLen, bestPos) = (pLen, pMatchPos)`. The caller passes the `Or.inr`
+    of the `chainWalk_spec` that found the pending match, so the rolling emission
+    re-establishes validity/encodability without ever inspecting the chain state.
+    Shared by `rollDefer_valid` and `rollDefer_encodable`; reused unchanged by
+    rungs 2-4 as the rolling arm is threaded up the tower. -/
+def RollPending (data : ByteArray) (windowSize mp pLen pMatchPos : Nat) : Prop :=
+  pMatchPos < mp ∧ mp - pMatchPos ≤ windowSize ∧
+    pMatchPos + min 258 (data.size - mp) ≤ data.size ∧
+    (∀ i, i < pLen → data[mp + i]! = data[pMatchPos + i]!) ∧ pLen ≤ min 258 (data.size - mp)
+
+/-! `lz77ChainLazy.mainLoop`/`rollDefer` produce valid decompositions. The
+    non-rolling reference cases use `chainWalk_spec` (at `pos`, and again at
+    `pos+1`) exactly as before; the rolling arm (`rollDefer_valid`) re-probes at
+    each defer and carries the fresh match's `chainWalk_spec` `Q` as `RollPending`,
+    so it emits a data-dependent number of literals while every reference stays
+    re-verified. -/
 set_option backward.split false in
-/-- `lz77ChainLazy.mainLoop` produces a valid decomposition from `pos`. The
-    reference cases use `chainWalk_spec` (at `pos`, and again at `pos+1` for the
-    lookahead) exactly as `lz77Chain_mainLoop_valid` does for the single match. -/
+mutual
 theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize maxChain : Nat) (useH3 : Bool)
-    (hashTable : Array Nat) (prev h3tab : Array Nat) (pos insertCap goodMatch niceLen lazyDepth : Nat) (hw : windowSize > 0) :
+    (hashTable : Array Nat) (prev h3tab : Array Nat) (pos insertCap goodMatch niceLen lazyDepth lazy2Steps : Nat) (hw : windowSize > 0) :
     ValidDecomp data pos
-      (lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab pos insertCap goodMatch niceLen lazyDepth) := by
+      (lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab pos insertCap goodMatch niceLen lazyDepth lazy2Steps) := by
   unfold lz77ChainLazy.mainLoop
   split
   · rename_i hlt
@@ -63,41 +79,92 @@ theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize max
                 · rename_i hle2
                   obtain h0' | hQ2 := hspec2
                   · omega
-                  · exact .literal (by omega) (getElem!_pos data pos (by omega))
-                      (lazyRef_at_pos data (pos + 1) _ _ hQ2.1 (by omega) hle2
-                        (fun i hi => hQ2.2.2.2.1 i hi)
-                        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw))
+                  · -- accept + spill-ok: `if 1 < lazy2Steps` (roll) `else` (single).
+                    split
+                    · split
+                      · -- rolling: literal at pos, then rollDefer at pos+1
+                        rename_i hpl2
+                        exact .literal (by omega) (getElem!_pos data pos (by omega))
+                          (rollDefer_valid data windowSize hashSize maxChain useH3 _ _ _
+                            (pos + 1) _ _ 1 insertCap goodMatch niceLen lazyDepth lazy2Steps
+                            hle2 hpl2 hQ2 hw)
+                      · -- ¬(3 ≤ matchLen2): unreachable, single-deferral fallback
+                        exact .literal (by omega) (getElem!_pos data pos (by omega))
+                          (lazyRef_at_pos data (pos + 1) _ _ hQ2.1 (by omega) hle2
+                            (fun i hi => hQ2.2.2.2.1 i hi)
+                            (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw))
+                    · -- ¬(1 < lazy2Steps): single deferral (original behavior)
+                      exact .literal (by omega) (getElem!_pos data pos (by omega))
+                        (lazyRef_at_pos data (pos + 1) _ _ hQ2.1 (by omega) hle2
+                          (fun i hi => hQ2.2.2.2.1 i hi)
+                          (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw))
                 · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                    (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
+                    (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
               · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                  (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
+                  (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
             · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
+                (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
           · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-              (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
+              (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
       · exact .literal (by omega) (getElem!_pos data pos (by omega))
-          (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
+          (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
     · exact .literal (by omega) (getElem!_pos data pos (by omega))
-        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
+        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
   · exact trailing_valid data pos
 termination_by data.size - pos
 decreasing_by all_goals omega
 
-/-- `lz77ChainLazy` produces a valid decomposition of the input data. -/
-theorem lz77ChainLazy_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
+theorem rollDefer_valid (data : ByteArray) (windowSize hashSize maxChain : Nat) (useH3 : Bool)
+    (hashTable : Array Nat) (prev h3tab : Array Nat)
+    (mp pLen pMatchPos step insertCap goodMatch niceLen lazyDepth lazy2Steps : Nat)
+    (hmp : mp + pLen ≤ data.size) (hpl : 3 ≤ pLen)
+    (hQ : RollPending data windowSize mp pLen pMatchPos) (hw : windowSize > 0) :
+    ValidDecomp data mp
+      (lz77ChainLazy.rollDefer data windowSize hashSize maxChain useH3 hashTable prev h3tab mp pLen pMatchPos step insertCap goodMatch niceLen lazyDepth lazy2Steps hmp hpl) := by
+  unfold lz77ChainLazy.rollDefer
+  split
+  · rename_i hcan
+    dsimp only
+    simp only [headProbeGuarded_eq, guardedSet_eq]
+    have hspec := chainWalk_spec data
+      (prev.set! (mp &&& 0x7FFF) hashTable[lz77Greedy.hash3 data mp hashSize (by omega)]!)
+      windowSize (mp + 1) (min 258 (data.size - (mp + 1))) niceLen (by omega)
+      (hashTable.set! (lz77Greedy.hash3 data mp hashSize (by omega)) mp)[
+        lz77Greedy.hash3 data (mp + 1) hashSize (by omega)]!
+      (lazy2ProbeDepth maxChain) 0 0 (Or.inl rfl)
+    split
+    · rename_i hacc
+      have hlt2 := lazyAcceptCost_lt hacc.1
+      obtain h0' | hQ' := hspec
+      · omega
+      · exact .literal (by omega) (getElem!_pos data mp (by omega))
+          (rollDefer_valid data windowSize hashSize maxChain useH3 _ _ _
+            (mp + 1) _ _ (step + 1) insertCap goodMatch niceLen lazyDepth lazy2Steps
+            hacc.2 (by omega) hQ' hw)
+    · exact lazyRef_at_pos data mp _ _ hQ.1 hpl hmp (fun i hi => hQ.2.2.2.1 i hi)
+        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
+  · exact lazyRef_at_pos data mp _ _ hQ.1 hpl hmp (fun i hi => hQ.2.2.2.1 i hi)
+      (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
+termination_by data.size - mp
+decreasing_by all_goals omega
+end
+
+/-- `lz77ChainLazy` produces a valid decomposition of the input data, for any
+    `lazy2Steps` (the rolling deferral only ever picks among valid matches). -/
+theorem lz77ChainLazy_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool) (lazy2Steps : Nat)
     (hw : windowSize > 0) :
-    ValidDecomp data 0 (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3).toList := by
+    ValidDecomp data 0 (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 lazy2Steps).toList := by
   simp only [lz77ChainLazy]
   split
   · simp only; exact trailing_valid data 0
-  · simp only; exact lz77ChainLazy_mainLoop_valid data windowSize 65536 maxChain useH3 _ _ _ 0 insertCap goodMatch niceLen lazyDepth hw
+  · simp only; exact lz77ChainLazy_mainLoop_valid data windowSize 65536 maxChain useH3 _ _ _ 0 insertCap goodMatch niceLen lazyDepth lazy2Steps hw
 
 /-- Resolving the LZ77 tokens produced by `lz77ChainLazy` recovers the original data. -/
-theorem lz77ChainLazy_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
+theorem lz77ChainLazy_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool) (lazy2Steps : Nat)
     (hw : windowSize > 0) :
-    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3)) [] =
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 lazy2Steps)) [] =
       some data.data.toList :=
-  validDecomp_resolves data _ (lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 hw)
+  validDecomp_resolves data _ (lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 lazy2Steps hw)
 
 /-! ## Encodability -/
 
@@ -107,10 +174,15 @@ private def Enc (t : LZ77Token) : Prop :=
   | .literal _ => True
   | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768
 
+/-! `lz77ChainLazy.mainLoop`/`rollDefer` emit only encoder-legal tokens. Mirrors
+    the validity tower: the rolling arm (`rollDefer_encodable`) reads the pending
+    match's length/offset bounds from `RollPending` (chainWalk_spec's `Q`) plus
+    `windowSize ≤ 32768`. -/
 set_option backward.split false in
+mutual
 theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize maxChain : Nat) (useH3 : Bool)
-    (hashTable : Array Nat) (prev h3tab : Array Nat) (pos insertCap goodMatch niceLen lazyDepth : Nat) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab pos insertCap goodMatch niceLen lazyDepth, Enc t := by
+    (hashTable : Array Nat) (prev h3tab : Array Nat) (pos insertCap goodMatch niceLen lazyDepth lazy2Steps : Nat) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    ∀ t ∈ lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab pos insertCap goodMatch niceLen lazyDepth lazy2Steps, Enc t := by
   unfold lz77ChainLazy.mainLoop
   split
   · rename_i hlt
@@ -144,48 +216,112 @@ theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize
                 have hlt2 := lazyAcceptCost_lt hacc
                 split
                 · rename_i hle2
-                  obtain h0' | ⟨hQ2a, hQ2b, _, _, hQ2e⟩ := hspec2
+                  obtain h0' | ⟨hQ2a, hQ2b, hQ2c, hQ2d, hQ2e⟩ := hspec2
                   · omega
-                  · intro t ht
-                    cases ht with
-                    | head => trivial
-                    | tail _ h =>
-                      cases h with
-                      | head => exact ⟨by omega, by omega, by omega, by omega⟩
-                      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+                  · -- accept + spill-ok: `if 1 < lazy2Steps` (roll) `else` (single).
+                    split
+                    · split
+                      · -- rolling: literal at pos, then rollDefer at pos+1
+                        rename_i hpl2
+                        intro t ht
+                        cases ht with
+                        | head => trivial
+                        | tail _ h =>
+                          exact rollDefer_encodable data windowSize hashSize maxChain useH3 _ _ _
+                            (pos + 1) _ _ 1 insertCap goodMatch niceLen lazyDepth lazy2Steps
+                            hle2 hpl2 ⟨hQ2a, hQ2b, hQ2c, hQ2d, hQ2e⟩ hw hws t h
+                      · -- ¬(3 ≤ matchLen2): unreachable single-deferral fallback
+                        intro t ht
+                        cases ht with
+                        | head => trivial
+                        | tail _ h =>
+                          cases h with
+                          | head => exact ⟨by omega, by omega, by omega, by omega⟩
+                          | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+                    · -- ¬(1 < lazy2Steps): single deferral (original behavior)
+                      intro t ht
+                      cases ht with
+                      | head => trivial
+                      | tail _ h =>
+                        cases h with
+                        | head => exact ⟨by omega, by omega, by omega, by omega⟩
+                        | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
                 · intro t ht
                   cases ht with
                   | head => exact ⟨hge, by omega, by omega, by omega⟩
-                  | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+                  | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
               · intro t ht
                 cases ht with
                 | head => exact ⟨hge, by omega, by omega, by omega⟩
-                | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+                | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
             · intro t ht
               cases ht with
               | head => exact ⟨hge, by omega, by omega, by omega⟩
-              | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+              | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
           · intro t ht
             cases ht with
             | head => exact ⟨hge, by omega, by omega, by omega⟩
-            | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+            | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
       · intro t ht
         cases ht with
         | head => trivial
-        | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+        | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
     · intro t ht
       cases ht with
       | head => trivial
-      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
   · intro t ht
     exact trailing_encodable data pos t ht
 termination_by data.size - pos
 decreasing_by all_goals omega
 
-/-- Every token `lz77ChainLazy` emits satisfies the encoder bounds. -/
-theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
+theorem rollDefer_encodable (data : ByteArray) (windowSize hashSize maxChain : Nat) (useH3 : Bool)
+    (hashTable : Array Nat) (prev h3tab : Array Nat)
+    (mp pLen pMatchPos step insertCap goodMatch niceLen lazyDepth lazy2Steps : Nat)
+    (hmp : mp + pLen ≤ data.size) (hpl : 3 ≤ pLen)
+    (hQ : RollPending data windowSize mp pLen pMatchPos) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    ∀ t ∈ lz77ChainLazy.rollDefer data windowSize hashSize maxChain useH3 hashTable prev h3tab mp pLen pMatchPos step insertCap goodMatch niceLen lazyDepth lazy2Steps hmp hpl, Enc t := by
+  obtain ⟨hq1, hq2, hq3, hq4, hq5⟩ := hQ
+  unfold lz77ChainLazy.rollDefer
+  split
+  · rename_i hcan
+    dsimp only
+    simp only [headProbeGuarded_eq, guardedSet_eq]
+    have hspec := chainWalk_spec data
+      (prev.set! (mp &&& 0x7FFF) hashTable[lz77Greedy.hash3 data mp hashSize (by omega)]!)
+      windowSize (mp + 1) (min 258 (data.size - (mp + 1))) niceLen (by omega)
+      (hashTable.set! (lz77Greedy.hash3 data mp hashSize (by omega)) mp)[
+        lz77Greedy.hash3 data (mp + 1) hashSize (by omega)]!
+      (lazy2ProbeDepth maxChain) 0 0 (Or.inl rfl)
+    split
+    · rename_i hacc
+      have hlt2 := lazyAcceptCost_lt hacc.1
+      obtain h0' | ⟨hQ'1, hQ'2, hQ'3, hQ'4, hQ'5⟩ := hspec
+      · omega
+      · intro t ht
+        cases ht with
+        | head => trivial
+        | tail _ h =>
+          exact rollDefer_encodable data windowSize hashSize maxChain useH3 _ _ _
+            (mp + 1) _ _ (step + 1) insertCap goodMatch niceLen lazyDepth lazy2Steps
+            hacc.2 (by omega) ⟨hQ'1, hQ'2, hQ'3, hQ'4, hQ'5⟩ hw hws t h
+    · intro t ht
+      cases ht with
+      | head => exact ⟨hpl, by omega, by omega, by omega⟩
+      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+  · intro t ht
+    cases ht with
+    | head => exact ⟨hpl, by omega, by omega, by omega⟩
+    | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+termination_by data.size - mp
+decreasing_by all_goals omega
+end
+
+/-- Every token `lz77ChainLazy` emits satisfies the encoder bounds, for any
+    `lazy2Steps`. -/
+theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool) (lazy2Steps : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3).toList,
+    ∀ t ∈ (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 lazy2Steps).toList,
       match t with
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
@@ -194,7 +330,7 @@ theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCa
   · intro t ht
     exact trailing_encodable data 0 t ht
   · intro t ht
-    exact lz77ChainLazy_mainLoop_encodable data windowSize 65536 maxChain useH3 _ _ _ 0 insertCap goodMatch niceLen lazyDepth hw hws t ht
+    exact lz77ChainLazy_mainLoop_encodable data windowSize 65536 maxChain useH3 _ _ _ 0 insertCap goodMatch niceLen lazyDepth lazy2Steps hw hws t ht
 
 /-! ## Iterative version: equivalence + transferred contracts -/
 
@@ -204,9 +340,9 @@ set_option maxHeartbeats 1000000 in
     one — identical branch structure, push vs. cons at each emission (two pushes in
     the lookahead arm). -/
 private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
-    (hashTable : Array Nat) (prev h3tab : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
+    (hashTable : Array Nat) (prev h3tab : Array Nat) (pos lazy2Steps : Nat) (hstep : ¬ (1 < lazy2Steps)) (acc : Array LZ77Token) :
     lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab pos acc =
-    acc ++ (lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab pos insertCap goodMatch niceLen lazyDepth).toArray := by
+    acc ++ (lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab pos insertCap goodMatch niceLen lazyDepth lazy2Steps).toArray := by
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev h3tab with
   | _ n ih =>
     unfold lz77ChainLazyIter.mainLoop lz77ChainLazy.mainLoop
@@ -217,7 +353,9 @@ private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize ma
       -- branch tree (via `matchLen`/`matchPos`) and blow up. Abstract those two
       -- opaque terms to variables first, then the (now cheap) zeta-simp aligns
       -- the two sides' walk decode through `chainWalkGuardedPacked_mod`/`_div`.
-      simp (config := { zeta := false }) only [hlt, ↓reduceDIte]
+      -- `dif_neg hstep` reduces the rolling dispatch `if 1 < lazy2Steps` (dead when
+      -- `lazy2Steps ≤ 1`) so the heavy walk-decode simp never traverses `rollDefer`.
+      simp (config := { zeta := false }) only [hlt, ↓reduceDIte, dif_neg hstep]
       -- The seed's decoded length is `≤ maxLen` (`h3Seed_spec`); keep that fact
       -- through the abstraction so the seed-general decode lemmas apply.
       have hbnd : h3Seed useH3 data h3tab windowSize pos hlt % 512 ≤ min 258 (data.size - pos) := by
@@ -242,7 +380,8 @@ private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize ma
               split
               · -- matchLen2 > matchLen
                 split
-                · -- hle2 : lookahead emits literal + reference(matchLen2), two pushes
+                · -- hle2 : lookahead emits literal + reference(matchLen2), two pushes.
+                  -- The rolling dispatch was already reduced away by `dif_neg hstep`.
                   rw [ih _ (by omega) _ _ _ _ _ rfl,
                     Array.push_eq_append, Array.push_eq_append,
                     Array.append_assoc, Array.append_assoc,
@@ -275,18 +414,19 @@ theorem lz77ChainLazyIter_eq_lz77ChainLazy (data : ByteArray) (maxChain windowSi
   unfold lz77ChainLazyIter lz77ChainLazy
   split
   · rw [trailing_eq]; simp only [List.append_toArray, List.nil_append]
-  · rw [mainLoop_eq_chainLazy]; simp only [List.append_toArray, List.nil_append]
+  · rw [mainLoop_eq_chainLazy (lazy2Steps := 1) (hstep := by omega)]
+    simp only [List.append_toArray, List.nil_append]
 
 theorem lz77ChainLazyIter_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
     (hw : windowSize > 0) :
     ValidDecomp data 0 (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3).toList := by
-  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 hw
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 1 hw
 
 theorem lz77ChainLazyIter_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
     (hw : windowSize > 0) :
     Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3)) [] =
       some data.data.toList := by
-  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_resolves data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 hw
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_resolves data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 1 hw
 
 theorem lz77ChainLazyIter_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
@@ -295,7 +435,7 @@ theorem lz77ChainLazyIter_encodable (data : ByteArray) (maxChain windowSize inse
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
   rw [lz77ChainLazyIter_eq_lz77ChainLazy]
-  exact lz77ChainLazy_encodable data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 hw hws
+  exact lz77ChainLazy_encodable data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 1 hw hws
 
 /-- The lazy chain matcher emits no tokens on empty input. -/
 theorem lz77ChainLazyIter_empty (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)


### PR DESCRIPTION
This PR land rung 1 of the #2837 rolling-lazy2 proof campaign: the boxed reference matcher `lz77ChainLazy` takes a `lazy2Steps : Nat := 1` knob and, on a cost-accepted lookahead with steps remaining, rolls the pending match through a new mutually-recursive `rollDefer` arm (the certified spike's policy: step cap, /4-constant follow-up depth, the production interior-insertion batch on commit). The base contracts (`_valid`/`_encodable`/`_resolves`) are re-proven for every `lazy2Steps` as mutual pairs, built on a reusable `RollPending` interface (exactly `chainWalk_spec`'s pending-match obligation) that rungs 2-4 consume as the arm climbs the iter/packed/merged tower; the iter lockstep stays green via a `¬(1 < lazy2Steps)` parameterization.

No runtime behavior changes and no perf overlay is attached, deliberately: the modified function is the production-dead boxed reference (`deflateRaw` reaches only the iter/merged twins — verified by grep), the default `lazy2Steps = 1` makes the rolling arm dead code even there, no call site passes a larger value, and `bench csize` is byte-identical to a pre-edit master binary. Zero new `sorry` (the campaign's per-rung target), `lake exe test` green. Rung-2 scoping notes are on #2837.

🤖 Prepared with Claude Code