### PR TITLE
chore(bench): guard pareto_history.py against a dirty latest.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__/
 /.claude/.pod-checksums
 /plans/[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]-*.md
 /.codex
+# local `pareto_history.py --preview` renders (working-tree state; never committed)
+/bench/graphs/*_preview.svg

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ __pycache__/
 /plans/[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]-*.md
 /.codex
 # local `pareto_history.py --preview` renders (working-tree state; never committed)
-/bench/graphs/*_preview.svg
+/bench/graphs/*_preview.*

--- a/bench/pareto_history.py
+++ b/bench/pareto_history.py
@@ -77,14 +77,23 @@ def git(*args):
                           capture_output=True, text=True, check=True).stdout
 
 
-def latest_json_dirty():
-    """True if bench/results/latest.json has uncommitted changes vs HEAD.
+# tracked data inputs that `extract` reads from the working tree; a dirty copy
+# of any of these changes the committed SVG (reference curves + provenance meta)
+# in a way CI's clean checkout cannot reproduce.
+GENERATOR_INPUTS = ["bench/results/latest.json", "bench/results/zopfli-ceiling.json"]
+
+
+def inputs_dirty():
+    """-> list of GENERATOR_INPUTS whose working-tree copy differs from HEAD.
 
     The committed animation SVG is rendered from committed git history; a dirty
-    latest.json would make it (references, a transient 'worktree' frame, and a
-    wall-clock date) depend on the working tree, which CI's clean checkout cannot
-    reproduce — so `animation-sync` would fail on the very next push."""
-    return bool(git("status", "--porcelain", "--", "bench/results/latest.json").strip())
+    input would make it (reference curves and provenance metadata, plus — only on
+    the --preview path — a transient 'worktree' frame and a wall-clock date)
+    depend on the working tree, which CI's clean checkout cannot reproduce, so
+    `animation-sync` would fail on the very next push. Uses `git status` so a
+    staged-but-not-committed change counts as dirty too."""
+    return [p for p in GENERATOR_INPUTS
+            if git("status", "--porcelain", "--", p).strip()]
 
 
 # --------------------------------------------------------------------------
@@ -667,32 +676,36 @@ def main():
     graphs.mkdir(parents=True, exist_ok=True)
     stem = f"{args.corpus}_compress_pareto_history"
 
-    if args.preview:
-        references, frames, meta = extract(args.corpus, include_worktree=True)
-        build_svg(references, frames, meta, graphs / f"{stem}_preview.svg")
-        print(f"preview written to {stem}_preview.svg (untracked — do NOT commit); "
-              "commit bench/results/latest.json and re-run without --preview to "
-              "regenerate the tracked SVG", file=sys.stderr)
-        return
+    # --preview renders the working-tree state (uncommitted refresh frame and all)
+    # to untracked <stem>_preview.* for local eyeballing; the default path renders
+    # the tracked artifacts and refuses to run when a data input is dirty.
+    if not args.preview:
+        dirty = inputs_dirty()
+        if dirty:
+            sys.exit(
+                "refusing to regenerate the committed SVG: "
+                + ", ".join(dirty) + " has uncommitted changes.\n"
+                "The committed animation is built from committed history so CI's "
+                "clean checkout can reproduce it byte-for-byte; dirty input data "
+                "would change the reference curves and provenance metadata (and, on "
+                "--preview, add a transient 'worktree' frame with a wall-clock date) "
+                "in ways CI cannot reproduce, so animation-sync would fail on the "
+                "next push.\n"
+                "Commit those file(s) first, then re-run.  (Use --preview to render "
+                "a local, uncommitted preview instead.)")
 
-    if latest_json_dirty():
-        sys.exit(
-            "refusing to regenerate the committed SVG: bench/results/latest.json "
-            "has uncommitted changes.\n"
-            "The committed animation is built from committed history so CI's clean "
-            "checkout can reproduce it byte-for-byte; a dirty latest.json would bake "
-            "in a transient 'worktree' frame and a wall-clock date that CI cannot "
-            "reproduce, so animation-sync would fail on the next push.\n"
-            "Commit bench/results/latest.json first, then re-run.  (Use --preview to "
-            "render a local, uncommitted preview instead.)")
-
-    references, frames, meta = extract(args.corpus, include_worktree=False)
-    build_svg(references, frames, meta, graphs / f"{stem}.svg")
+    suffix = "_preview" if args.preview else ""
+    references, frames, meta = extract(args.corpus, include_worktree=args.preview)
+    build_svg(references, frames, meta, graphs / f"{stem}{suffix}.svg")
     if args.video:
         build_video(references, frames, meta,
-                    graphs / f"{stem}.mp4", graphs / f"{stem}.gif")
+                    graphs / f"{stem}{suffix}.mp4", graphs / f"{stem}{suffix}.gif")
     if args.html:
-        build_html(references, frames, meta, graphs / f"{stem}.html")
+        build_html(references, frames, meta, graphs / f"{stem}{suffix}.html")
+    if args.preview:
+        print(f"preview written to {stem}_preview.* (untracked — do NOT commit); "
+              "commit the refreshed data and re-run without --preview to regenerate "
+              "the tracked artifacts", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/bench/pareto_history.py
+++ b/bench/pareto_history.py
@@ -77,6 +77,16 @@ def git(*args):
                           capture_output=True, text=True, check=True).stdout
 
 
+def latest_json_dirty():
+    """True if bench/results/latest.json has uncommitted changes vs HEAD.
+
+    The committed animation SVG is rendered from committed git history; a dirty
+    latest.json would make it (references, a transient 'worktree' frame, and a
+    wall-clock date) depend on the working tree, which CI's clean checkout cannot
+    reproduce — so `animation-sync` would fail on the very next push."""
+    return bool(git("status", "--porcelain", "--", "bench/results/latest.json").strip())
+
+
 # --------------------------------------------------------------------------
 # extraction
 
@@ -135,10 +145,13 @@ def drop_noise(frames):
     return out
 
 
-def extract(corpus):
+def extract(corpus, include_worktree=False):
     """-> (references, frames, meta): fixed reference curves from the current
     latest.json (+ frozen zopfli ceiling), one filtered frame per committed
-    dashboard refresh (plus the working tree, if it differs from HEAD's)."""
+    dashboard refresh. When include_worktree is set, an uncommitted refresh that
+    differs from HEAD is appended as a final 'worktree' frame — that path is for
+    local --preview only; the committed SVG is built from committed frames so
+    CI's clean checkout can reproduce it (see latest_json_dirty)."""
     now = json.load(open(REPO / "bench/results/latest.json"))
     results_now = now["results"]
     ceiling_path = REPO / "bench/results/zopfli-ceiling.json"
@@ -175,11 +188,13 @@ def extract(corpus):
                  "bench/results/latest.json")
 
     # a just-refreshed, not-yet-committed dashboard becomes the final frame
-    wt = native_points(now["results"], corpus)
-    if wt and wt != frames[-1]["points"]:
-        frames.append(dict(commit="worktree", subject="uncommitted dashboard refresh",
-                           commit_date=now.get("meta", {}).get("date", "?"),
-                           points=wt))
+    # (preview only; excluded from the committed SVG for CI reproducibility)
+    if include_worktree:
+        wt = native_points(now["results"], corpus)
+        if wt and wt != frames[-1]["points"]:
+            frames.append(dict(commit="worktree", subject="uncommitted dashboard refresh",
+                               commit_date=now.get("meta", {}).get("date", "?"),
+                               points=wt))
 
     raw = len(frames)
     frames = drop_noise(drop_spikes(frames))
@@ -642,12 +657,36 @@ def main():
                     help="also render mp4 + GIF (matplotlib frames + ffmpeg)")
     ap.add_argument("--html", action="store_true",
                     help="also emit the interactive player page")
+    ap.add_argument("--preview", action="store_true",
+                    help="render a local preview to <stem>_preview.svg that "
+                         "includes the uncommitted working-tree refresh; the file "
+                         "is untracked and must NOT be committed")
     args = ap.parse_args()
 
-    references, frames, meta = extract(args.corpus)
     graphs = REPO / "bench/graphs"
     graphs.mkdir(parents=True, exist_ok=True)
     stem = f"{args.corpus}_compress_pareto_history"
+
+    if args.preview:
+        references, frames, meta = extract(args.corpus, include_worktree=True)
+        build_svg(references, frames, meta, graphs / f"{stem}_preview.svg")
+        print(f"preview written to {stem}_preview.svg (untracked — do NOT commit); "
+              "commit bench/results/latest.json and re-run without --preview to "
+              "regenerate the tracked SVG", file=sys.stderr)
+        return
+
+    if latest_json_dirty():
+        sys.exit(
+            "refusing to regenerate the committed SVG: bench/results/latest.json "
+            "has uncommitted changes.\n"
+            "The committed animation is built from committed history so CI's clean "
+            "checkout can reproduce it byte-for-byte; a dirty latest.json would bake "
+            "in a transient 'worktree' frame and a wall-clock date that CI cannot "
+            "reproduce, so animation-sync would fail on the next push.\n"
+            "Commit bench/results/latest.json first, then re-run.  (Use --preview to "
+            "render a local, uncommitted preview instead.)")
+
+    references, frames, meta = extract(args.corpus, include_worktree=False)
     build_svg(references, frames, meta, graphs / f"{stem}.svg")
     if args.video:
         build_video(references, frames, meta,


### PR DESCRIPTION
This PR guards `bench/pareto_history.py` against regenerating the committed animation SVG from a dirty `bench/results/latest.json`, the footgun behind the recurring `animation-sync` CI failures. Previously `extract()` appended a transient "worktree" frame (with a wall-clock date) whenever the working-tree `latest.json` differed from HEAD, and that frame plus its date got baked into the tracked `silesia_compress_pareto_history.svg` — which a clean CI checkout can never reproduce, so the next push failed `animation-sync`.

Now the committed SVG is built from committed git history only. The default path refuses to run (exit 1, with an explanation) when `latest.json` has uncommitted changes, telling you to commit it first. A new `--preview` flag renders the working-tree state — including the uncommitted refresh frame — to an untracked, gitignored `<stem>_preview.svg` for local eyeballing. On a clean tree the default path regenerates the tracked SVG byte-for-byte identically to what is committed.

🤖 Prepared with Claude Code