### PR TITLE
perf(bench): route decode-density through the verified exact-size fastloop

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -216,6 +216,16 @@ memory-bandwidth ceiling on emitting the output bytes. This is the rigorous way 
 isolate a decoder: an own-encoder scatter (the lzbench / Squash convention)
 confounds decoder speed with each encoder's ratio.
 
+The native row here is the **known-exact-size production path** — the same one
+ZIP extraction runs (`Zip.Archive` decodes each entry at its declared
+`uncompressedSize`). The decode-density harness feeds the decoder the stream's
+true output size, so native decodes through
+`Zip.Native.Inflate.inflateSized … (exact := true)`: the verified branch-free
+`uset` exact-size fastloop that writes every byte once into the pre-extended
+buffer, dropping the per-literal capacity and output-size checks. It is proven
+byte-identical to the push decoder `inflate` (`inflateSized_agrees`), so the
+measured throughput is the production fast path, not a benchmark-only shortcut.
+
 Two views over the fixed-encoder streams — libdeflate at levels 1/3/6/9/12 plus a
 zopfli stream per file (the densest realistic raw DEFLATE):
 

--- a/bench/ZipBenchReport.lean
+++ b/bench/ZipBenchReport.lean
@@ -187,10 +187,11 @@ def runWorkloads
           if level > 9 then pure none
           else do
             let ref ← RawDeflate.compress data level.toUInt8
-            -- The decompressed size is known here; pass it so the native decoder
-            -- pre-sizes its output buffer, matching the production ZIP/gzip path
-            -- where the uncompressed size comes from the archive metadata. The FFI
-            -- reference decoders ignore it.
+            -- The decompressed size is known here; pass it as the exact size so
+            -- the native decoder runs its verified `uset` exact-size fastloop
+            -- (`inflateSized … (exact := true)`), matching the production
+            -- ZIP/gzip path where the uncompressed size comes from the archive
+            -- metadata. The FFI reference decoders ignore it.
             let dNs ← measureNs size theReps (dec ref size >>= sink)
             pure (mbps size dNs)
       rows := { compressor := name, pattern := pat, size := size, level := level,
@@ -206,8 +207,13 @@ def nativeCompress (data : ByteArray) (level : Nat) : IO ByteArray :=
   pure (Zip.Native.Deflate.deflateRaw data level.toUInt8)
 
 def nativeDecompress (data : ByteArray) (origSize : Nat) : IO ByteArray :=
-  -- `Inflate.inflate` is the shipped production decode path (tree-free).
-  match Zip.Native.Inflate.inflate data (sizeHint := origSize) with
+  -- Route through `inflateSized … (exact := true)`: the decode-density scenario
+  -- feeds the true `origSize`, so this engages the verified branch-free `uset`
+  -- exact-size fastloop — exactly the production ZIP-extraction decode path
+  -- (`Zip.Archive`), not the push decoder. `inflateSized_agrees` proves this is
+  -- byte-identical to `inflate`; with the true non-zero corpus `origSize`,
+  -- `exact := true` takes the fast path (a `0` size would fall back harmlessly).
+  match Zip.Native.Inflate.inflateSized data (sizeHint := origSize) (exact := true) with
   | .ok b => pure b
   | .error e => throw (IO.userError e)
 
@@ -361,23 +367,29 @@ def runZopfliCeiling (outPath : String) : IO Unit := do
   IO.FS.writeFile outPath json
   IO.eprintln s!"Wrote {rows.length} zopfli rows → {outPath}"
 
-/-- Decode `ref`, optionally pre-sizing the output to `hint` (`0` = no hint).
-    `Inflate.inflate` is the shipped production decode path (tree-free).
-    `@[noinline]` keeps the pure decode call from being hoisted out of the
-    timed loop (it is otherwise loop-invariant), so each timed call really decodes. -/
+/-- Decode `ref` through `inflateSized … (exact := true)`, optionally at exact
+    size `hint` (`0` = no hint → push decoder; `> 0` → verified exact-size `uset`
+    fastloop, the production ZIP-extraction path). `inflateSized_agrees` makes both
+    arms byte-identical to `inflate`. `@[noinline]` keeps the pure decode call from
+    being hoisted out of the timed loop (it is otherwise loop-invariant), so each
+    timed call really decodes. -/
 @[noinline] def decodeForAB (ref : ByteArray) (hint : Nat) : IO Nat := do
-  match Zip.Native.Inflate.inflate ref (sizeHint := hint) with
+  match Zip.Native.Inflate.inflateSized ref (sizeHint := hint) (exact := true) with
   | .ok b => sink b
   | .error e => throw (IO.userError e)
 
-/-- Paired, interleaved decode A/B: native decode WITH the output-size hint vs
+/-- Paired, interleaved decode A/B: native decode WITH the exact output size vs
     WITHOUT it, measured back-to-back per file so machine-load common-mode noise
-    cancels. Reports per-corpus geomean speedup (no-hint time / hint time) with a
-    95% CI on the log-ratios. Robust on a busy shared machine; pin with `taskset -c`.
-    This is a diagnostic, not part of the dashboard matrix. -/
+    cancels. Since both arms go through `inflateSized … (exact := true)`, the
+    exact-size arm (`hint = size`) engages the verified `uset` fastloop while the
+    no-hint arm (`hint = 0`) falls back to the push decoder — so this now measures
+    the *fastloop* speedup, not merely output presizing. Reports per-corpus geomean
+    speedup (no-hint time / exact-size time) with a 95% CI on the log-ratios. Robust
+    on a busy shared machine; pin with `taskset -c`. This is a diagnostic, not part
+    of the dashboard matrix. -/
 def runPresizeAB (pairs : Nat := 12) : IO Unit := do
   let corpora ← loadCorpora
-  IO.println s!"Paired decode A/B (no-hint time / hint time), {pairs} pairs/file, level 6:"
+  IO.println s!"Paired decode A/B (push no-hint time / exact-size fastloop time), {pairs} pairs/file, level 6:"
   for (corpus, files) in corpora do
     let mut logs : List Float := []
     let mut noMBs : List Float := []

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m4559f7c6b7" d="M 0 0 
+       <path id="m409c4191e2" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4559f7c6b7" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m409c4191e2" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m4559f7c6b7" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m409c4191e2" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m4559f7c6b7" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m409c4191e2" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m4559f7c6b7" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m409c4191e2" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m4559f7c6b7" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m409c4191e2" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m4559f7c6b7" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m409c4191e2" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m4559f7c6b7" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m409c4191e2" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -895,23 +895,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 391.323447 
-L 637.2 391.323447 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 391.391504 
+L 637.2 391.391504 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mcd8a495026" d="M 0 0 
+       <path id="m8abc97f1c2" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcd8a495026" x="49.078125" y="391.323447" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8abc97f1c2" x="49.078125" y="391.391504" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 395.122666) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 395.190723) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -920,18 +920,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 263.552396 
-L 637.2 263.552396 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 265.406518 
+L 637.2 265.406518 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mcd8a495026" x="49.078125" y="263.552396" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8abc97f1c2" x="49.078125" y="265.406518" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(24.478125 267.351615) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 269.205736) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -940,18 +940,18 @@ L 637.2 263.552396
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 135.781345 
-L 637.2 135.781345 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 139.421531 
+L 637.2 139.421531 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mcd8a495026" x="49.078125" y="135.781345" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8abc97f1c2" x="49.078125" y="139.421531" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(24.478125 139.580564) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 143.22075) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -960,270 +960,282 @@ L 637.2 135.781345
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 411.115433 
-L 637.2 411.115433 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 410.906825 
+L 637.2 410.906825 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m34f4c66352" d="M 0 0 
+       <path id="mc0c2f21cd5" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="411.115433" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="410.906825" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 403.705741 
-L 637.2 403.705741 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 403.600711 
+L 637.2 403.600711 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="403.705741" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="403.600711" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 397.16993 
-L 637.2 397.16993 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 397.156261 
+L 637.2 397.156261 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="397.16993" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="397.156261" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 352.860528 
-L 637.2 352.860528 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 353.466244 
+L 637.2 353.466244 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="352.860528" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="353.466244" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 330.361163 
-L 637.2 330.361163 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 331.281389 
+L 637.2 331.281389 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="330.361163" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="331.281389" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 314.397609 
-L 637.2 314.397609 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 315.540984 
+L 637.2 315.540984 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="314.397609" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="315.540984" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 302.015315 
-L 637.2 302.015315 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 303.331778 
+L 637.2 303.331778 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="302.015315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="303.331778" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 291.898244 
-L 637.2 291.898244 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 293.356129 
+L 637.2 293.356129 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="291.898244" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="293.356129" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 283.344382 
-L 637.2 283.344382 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 284.921839 
+L 637.2 284.921839 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="283.344382" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="284.921839" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 275.93469 
-L 637.2 275.93469 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 277.615724 
+L 637.2 277.615724 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="275.93469" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="277.615724" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 269.398879 
-L 637.2 269.398879 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 271.171274 
+L 637.2 271.171274 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="269.398879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="271.171274" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 225.089477 
-L 637.2 225.089477 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 227.481258 
+L 637.2 227.481258 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="225.089477" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="227.481258" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 202.590112 
-L 637.2 202.590112 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 205.296403 
+L 637.2 205.296403 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="202.590112" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="205.296403" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 186.626558 
-L 637.2 186.626558 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 189.555998 
+L 637.2 189.555998 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="186.626558" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="189.555998" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 174.244264 
-L 637.2 174.244264 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 177.346791 
+L 637.2 177.346791 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="174.244264" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="177.346791" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 164.127193 
-L 637.2 164.127193 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 167.371143 
+L 637.2 167.371143 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="164.127193" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="167.371143" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 155.573332 
-L 637.2 155.573332 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 158.936853 
+L 637.2 158.936853 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="155.573332" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="158.936853" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 148.16364 
-L 637.2 148.16364 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 151.630738 
+L 637.2 151.630738 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="148.16364" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="151.630738" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 141.627828 
-L 637.2 141.627828 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 145.186288 
+L 637.2 145.186288 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="141.627828" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="145.186288" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 97.318426 
-L 637.2 97.318426 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 101.496271 
+L 637.2 101.496271 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="97.318426" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="101.496271" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 74.819061 
-L 637.2 74.819061 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 79.311416 
+L 637.2 79.311416 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="74.819061" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="79.311416" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 58.855508 
-L 637.2 58.855508 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 63.571011 
+L 637.2 63.571011 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m34f4c66352" x="49.078125" y="58.855508" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="63.571011" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_65">
+      <path d="M 49.078125 51.361805 
+L 637.2 51.361805 
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#mc0c2f21cd5" x="49.078125" y="51.361805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1383,10 +1395,10 @@ z
      </g>
     </g>
    </g>
-   <g id="line2d_65">
+   <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#pafa2894bef)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p981ea6b935)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1409,7 +1421,7 @@ L 637.2 47.3475
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_13">
-    <!--  memcpy ceiling ≈ 36 GB/s -->
+    <!--  memcpy ceiling ≈ 40 GB/s -->
     <g style="fill: #777777" transform="translate(525.255641 62.295398) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-79" d="M 2059 -325 
@@ -1514,8 +1526,8 @@ z
      <use xlink:href="#DejaVuSans-20" transform="translate(824.267578 0)"/>
      <use xlink:href="#DejaVuSans-2248" transform="translate(856.054688 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(939.84375 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(971.630859 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(1035.253906 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(971.630859 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(1035.253906 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(1098.876953 0)"/>
      <use xlink:href="#DejaVuSans-47" transform="translate(1130.664062 0)"/>
      <use xlink:href="#DejaVuSans-42" transform="translate(1208.154297 0)"/>
@@ -1748,80 +1760,80 @@ z
      <use xlink:href="#DejaVuSans-Bold-72" transform="translate(910.302734 0)"/>
     </g>
    </g>
-   <g id="line2d_66">
+   <g id="line2d_68">
     <defs>
-     <path id="m802f1569b7" d="M -2.5 2.5 
+     <path id="mebf82ae5d6" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pafa2894bef)">
-     <use xlink:href="#m802f1569b7" x="75.810937" y="261.499418" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m802f1569b7" x="105.634056" y="267.789789" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m802f1569b7" x="204.490635" y="300.141767" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m802f1569b7" x="234.479899" y="305.825518" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m802f1569b7" x="242.537956" y="315.036638" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m802f1569b7" x="300.771958" y="297.144782" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m802f1569b7" x="303.26414" y="308.187059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m802f1569b7" x="304.261013" y="317.962594" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m802f1569b7" x="313.897453" y="317.915276" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m802f1569b7" x="414.166268" y="334.703269" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m802f1569b7" x="587.289889" y="327.69079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m802f1569b7" x="610.467187" y="318.226537" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p981ea6b935)">
+     <use xlink:href="#mebf82ae5d6" x="75.810937" y="262.971979" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebf82ae5d6" x="105.634056" y="268.971577" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebf82ae5d6" x="204.490635" y="301.738921" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebf82ae5d6" x="234.479899" y="306.528998" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebf82ae5d6" x="242.537956" y="315.114509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebf82ae5d6" x="300.771958" y="297.804449" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebf82ae5d6" x="303.26414" y="308.905974" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebf82ae5d6" x="304.261013" y="318.530644" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebf82ae5d6" x="313.897453" y="318.845042" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebf82ae5d6" x="414.166268" y="335.064122" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebf82ae5d6" x="587.289889" y="328.026168" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebf82ae5d6" x="610.467187" y="318.943936" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_67">
+   <g id="line2d_69">
     <defs>
-     <path id="mc8bfea1032" d="M 0 -2.5 
+     <path id="m5d624b3691" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pafa2894bef)">
-     <use xlink:href="#mc8bfea1032" x="75.810937" y="260.530934" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8bfea1032" x="105.634056" y="253.086833" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8bfea1032" x="204.490635" y="298.70349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8bfea1032" x="234.479899" y="296.22935" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8bfea1032" x="242.537956" y="305.176737" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8bfea1032" x="300.771958" y="285.410956" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8bfea1032" x="303.26414" y="298.378247" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8bfea1032" x="304.261013" y="313.133077" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8bfea1032" x="313.897453" y="305.293171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8bfea1032" x="414.166268" y="324.077479" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8bfea1032" x="587.289889" y="327.012757" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8bfea1032" x="610.467187" y="316.190866" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p981ea6b935)">
+     <use xlink:href="#m5d624b3691" x="75.810937" y="263.076222" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5d624b3691" x="105.634056" y="255.90115" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5d624b3691" x="204.490635" y="299.055066" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5d624b3691" x="234.479899" y="297.649373" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5d624b3691" x="242.537956" y="306.959943" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5d624b3691" x="300.771958" y="287.091113" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5d624b3691" x="303.26414" y="299.68614" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5d624b3691" x="304.261013" y="314.402537" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5d624b3691" x="313.897453" y="306.75453" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5d624b3691" x="414.166268" y="325.079029" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5d624b3691" x="587.289889" y="327.770713" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5d624b3691" x="610.467187" y="317.262571" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_68">
+   <g id="line2d_70">
     <defs>
-     <path id="me8fc2aefe7" d="M -0 3.535534 
+     <path id="m53bba15645" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pafa2894bef)">
-     <use xlink:href="#me8fc2aefe7" x="75.810937" y="227.388814" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fc2aefe7" x="105.634056" y="230.25942" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fc2aefe7" x="204.490635" y="258.634614" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fc2aefe7" x="234.479899" y="259.9616" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fc2aefe7" x="242.537956" y="271.375201" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fc2aefe7" x="300.771958" y="257.414579" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fc2aefe7" x="303.26414" y="268.600048" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fc2aefe7" x="304.261013" y="280.21882" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fc2aefe7" x="313.897453" y="276.166151" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fc2aefe7" x="414.166268" y="294.866345" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fc2aefe7" x="587.289889" y="301.289826" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fc2aefe7" x="610.467187" y="295.675174" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p981ea6b935)">
+     <use xlink:href="#m53bba15645" x="75.810937" y="230.59646" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53bba15645" x="105.634056" y="232.493417" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53bba15645" x="204.490635" y="259.843592" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53bba15645" x="234.479899" y="261.613147" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53bba15645" x="242.537956" y="273.024926" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53bba15645" x="300.771958" y="259.982157" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53bba15645" x="303.26414" y="270.115206" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53bba15645" x="304.261013" y="281.39919" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53bba15645" x="313.897453" y="276.610068" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53bba15645" x="414.166268" y="296.031271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53bba15645" x="587.289889" y="300.918176" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53bba15645" x="610.467187" y="296.657281" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_69">
+   <g id="line2d_71">
     <defs>
-     <path id="m06885c3e88" d="M -0.833333 2.5 
+     <path id="ma8f4df3cba" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1836,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pafa2894bef)">
-     <use xlink:href="#m06885c3e88" x="75.810937" y="285.710438" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m06885c3e88" x="105.634056" y="293.592247" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m06885c3e88" x="204.490635" y="326.133408" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m06885c3e88" x="234.479899" y="337.73493" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m06885c3e88" x="242.537956" y="340.932892" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m06885c3e88" x="300.771958" y="336.31256" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m06885c3e88" x="303.26414" y="344.605532" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m06885c3e88" x="304.261013" y="344.457488" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m06885c3e88" x="313.897453" y="351.398372" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m06885c3e88" x="414.166268" y="363.200005" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m06885c3e88" x="587.289889" y="368.07815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m06885c3e88" x="610.467187" y="356.863633" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p981ea6b935)">
+     <use xlink:href="#ma8f4df3cba" x="75.810937" y="287.254821" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8f4df3cba" x="105.634056" y="295.026453" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8f4df3cba" x="204.490635" y="327.112732" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8f4df3cba" x="234.479899" y="338.552081" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8f4df3cba" x="242.537956" y="341.70534" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8f4df3cba" x="300.771958" y="337.149594" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8f4df3cba" x="303.26414" y="345.326641" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8f4df3cba" x="304.261013" y="345.180667" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8f4df3cba" x="313.897453" y="352.024527" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8f4df3cba" x="414.166268" y="363.66119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8f4df3cba" x="587.289889" y="368.471144" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8f4df3cba" x="610.467187" y="357.413391" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_70">
+   <g id="line2d_72">
     <defs>
-     <path id="ma6ca1294b7" d="M -1.25 2.5 
+     <path id="mcbf4da7508" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1868,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pafa2894bef)">
-     <use xlink:href="#ma6ca1294b7" x="75.810937" y="327.525336" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ca1294b7" x="105.634056" y="342.492009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ca1294b7" x="204.490635" y="362.75387" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ca1294b7" x="234.479899" y="371.266849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ca1294b7" x="242.537956" y="367.162311" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ca1294b7" x="300.771958" y="359.922516" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ca1294b7" x="303.26414" y="374.621262" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ca1294b7" x="304.261013" y="357.345835" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ca1294b7" x="313.897453" y="374.526887" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ca1294b7" x="414.166268" y="384.995187" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ca1294b7" x="587.289889" y="394.327659" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ca1294b7" x="610.467187" y="391.234733" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p981ea6b935)">
+     <use xlink:href="#mcbf4da7508" x="75.810937" y="328.485204" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf4da7508" x="105.634056" y="343.242663" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf4da7508" x="204.490635" y="363.221291" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf4da7508" x="234.479899" y="371.61527" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf4da7508" x="242.537956" y="367.568107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf4da7508" x="300.771958" y="360.429515" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf4da7508" x="303.26414" y="374.922792" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf4da7508" x="304.261013" y="357.888852" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf4da7508" x="313.897453" y="374.829737" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf4da7508" x="414.166268" y="385.151704" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf4da7508" x="587.289889" y="394.353721" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf4da7508" x="610.467187" y="391.304031" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_71">
+   <g id="line2d_73">
     <defs>
-     <path id="mbc7fa6ae22" d="M 0 -2.5 
+     <path id="mf684ab8e80" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1898,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pafa2894bef)">
-     <use xlink:href="#mbc7fa6ae22" x="75.810937" y="273.42452" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc7fa6ae22" x="105.634056" y="285.910165" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc7fa6ae22" x="204.490635" y="319.387555" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc7fa6ae22" x="234.479899" y="320.971757" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc7fa6ae22" x="242.537956" y="325.718465" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc7fa6ae22" x="300.771958" y="332.867753" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc7fa6ae22" x="303.26414" y="336.779875" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc7fa6ae22" x="304.261013" y="345.614079" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc7fa6ae22" x="313.897453" y="336.582957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc7fa6ae22" x="414.166268" y="357.342827" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc7fa6ae22" x="587.289889" y="366.194267" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc7fa6ae22" x="610.467187" y="360.776693" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p981ea6b935)">
+     <use xlink:href="#mf684ab8e80" x="75.810937" y="275.140642" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf684ab8e80" x="105.634056" y="287.451755" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf684ab8e80" x="204.490635" y="320.461177" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf684ab8e80" x="234.479899" y="322.023234" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf684ab8e80" x="242.537956" y="326.70359" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf684ab8e80" x="300.771958" y="333.752941" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf684ab8e80" x="303.26414" y="337.610376" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf684ab8e80" x="304.261013" y="346.32109" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf684ab8e80" x="313.897453" y="337.416212" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf684ab8e80" x="414.166268" y="357.885886" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf684ab8e80" x="587.289889" y="366.613596" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf684ab8e80" x="610.467187" y="361.271752" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
-   <g id="line2d_72">
+   <g id="line2d_74">
     <defs>
-     <path id="md959077eb3" d="M 0 -2.5 
+     <path id="m0797875cd2" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1924,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pafa2894bef)">
-     <use xlink:href="#md959077eb3" x="75.810937" y="347.034581" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959077eb3" x="105.634056" y="348.566824" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959077eb3" x="204.490635" y="367.234161" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959077eb3" x="234.479899" y="372.966525" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959077eb3" x="242.537956" y="379.953597" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959077eb3" x="300.771958" y="370.457094" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959077eb3" x="303.26414" y="375.315519" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959077eb3" x="304.261013" y="382.991991" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959077eb3" x="313.897453" y="385.183642" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959077eb3" x="414.166268" y="391.635066" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959077eb3" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959077eb3" x="610.467187" y="383.674277" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p981ea6b935)">
+     <use xlink:href="#m0797875cd2" x="75.810937" y="347.721735" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0797875cd2" x="105.634056" y="349.23256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0797875cd2" x="204.490635" y="367.638954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0797875cd2" x="234.479899" y="373.291186" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0797875cd2" x="242.537956" y="380.180589" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0797875cd2" x="300.771958" y="370.816834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0797875cd2" x="303.26414" y="375.607345" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0797875cd2" x="304.261013" y="383.176511" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0797875cd2" x="313.897453" y="385.337526" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0797875cd2" x="414.166268" y="391.698767" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0797875cd2" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0797875cd2" x="610.467187" y="383.849259" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1953,9 +1965,9 @@ Q 422.84625 254.871875 424.44625 254.871875
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_73">
+    <g id="line2d_75">
      <defs>
-      <path id="mb7a5b9d9cd" d="M 0 3.5 
+      <path id="m7c6bc0ecc2" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1968,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mb7a5b9d9cd" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m7c6bc0ecc2" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2025,9 +2037,9 @@ z
       <use xlink:href="#DejaVuSans-29" transform="translate(776.953125 0)"/>
      </g>
     </g>
-    <g id="line2d_74">
+    <g id="line2d_76">
      <g>
-      <use xlink:href="#m802f1569b7" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mebf82ae5d6" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2039,9 +2051,9 @@ z
       <use xlink:href="#DejaVuSans-62" transform="translate(108.056641 0)"/>
      </g>
     </g>
-    <g id="line2d_75">
+    <g id="line2d_77">
      <g>
-      <use xlink:href="#mc8bfea1032" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5d624b3691" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2084,9 +2096,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
      </g>
     </g>
-    <g id="line2d_76">
+    <g id="line2d_78">
      <g>
-      <use xlink:href="#me8fc2aefe7" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m53bba15645" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2104,9 +2116,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(407.519531 0)"/>
      </g>
     </g>
-    <g id="line2d_77">
+    <g id="line2d_79">
      <g>
-      <use xlink:href="#m06885c3e88" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma8f4df3cba" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2131,9 +2143,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
      </g>
     </g>
-    <g id="line2d_78">
+    <g id="line2d_80">
      <g>
-      <use xlink:href="#ma6ca1294b7" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mcbf4da7508" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2196,9 +2208,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(323.4375 0)"/>
      </g>
     </g>
-    <g id="line2d_79">
+    <g id="line2d_81">
      <g>
-      <use xlink:href="#mbc7fa6ae22" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mf684ab8e80" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,9 +2246,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(541.601562 0)"/>
      </g>
     </g>
-    <g id="line2d_80">
+    <g id="line2d_82">
      <g>
-      <use xlink:href="#md959077eb3" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0797875cd2" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2305,20 +2317,20 @@ z
      </g>
     </g>
    </g>
-   <g id="line2d_81">
-    <g clip-path="url(#pafa2894bef)">
-     <use xlink:href="#mb7a5b9d9cd" x="75.810937" y="271.412271" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb7a5b9d9cd" x="105.634056" y="288.483705" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb7a5b9d9cd" x="204.490635" y="322.051997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb7a5b9d9cd" x="234.479899" y="323.836862" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb7a5b9d9cd" x="242.537956" y="323.417459" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb7a5b9d9cd" x="300.771958" y="312.420349" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb7a5b9d9cd" x="303.26414" y="331.455799" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb7a5b9d9cd" x="304.261013" y="352.291902" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb7a5b9d9cd" x="313.897453" y="337.639947" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb7a5b9d9cd" x="414.166268" y="356.780198" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb7a5b9d9cd" x="587.289889" y="359.564452" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb7a5b9d9cd" x="610.467187" y="343.056471" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+   <g id="line2d_83">
+    <g clip-path="url(#p981ea6b935)">
+     <use xlink:href="#m7c6bc0ecc2" x="75.810937" y="272.805883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7c6bc0ecc2" x="105.634056" y="288.299011" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7c6bc0ecc2" x="204.490635" y="322.298027" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7c6bc0ecc2" x="234.479899" y="322.158915" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7c6bc0ecc2" x="242.537956" y="323.1245" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7c6bc0ecc2" x="300.771958" y="312.493664" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7c6bc0ecc2" x="303.26414" y="331.266801" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7c6bc0ecc2" x="304.261013" y="352.259514" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7c6bc0ecc2" x="313.897453" y="335.009427" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7c6bc0ecc2" x="414.166268" y="356.246824" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7c6bc0ecc2" x="587.289889" y="359.544989" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7c6bc0ecc2" x="610.467187" y="342.050655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2880,8 +2892,8 @@ z
    </g>
   </g>
   <g id="text_24">
-   <!-- 2026-07-08T17:40:34Z  ·  Linux chungus2 x86_64  ·  commit da9d9c0e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.847969 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-18T17:07:56Z  ·  Linux chungus2 x86_64  ·  commit 3f5fffbd  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(47.369297 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -2953,36 +2965,6 @@ L 684 1825
 L 684 2619 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -3020,17 +3002,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3070,109 +3052,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.630859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3260.253906 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3323.730469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3387.353516 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3442.333984 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3567.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.267578 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3631.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3662.841797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3694.628906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3726.416016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3815.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3877.001953 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4003.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4042.720703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4103.902344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4224.605469 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4265.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4299.410156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4388.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4449.996094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4576.998047 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4610.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4733.492188 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4892.525391 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4987.935547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5024.019531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5062.882812 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5181.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.273438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5245.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5276.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5308.634766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5340.421875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5379.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5443.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5481.873047 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5543.054688 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5796.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5860.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5899.353516 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5931.140625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6014.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6269.128906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6296.912109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6358.191406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6421.570312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6453.357422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6505.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6568.835938 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6693.591797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6745.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6809.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6870.251953 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6909.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6943.152344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6974.939453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7016.052734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7077.332031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7116.541016 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7144.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7237.292969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7317.175781 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7473.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7574.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7614.058594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7711.470703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7739.253906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7802.632812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7830.416016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7882.515625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7921.724609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7949.507812 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3269.53125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3304.736328 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3339.941406 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3403.417969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3466.894531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3498.681641 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3530.46875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3562.255859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3594.042969 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3625.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3653.613281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3715.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3776.416016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3839.794922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3903.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3942.134766 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4003.316406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4062.496094 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4124.019531 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4165.132812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4198.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4226.607422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4288.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4349.410156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4412.789062 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4476.412109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4510.103516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4569.283203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4632.90625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4664.693359 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4728.316406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4791.939453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4823.726562 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4887.349609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4923.433594 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4962.296875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5017.277344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5080.900391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5112.6875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5144.474609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5176.261719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5208.048828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5239.835938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5279.044922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5342.423828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5381.287109 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5442.46875 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5505.847656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5569.324219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5632.703125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5696.179688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5759.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5798.767578 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5830.554688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5914.34375 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5946.130859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6043.542969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6105.066406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6168.542969 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6196.326172 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6257.605469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6320.984375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6352.771484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6404.871094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6468.25 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6529.529297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6593.005859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6645.105469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6708.484375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6769.666016 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6808.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6842.566406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6874.353516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6915.466797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6976.746094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7015.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7043.738281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7104.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7136.707031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7164.490234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.589844 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7248.376953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7311.853516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7373.376953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7412.585938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7474.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7513.472656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7610.884766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7638.667969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7702.046875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7729.830078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7781.929688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7821.138672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7848.921875 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pafa2894bef">
+  <clipPath id="p981ea6b935">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -40,23 +40,23 @@ z
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 292.711764 308.04375 
-L 292.711764 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 292.132019 308.04375 
+L 292.132019 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mac66181283" d="M 0 0 
+       <path id="mfe236cacda" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mac66181283" x="292.711764" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfe236cacda" x="292.132019" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(283.911764 322.642188) scale(0.1 -0.1)">
+      <g transform="translate(283.332019 322.642188) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -134,18 +134,18 @@ z
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 450.890649 308.04375 
-L 450.890649 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 449.712908 308.04375 
+L 449.712908 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mac66181283" x="450.890649" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfe236cacda" x="449.712908" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(442.090649 322.642188) scale(0.1 -0.1)">
+      <g transform="translate(440.912908 322.642188) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -175,246 +175,246 @@ z
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 182.149468 308.04375 
-L 182.149468 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 181.987704 308.04375 
+L 181.987704 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m8657cbe0de" d="M 0 0 
+       <path id="mb0940069d1" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m8657cbe0de" x="182.149468" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="181.987704" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 210.003387 308.04375 
-L 210.003387 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 209.736321 308.04375 
+L 209.736321 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m8657cbe0de" x="210.003387" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="209.736321" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 229.766057 308.04375 
-L 229.766057 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 229.424278 308.04375 
+L 229.424278 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m8657cbe0de" x="229.766057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="229.424278" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 245.095175 308.04375 
-L 245.095175 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 244.695444 308.04375 
+L 244.695444 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m8657cbe0de" x="245.095175" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="244.695444" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
-      <path d="M 257.619976 308.04375 
-L 257.619976 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 257.172895 308.04375 
+L 257.172895 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m8657cbe0de" x="257.619976" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="257.172895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_15">
-      <path d="M 268.209544 308.04375 
-L 268.209544 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 267.72243 308.04375 
+L 267.72243 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m8657cbe0de" x="268.209544" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="267.72243" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_17">
-      <path d="M 277.382646 308.04375 
-L 277.382646 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 276.860853 308.04375 
+L 276.860853 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m8657cbe0de" x="277.382646" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="276.860853" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_19">
-      <path d="M 285.473895 308.04375 
-L 285.473895 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 284.921513 308.04375 
+L 284.921513 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m8657cbe0de" x="285.473895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="284.921513" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_21">
-      <path d="M 340.328353 308.04375 
-L 340.328353 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 339.568593 308.04375 
+L 339.568593 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m8657cbe0de" x="340.328353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="339.568593" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_23">
-      <path d="M 368.182272 308.04375 
-L 368.182272 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 367.31721 308.04375 
+L 367.31721 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m8657cbe0de" x="368.182272" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="367.31721" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_25">
-      <path d="M 387.944942 308.04375 
-L 387.944942 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 387.005168 308.04375 
+L 387.005168 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m8657cbe0de" x="387.944942" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="387.005168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_27">
-      <path d="M 403.27406 308.04375 
-L 403.27406 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 402.276334 308.04375 
+L 402.276334 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m8657cbe0de" x="403.27406" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="402.276334" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_29">
-      <path d="M 415.798861 308.04375 
-L 415.798861 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 414.753785 308.04375 
+L 414.753785 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m8657cbe0de" x="415.798861" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="414.753785" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_31">
-      <path d="M 426.38843 308.04375 
-L 426.38843 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 425.30332 308.04375 
+L 425.30332 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m8657cbe0de" x="426.38843" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="425.30332" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_33">
-      <path d="M 435.561531 308.04375 
-L 435.561531 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 434.441742 308.04375 
+L 434.441742 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m8657cbe0de" x="435.561531" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="434.441742" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_35">
-      <path d="M 443.65278 308.04375 
-L 443.65278 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 442.502402 308.04375 
+L 442.502402 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m8657cbe0de" x="443.65278" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="442.502402" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_37">
-      <path d="M 498.507238 308.04375 
-L 498.507238 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 497.149483 308.04375 
+L 497.149483 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m8657cbe0de" x="498.507238" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="497.149483" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_39">
-      <path d="M 526.361157 308.04375 
-L 526.361157 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 524.8981 308.04375 
+L 524.8981 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m8657cbe0de" x="526.361157" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="524.8981" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
      <g id="line2d_41">
-      <path d="M 546.123827 308.04375 
-L 546.123827 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 544.586057 308.04375 
+L 544.586057 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m8657cbe0de" x="546.123827" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="544.586057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_22">
      <g id="line2d_43">
-      <path d="M 561.452945 308.04375 
-L 561.452945 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 559.857223 308.04375 
+L 559.857223 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m8657cbe0de" x="561.452945" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb0940069d1" x="559.857223" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1016,12 +1016,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m8260cffff1" d="M 0 0 
+       <path id="ma42deca3be" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8260cffff1" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma42deca3be" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1093,7 +1093,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m8260cffff1" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma42deca3be" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1160,7 +1160,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m8260cffff1" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma42deca3be" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1216,7 +1216,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m8260cffff1" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma42deca3be" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1263,7 +1263,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m8260cffff1" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma42deca3be" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1376,7 +1376,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m8260cffff1" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma42deca3be" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1392,7 +1392,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m8260cffff1" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma42deca3be" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1439,7 +1439,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m8260cffff1" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma42deca3be" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1461,48 +1461,48 @@ z
    </g>
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
-L 154.689587 296.619375 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 154.631635 296.619375 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
-L 161.205974 263.978304 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 161.123387 263.978304 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
-L 200.830675 231.337232 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 200.598286 231.337232 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
-L 208.626886 198.696161 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 208.365024 198.696161 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
-L 213.069162 166.055089 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+L 214.058201 166.055089 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
-L 240.46049 133.414018 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 240.815684 133.414018 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
-L 249.06205 100.772946 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 248.956282 100.772946 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
-L 286.244503 68.131875 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 286.395117 68.131875 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
-    <path d="M 542.08563 308.04375 
-L 542.08563 56.7075 
-" clip-path="url(#p2ce6614ca1)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+    <path d="M 542.173014 308.04375 
+L 542.173014 56.7075 
+" clip-path="url(#pd857e3ea02)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1526,7 +1526,7 @@ L 565.2 56.7075
    </g>
    <g id="text_12">
     <!-- 134 -->
-    <g style="fill: #17becf" transform="translate(158.041286 298.964844) scale(0.085 -0.085)">
+    <g style="fill: #17becf" transform="translate(157.970663 298.964844) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
@@ -1534,7 +1534,7 @@ L 565.2 56.7075
    </g>
    <g id="text_13">
     <!-- 147 -->
-    <g style="fill: #e377c2" transform="translate(164.557674 266.323772) scale(0.085 -0.085)">
+    <g style="fill: #e377c2" transform="translate(164.462416 266.323772) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1554,7 +1554,7 @@ z
    </g>
    <g id="text_14">
     <!-- 263 -->
-    <g style="fill: #8c564b" transform="translate(204.182374 233.682701) scale(0.085 -0.085)">
+    <g style="fill: #8c564b" transform="translate(203.937315 233.682701) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -1618,7 +1618,7 @@ z
    </g>
    <g id="text_15">
     <!-- 294 -->
-    <g style="fill: #bcbd22" transform="translate(211.978586 201.041629) scale(0.085 -0.085)">
+    <g style="fill: #bcbd22" transform="translate(211.704053 201.041629) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1657,8 +1657,8 @@ z
     </g>
    </g>
    <g id="text_16">
-    <!-- 314 -->
-    <g style="fill: #d62728" transform="translate(216.420862 168.400558) scale(0.085 -0.085)">
+    <!-- 320 -->
+    <g style="fill: #d62728" transform="translate(217.39723 168.400558) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-Bold-33" d="M 2981 2516 
 Q 3453 2394 3698 2092 
@@ -1692,56 +1692,66 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
+      <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
+      <path id="DejaVuSans-Bold-30" d="M 2944 2338 
+Q 2944 3213 2780 3570 
+Q 2616 3928 2228 3928 
+Q 1841 3928 1675 3570 
+Q 1509 3213 1509 2338 
+Q 1509 1453 1675 1090 
+Q 1841 728 2228 728 
+Q 2613 728 2778 1090 
+Q 2944 1453 2944 2338 
 z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
+M 4147 2328 
+Q 4147 1169 3647 539 
+Q 3147 -91 2228 -91 
+Q 1306 -91 806 539 
+Q 306 1169 306 2328 
+Q 306 3491 806 4120 
+Q 1306 4750 2228 4750 
+Q 3147 4750 3647 4120 
+Q 4147 3491 4147 2328 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_17">
-    <!-- 467 -->
-    <g style="fill: #1f77b4" transform="translate(243.812189 135.759487) scale(0.085 -0.085)">
+    <!-- 472 -->
+    <g style="fill: #1f77b4" transform="translate(244.154712 135.759487) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_18">
-    <!-- 530 -->
-    <g style="fill: #2ca02c" transform="translate(252.41375 103.118415) scale(0.085 -0.085)">
+    <!-- 532 -->
+    <g style="fill: #2ca02c" transform="translate(252.295311 103.118415) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1771,20 +1781,20 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_19">
-    <!-- 910 -->
-    <g style="fill: #9467bd" transform="translate(289.596202 70.477344) scale(0.085 -0.085)">
+    <!-- 920 -->
+    <g style="fill: #9467bd" transform="translate(289.734146 70.477344) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- memcpy ≈ 38 GB/s  -->
-    <g style="fill: #777777" transform="translate(540.42188 128.870982) rotate(-90) scale(0.08 -0.08)">
+    <!-- memcpy ≈ 39 GB/s  -->
+    <g style="fill: #777777" transform="translate(540.509264 128.870982) rotate(-90) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-79" d="M 2059 -325 
 Q 1816 -950 1584 -1140 
@@ -1844,45 +1854,6 @@ Q 3834 2663 4098 2780
 Q 4363 2897 4684 3163 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-6d"/>
      <use xlink:href="#DejaVuSans-65" transform="translate(97.412109 0)"/>
@@ -1894,7 +1865,7 @@ z
      <use xlink:href="#DejaVuSans-2248" transform="translate(465.771484 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(549.560547 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(581.347656 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(644.970703 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(644.970703 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(708.59375 0)"/>
      <use xlink:href="#DejaVuSans-47" transform="translate(740.380859 0)"/>
      <use xlink:href="#DejaVuSans-42" transform="translate(817.871094 0)"/>
@@ -1905,7 +1876,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m1ce194db11" d="M 0 3 
+     <path id="m42ea335358" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1917,13 +1888,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p2ce6614ca1)">
-     <use xlink:href="#m1ce194db11" x="154.689587" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#pd857e3ea02)">
+     <use xlink:href="#m42ea335358" x="154.631635" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="mdb1c261f3d" d="M 0 3 
+     <path id="m0f5e434447" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1935,13 +1906,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p2ce6614ca1)">
-     <use xlink:href="#mdb1c261f3d" x="161.205974" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#pd857e3ea02)">
+     <use xlink:href="#m0f5e434447" x="161.123387" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m4351a9851e" d="M 0 3 
+     <path id="m1252583ce4" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1953,13 +1924,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p2ce6614ca1)">
-     <use xlink:href="#m4351a9851e" x="200.830675" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#pd857e3ea02)">
+     <use xlink:href="#m1252583ce4" x="200.598286" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m62ba8f169f" d="M 0 3 
+     <path id="m02fc5954f0" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1971,13 +1942,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p2ce6614ca1)">
-     <use xlink:href="#m62ba8f169f" x="208.626886" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#pd857e3ea02)">
+     <use xlink:href="#m02fc5954f0" x="208.365024" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m7a5be9d635" d="M 0 5 
+     <path id="maa9b8815ec" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1989,13 +1960,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p2ce6614ca1)">
-     <use xlink:href="#m7a5be9d635" x="213.069162" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#pd857e3ea02)">
+     <use xlink:href="#maa9b8815ec" x="214.058201" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m94c5366b72" d="M 0 3 
+     <path id="m6502e7a4ef" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2007,13 +1978,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p2ce6614ca1)">
-     <use xlink:href="#m94c5366b72" x="240.46049" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pd857e3ea02)">
+     <use xlink:href="#m6502e7a4ef" x="240.815684" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m6a2d0d34c5" d="M 0 3 
+     <path id="m513ffa9634" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2025,13 +1996,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p2ce6614ca1)">
-     <use xlink:href="#m6a2d0d34c5" x="249.06205" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#pd857e3ea02)">
+     <use xlink:href="#m513ffa9634" x="248.956282" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m7f1c79b48b" d="M 0 3 
+     <path id="mc649998707" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2043,8 +2014,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p2ce6614ca1)">
-     <use xlink:href="#m7f1c79b48b" x="286.244503" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#pd857e3ea02)">
+     <use xlink:href="#mc649998707" x="286.395117" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2508,6 +2479,20 @@ L 588 0
 L 588 4666 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-Bold-2f" d="M 1644 4666 
 L 2338 4666 
 L 691 -594 
@@ -2573,28 +2558,6 @@ Q 1809 3988 1650 3781
 Q 1491 3575 1491 3169 
 Q 1491 2759 1650 2554 
 Q 1809 2350 2125 2350 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-32" d="M 1844 884 
-L 3897 884 
-L 3897 0 
-L 506 0 
-L 506 884 
-L 2209 2388 
-Q 2438 2594 2547 2791 
-Q 2656 2988 2656 3200 
-Q 2656 3528 2436 3728 
-Q 2216 3928 1850 3928 
-Q 1569 3928 1234 3808 
-Q 900 3688 519 3450 
-L 519 4475 
-Q 925 4609 1322 4679 
-Q 1719 4750 2100 4750 
-Q 2938 4750 3402 4381 
-Q 3866 4013 3866 3353 
-Q 3866 2972 3669 2642 
-Q 3472 2313 2841 1759 
-L 1844 884 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Bold-2b" d="M 3053 4013 
@@ -2752,9 +2715,48 @@ z
    </g>
   </g>
   <g id="text_22">
-   <!-- 2026-07-08T17:40:34Z  ·  Linux chungus2 x86_64  ·  commit da9d9c0e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(7.847969 358.2) scale(0.07 -0.07)">
+   <!-- 2026-07-18T17:07:56Z  ·  Linux chungus2 x86_64  ·  commit 3f5fffbd  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(11.369297 358.2) scale(0.07 -0.07)">
     <defs>
+     <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -2832,17 +2834,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2882,109 +2884,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.630859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3260.253906 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3323.730469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3387.353516 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3442.333984 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3567.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.267578 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3631.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3662.841797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3694.628906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3726.416016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3815.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3877.001953 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4003.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4042.720703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4103.902344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4224.605469 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4265.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4299.410156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4388.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4449.996094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4576.998047 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4610.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4733.492188 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4892.525391 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4987.935547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5024.019531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5062.882812 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5181.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.273438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5245.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5276.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5308.634766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5340.421875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5379.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5443.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5481.873047 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5543.054688 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5796.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5860.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5899.353516 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5931.140625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6014.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6269.128906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6296.912109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6358.191406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6421.570312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6453.357422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6505.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6568.835938 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6693.591797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6745.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6809.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6870.251953 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6909.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6943.152344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6974.939453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7016.052734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7077.332031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7116.541016 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7144.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7237.292969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7317.175781 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7473.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7574.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7614.058594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7711.470703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7739.253906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7802.632812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7830.416016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7882.515625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7921.724609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7949.507812 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3269.53125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3304.736328 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3339.941406 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3403.417969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3466.894531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3498.681641 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3530.46875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3562.255859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3594.042969 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3625.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3653.613281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3715.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3776.416016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3839.794922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3903.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3942.134766 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4003.316406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4062.496094 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4124.019531 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4165.132812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4198.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4226.607422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4288.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4349.410156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4412.789062 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4476.412109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4510.103516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4569.283203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4632.90625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4664.693359 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4728.316406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4791.939453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4823.726562 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4887.349609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4923.433594 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4962.296875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5017.277344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5080.900391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5112.6875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5144.474609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5176.261719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5208.048828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5239.835938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5279.044922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5342.423828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5381.287109 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5442.46875 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5505.847656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5569.324219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5632.703125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5696.179688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5759.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5798.767578 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5830.554688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5914.34375 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5946.130859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6043.542969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6105.066406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6168.542969 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6196.326172 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6257.605469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6320.984375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6352.771484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6404.871094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6468.25 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6529.529297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6593.005859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6645.105469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6708.484375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6769.666016 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6808.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6842.566406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6874.353516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6915.466797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6976.746094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7015.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7043.738281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7104.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7136.707031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7164.490234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.589844 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7248.376953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7311.853516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7373.376953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7412.585938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7474.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7513.472656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7610.884766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7638.667969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7702.046875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7729.830078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7781.929688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7821.138672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7848.921875 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p2ce6614ca1">
+  <clipPath id="pd857e3ea02">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/results/decode_density.json
+++ b/bench/results/decode_density.json
@@ -1,6491 +1,6491 @@
 {
- "meta": {
-  "date": "2026-07-08T17:40:34Z",
-  "machine": "Linux chungus2 x86_64",
-  "git_commit": "da9d9c0e",
-  "toolchain": "leanprover/lean4:v4.30.0-rc2",
-  "experiment": "decode-density: fixed encoder (libdeflate levels + zopfli, level 0 = zopfli), ratio = encoder compression ratio, decompress_mbps = each decoder on identical streams; compressor field holds the decoder name"
- },
- "results": [
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4217525,
-   "ratio": 0.4138,
-   "compress_mbps": null,
-   "decompress_mbps": 192.06
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 12,
-   "out_size": 3679105,
-   "ratio": 0.361,
-   "compress_mbps": null,
-   "decompress_mbps": 221.08
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 3989875,
-   "ratio": 0.3915,
-   "compress_mbps": null,
-   "decompress_mbps": 202.07
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3859436,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 205.34
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3810354,
-   "ratio": 0.3738,
-   "compress_mbps": null,
-   "decompress_mbps": 203.21
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 0,
-   "out_size": 3673380,
-   "ratio": 0.3604,
-   "compress_mbps": null,
-   "decompress_mbps": 214.43
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20192961,
-   "ratio": 0.3942,
-   "compress_mbps": null,
-   "decompress_mbps": 231.18
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 12,
-   "out_size": 18241312,
-   "ratio": 0.3561,
-   "compress_mbps": null,
-   "decompress_mbps": 231.96
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19234937,
-   "ratio": 0.3755,
-   "compress_mbps": null,
-   "decompress_mbps": 224.51
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 18805391,
-   "ratio": 0.3671,
-   "compress_mbps": null,
-   "decompress_mbps": 232.7
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 18713659,
-   "ratio": 0.3654,
-   "compress_mbps": null,
-   "decompress_mbps": 234.15
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 0,
-   "out_size": 18317341,
-   "ratio": 0.3576,
-   "compress_mbps": null,
-   "decompress_mbps": 238.76
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3740775,
-   "ratio": 0.3752,
-   "compress_mbps": null,
-   "decompress_mbps": 230.41
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 12,
-   "out_size": 3447985,
-   "ratio": 0.3458,
-   "compress_mbps": null,
-   "decompress_mbps": 235.41
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3672389,
-   "ratio": 0.3683,
-   "compress_mbps": null,
-   "decompress_mbps": 225.26
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3648644,
-   "ratio": 0.3659,
-   "compress_mbps": null,
-   "decompress_mbps": 232.08
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3625176,
-   "ratio": 0.3636,
-   "compress_mbps": null,
-   "decompress_mbps": 233
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 0,
-   "out_size": 3450225,
-   "ratio": 0.346,
-   "compress_mbps": null,
-   "decompress_mbps": 233.65
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3837577,
-   "ratio": 0.1144,
-   "compress_mbps": null,
-   "decompress_mbps": 580.78
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 12,
-   "out_size": 2748273,
-   "ratio": 0.0819,
-   "compress_mbps": null,
-   "decompress_mbps": 784.5
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3599455,
-   "ratio": 0.1073,
-   "compress_mbps": null,
-   "decompress_mbps": 599.89
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3091741,
-   "ratio": 0.0921,
-   "compress_mbps": null,
-   "decompress_mbps": 670.78
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2925243,
-   "ratio": 0.0872,
-   "compress_mbps": null,
-   "decompress_mbps": 741.92
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 0,
-   "out_size": 2740598,
-   "ratio": 0.0817,
-   "compress_mbps": null,
-   "decompress_mbps": 749.65
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3275124,
-   "ratio": 0.5324,
-   "compress_mbps": null,
-   "decompress_mbps": 168.31
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 12,
-   "out_size": 2994086,
-   "ratio": 0.4867,
-   "compress_mbps": null,
-   "decompress_mbps": 160.64
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3137061,
-   "ratio": 0.5099,
-   "compress_mbps": null,
-   "decompress_mbps": 155.39
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3072378,
-   "ratio": 0.4994,
-   "compress_mbps": null,
-   "decompress_mbps": 166
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3066968,
-   "ratio": 0.4985,
-   "compress_mbps": null,
-   "decompress_mbps": 169.75
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 0,
-   "out_size": 2992113,
-   "ratio": 0.4863,
-   "compress_mbps": null,
-   "decompress_mbps": 160.99
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3868663,
-   "ratio": 0.3836,
-   "compress_mbps": null,
-   "decompress_mbps": 253.4
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 12,
-   "out_size": 3608138,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 269.43
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3818964,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 262.57
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3660266,
-   "ratio": 0.3629,
-   "compress_mbps": null,
-   "decompress_mbps": 269.49
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3654860,
-   "ratio": 0.3624,
-   "compress_mbps": null,
-   "decompress_mbps": 270.57
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 0,
-   "out_size": 3607217,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 285.93
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2197055,
-   "ratio": 0.3315,
-   "compress_mbps": null,
-   "decompress_mbps": 227.09
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 12,
-   "out_size": 1696488,
-   "ratio": 0.256,
-   "compress_mbps": null,
-   "decompress_mbps": 283.58
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2021047,
-   "ratio": 0.305,
-   "compress_mbps": null,
-   "decompress_mbps": 256.09
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1876257,
-   "ratio": 0.2831,
-   "compress_mbps": null,
-   "decompress_mbps": 262.67
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1806374,
-   "ratio": 0.2726,
-   "compress_mbps": null,
-   "decompress_mbps": 260.9
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 0,
-   "out_size": 1691994,
-   "ratio": 0.2553,
-   "compress_mbps": null,
-   "decompress_mbps": 285.32
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 5866517,
-   "ratio": 0.2715,
-   "compress_mbps": null,
-   "decompress_mbps": 306.97
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 12,
-   "out_size": 5118130,
-   "ratio": 0.2369,
-   "compress_mbps": null,
-   "decompress_mbps": 324.28
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5605878,
-   "ratio": 0.2595,
-   "compress_mbps": null,
-   "decompress_mbps": 316.81
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5337149,
-   "ratio": 0.247,
-   "compress_mbps": null,
-   "decompress_mbps": 323.75
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5270405,
-   "ratio": 0.2439,
-   "compress_mbps": null,
-   "decompress_mbps": 328.64
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 0,
-   "out_size": 5107588,
-   "ratio": 0.2364,
-   "compress_mbps": null,
-   "decompress_mbps": 344.93
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5575128,
-   "ratio": 0.7688,
-   "compress_mbps": null,
-   "decompress_mbps": 182.22
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 12,
-   "out_size": 5250745,
-   "ratio": 0.724,
-   "compress_mbps": null,
-   "decompress_mbps": 188.68
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5397999,
-   "ratio": 0.7444,
-   "compress_mbps": null,
-   "decompress_mbps": 187.28
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5335405,
-   "ratio": 0.7357,
-   "compress_mbps": null,
-   "decompress_mbps": 186.08
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5323197,
-   "ratio": 0.734,
-   "compress_mbps": null,
-   "decompress_mbps": 188.75
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 0,
-   "out_size": 5242394,
-   "ratio": 0.7229,
-   "compress_mbps": null,
-   "decompress_mbps": 186.36
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 13550569,
-   "ratio": 0.3268,
-   "compress_mbps": null,
-   "decompress_mbps": 225.06
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 12,
-   "out_size": 11520871,
-   "ratio": 0.2779,
-   "compress_mbps": null,
-   "decompress_mbps": 256.66
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12839361,
-   "ratio": 0.3097,
-   "compress_mbps": null,
-   "decompress_mbps": 242.54
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12140474,
-   "ratio": 0.2928,
-   "compress_mbps": null,
-   "decompress_mbps": 247.96
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 11882496,
-   "ratio": 0.2866,
-   "compress_mbps": null,
-   "decompress_mbps": 250.83
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 0,
-   "out_size": 11518290,
-   "ratio": 0.2778,
-   "compress_mbps": null,
-   "decompress_mbps": 256.89
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6293390,
-   "ratio": 0.7426,
-   "compress_mbps": null,
-   "decompress_mbps": 166.3
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 12,
-   "out_size": 5747146,
-   "ratio": 0.6782,
-   "compress_mbps": null,
-   "decompress_mbps": 140.99
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6058381,
-   "ratio": 0.7149,
-   "compress_mbps": null,
-   "decompress_mbps": 144.96
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5998438,
-   "ratio": 0.7078,
-   "compress_mbps": null,
-   "decompress_mbps": 152.03
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5986859,
-   "ratio": 0.7065,
-   "compress_mbps": null,
-   "decompress_mbps": 149.13
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 0,
-   "out_size": 5744697,
-   "ratio": 0.6779,
-   "compress_mbps": null,
-   "decompress_mbps": 136.8
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 887708,
-   "ratio": 0.1661,
-   "compress_mbps": null,
-   "decompress_mbps": 440.5
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 12,
-   "out_size": 629349,
-   "ratio": 0.1177,
-   "compress_mbps": null,
-   "decompress_mbps": 615.59
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 793388,
-   "ratio": 0.1484,
-   "compress_mbps": null,
-   "decompress_mbps": 507.61
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 684405,
-   "ratio": 0.128,
-   "compress_mbps": null,
-   "decompress_mbps": 581.96
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 649494,
-   "ratio": 0.1215,
-   "compress_mbps": null,
-   "decompress_mbps": 607.22
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 0,
-   "out_size": 627169,
-   "ratio": 0.1173,
-   "compress_mbps": null,
-   "decompress_mbps": 618.22
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4217525,
-   "ratio": 0.4138,
-   "compress_mbps": null,
-   "decompress_mbps": 110.32
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 12,
-   "out_size": 3679105,
-   "ratio": 0.361,
-   "compress_mbps": null,
-   "decompress_mbps": 121.35
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 3989875,
-   "ratio": 0.3915,
-   "compress_mbps": null,
-   "decompress_mbps": 135.89
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3859436,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 135.35
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3810354,
-   "ratio": 0.3738,
-   "compress_mbps": null,
-   "decompress_mbps": 122.04
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 0,
-   "out_size": 3673380,
-   "ratio": 0.3604,
-   "compress_mbps": null,
-   "decompress_mbps": 129.36
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20192961,
-   "ratio": 0.3942,
-   "compress_mbps": null,
-   "decompress_mbps": 157.13
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 12,
-   "out_size": 18241312,
-   "ratio": 0.3561,
-   "compress_mbps": null,
-   "decompress_mbps": 151.8
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19234937,
-   "ratio": 0.3755,
-   "compress_mbps": null,
-   "decompress_mbps": 155.7
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 18805391,
-   "ratio": 0.3671,
-   "compress_mbps": null,
-   "decompress_mbps": 184.47
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 18713659,
-   "ratio": 0.3654,
-   "compress_mbps": null,
-   "decompress_mbps": 161.51
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 0,
-   "out_size": 18317341,
-   "ratio": 0.3576,
-   "compress_mbps": null,
-   "decompress_mbps": 179.47
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3740775,
-   "ratio": 0.3752,
-   "compress_mbps": null,
-   "decompress_mbps": 139.97
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 12,
-   "out_size": 3447985,
-   "ratio": 0.3458,
-   "compress_mbps": null,
-   "decompress_mbps": 140.17
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3672389,
-   "ratio": 0.3683,
-   "compress_mbps": null,
-   "decompress_mbps": 142.22
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3648644,
-   "ratio": 0.3659,
-   "compress_mbps": null,
-   "decompress_mbps": 135.12
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3625176,
-   "ratio": 0.3636,
-   "compress_mbps": null,
-   "decompress_mbps": 134.98
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 0,
-   "out_size": 3450225,
-   "ratio": 0.346,
-   "compress_mbps": null,
-   "decompress_mbps": 135.73
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3837577,
-   "ratio": 0.1144,
-   "compress_mbps": null,
-   "decompress_mbps": 247.01
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 12,
-   "out_size": 2748273,
-   "ratio": 0.0819,
-   "compress_mbps": null,
-   "decompress_mbps": 288.55
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3599455,
-   "ratio": 0.1073,
-   "compress_mbps": null,
-   "decompress_mbps": 285.59
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3091741,
-   "ratio": 0.0921,
-   "compress_mbps": null,
-   "decompress_mbps": 315.73
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2925243,
-   "ratio": 0.0872,
-   "compress_mbps": null,
-   "decompress_mbps": 325.56
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 0,
-   "out_size": 2740598,
-   "ratio": 0.0817,
-   "compress_mbps": null,
-   "decompress_mbps": 282.97
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3275124,
-   "ratio": 0.5324,
-   "compress_mbps": null,
-   "decompress_mbps": 103.44
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 12,
-   "out_size": 2994086,
-   "ratio": 0.4867,
-   "compress_mbps": null,
-   "decompress_mbps": 100.24
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3137061,
-   "ratio": 0.5099,
-   "compress_mbps": null,
-   "decompress_mbps": 111.59
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3072378,
-   "ratio": 0.4994,
-   "compress_mbps": null,
-   "decompress_mbps": 112.08
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3066968,
-   "ratio": 0.4985,
-   "compress_mbps": null,
-   "decompress_mbps": 100.54
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 0,
-   "out_size": 2992113,
-   "ratio": 0.4863,
-   "compress_mbps": null,
-   "decompress_mbps": 86.65
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3868663,
-   "ratio": 0.3836,
-   "compress_mbps": null,
-   "decompress_mbps": 147.38
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 12,
-   "out_size": 3608138,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 179.06
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3818964,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 162.32
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3660266,
-   "ratio": 0.3629,
-   "compress_mbps": null,
-   "decompress_mbps": 176.1
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3654860,
-   "ratio": 0.3624,
-   "compress_mbps": null,
-   "decompress_mbps": 161.28
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 0,
-   "out_size": 3607217,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 178.95
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2197055,
-   "ratio": 0.3315,
-   "compress_mbps": null,
-   "decompress_mbps": 116.87
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 12,
-   "out_size": 1696488,
-   "ratio": 0.256,
-   "compress_mbps": null,
-   "decompress_mbps": 143.07
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2021047,
-   "ratio": 0.305,
-   "compress_mbps": null,
-   "decompress_mbps": 147.34
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1876257,
-   "ratio": 0.2831,
-   "compress_mbps": null,
-   "decompress_mbps": 143.54
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1806374,
-   "ratio": 0.2726,
-   "compress_mbps": null,
-   "decompress_mbps": 144.39
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 0,
-   "out_size": 1691994,
-   "ratio": 0.2553,
-   "compress_mbps": null,
-   "decompress_mbps": 107.62
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 5866517,
-   "ratio": 0.2715,
-   "compress_mbps": null,
-   "decompress_mbps": 171.56
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 12,
-   "out_size": 5118130,
-   "ratio": 0.2369,
-   "compress_mbps": null,
-   "decompress_mbps": 169.28
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5605878,
-   "ratio": 0.2595,
-   "compress_mbps": null,
-   "decompress_mbps": 157
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5337149,
-   "ratio": 0.247,
-   "compress_mbps": null,
-   "decompress_mbps": 167.34
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5270405,
-   "ratio": 0.2439,
-   "compress_mbps": null,
-   "decompress_mbps": 175.15
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 0,
-   "out_size": 5107588,
-   "ratio": 0.2364,
-   "compress_mbps": null,
-   "decompress_mbps": 190.12
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5575128,
-   "ratio": 0.7688,
-   "compress_mbps": null,
-   "decompress_mbps": 99.87
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 12,
-   "out_size": 5250745,
-   "ratio": 0.724,
-   "compress_mbps": null,
-   "decompress_mbps": 98.34
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5397999,
-   "ratio": 0.7444,
-   "compress_mbps": null,
-   "decompress_mbps": 104.89
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5335405,
-   "ratio": 0.7357,
-   "compress_mbps": null,
-   "decompress_mbps": 100.16
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5323197,
-   "ratio": 0.734,
-   "compress_mbps": null,
-   "decompress_mbps": 107.95
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 0,
-   "out_size": 5242394,
-   "ratio": 0.7229,
-   "compress_mbps": null,
-   "decompress_mbps": 112.69
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 13550569,
-   "ratio": 0.3268,
-   "compress_mbps": null,
-   "decompress_mbps": 141.66
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 12,
-   "out_size": 11520871,
-   "ratio": 0.2779,
-   "compress_mbps": null,
-   "decompress_mbps": 158.68
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12839361,
-   "ratio": 0.3097,
-   "compress_mbps": null,
-   "decompress_mbps": 148.82
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12140474,
-   "ratio": 0.2928,
-   "compress_mbps": null,
-   "decompress_mbps": 154.56
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 11882496,
-   "ratio": 0.2866,
-   "compress_mbps": null,
-   "decompress_mbps": 162.66
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 0,
-   "out_size": 11518290,
-   "ratio": 0.2778,
-   "compress_mbps": null,
-   "decompress_mbps": 145.3
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6293390,
-   "ratio": 0.7426,
-   "compress_mbps": null,
-   "decompress_mbps": 100.14
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 12,
-   "out_size": 5747146,
-   "ratio": 0.6782,
-   "compress_mbps": null,
-   "decompress_mbps": 107.98
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6058381,
-   "ratio": 0.7149,
-   "compress_mbps": null,
-   "decompress_mbps": 102.33
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5998438,
-   "ratio": 0.7078,
-   "compress_mbps": null,
-   "decompress_mbps": 94.73
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5986859,
-   "ratio": 0.7065,
-   "compress_mbps": null,
-   "decompress_mbps": 105.01
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 0,
-   "out_size": 5744697,
-   "ratio": 0.6779,
-   "compress_mbps": null,
-   "decompress_mbps": 96.26
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 887708,
-   "ratio": 0.1661,
-   "compress_mbps": null,
-   "decompress_mbps": 183.84
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 12,
-   "out_size": 629349,
-   "ratio": 0.1177,
-   "compress_mbps": null,
-   "decompress_mbps": 269.82
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 793388,
-   "ratio": 0.1484,
-   "compress_mbps": null,
-   "decompress_mbps": 181.01
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 684405,
-   "ratio": 0.128,
-   "compress_mbps": null,
-   "decompress_mbps": 241.09
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 649494,
-   "ratio": 0.1215,
-   "compress_mbps": null,
-   "decompress_mbps": 241.61
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 0,
-   "out_size": 627169,
-   "ratio": 0.1173,
-   "compress_mbps": null,
-   "decompress_mbps": 150.18
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4217525,
-   "ratio": 0.4138,
-   "compress_mbps": null,
-   "decompress_mbps": 221.52
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 12,
-   "out_size": 3679105,
-   "ratio": 0.361,
-   "compress_mbps": null,
-   "decompress_mbps": 279.11
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 3989875,
-   "ratio": 0.3915,
-   "compress_mbps": null,
-   "decompress_mbps": 271.68
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3859436,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 268.18
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3810354,
-   "ratio": 0.3738,
-   "compress_mbps": null,
-   "decompress_mbps": 261.3
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 0,
-   "out_size": 3673380,
-   "ratio": 0.3604,
-   "compress_mbps": null,
-   "decompress_mbps": 280.48
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20192961,
-   "ratio": 0.3942,
-   "compress_mbps": null,
-   "decompress_mbps": 235.66
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 12,
-   "out_size": 18241312,
-   "ratio": 0.3561,
-   "compress_mbps": null,
-   "decompress_mbps": 217.47
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19234937,
-   "ratio": 0.3755,
-   "compress_mbps": null,
-   "decompress_mbps": 217.25
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 18805391,
-   "ratio": 0.3671,
-   "compress_mbps": null,
-   "decompress_mbps": 227.9
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 18713659,
-   "ratio": 0.3654,
-   "compress_mbps": null,
-   "decompress_mbps": 231.3
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 0,
-   "out_size": 18317341,
-   "ratio": 0.3576,
-   "compress_mbps": null,
-   "decompress_mbps": 252.69
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3740775,
-   "ratio": 0.3752,
-   "compress_mbps": null,
-   "decompress_mbps": 231.68
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 12,
-   "out_size": 3447985,
-   "ratio": 0.3458,
-   "compress_mbps": null,
-   "decompress_mbps": 267.47
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3672389,
-   "ratio": 0.3683,
-   "compress_mbps": null,
-   "decompress_mbps": 260.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3648644,
-   "ratio": 0.3659,
-   "compress_mbps": null,
-   "decompress_mbps": 267.23
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3625176,
-   "ratio": 0.3636,
-   "compress_mbps": null,
-   "decompress_mbps": 269.92
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 0,
-   "out_size": 3450225,
-   "ratio": 0.346,
-   "compress_mbps": null,
-   "decompress_mbps": 250.54
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3837577,
-   "ratio": 0.1144,
-   "compress_mbps": null,
-   "decompress_mbps": 681.98
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 12,
-   "out_size": 2748273,
-   "ratio": 0.0819,
-   "compress_mbps": null,
-   "decompress_mbps": 850.06
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3599455,
-   "ratio": 0.1073,
-   "compress_mbps": null,
-   "decompress_mbps": 740.59
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3091741,
-   "ratio": 0.0921,
-   "compress_mbps": null,
-   "decompress_mbps": 837.02
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2925243,
-   "ratio": 0.0872,
-   "compress_mbps": null,
-   "decompress_mbps": 898.09
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 0,
-   "out_size": 2740598,
-   "ratio": 0.0817,
-   "compress_mbps": null,
-   "decompress_mbps": 929.1
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3275124,
-   "ratio": 0.5324,
-   "compress_mbps": null,
-   "decompress_mbps": 175.52
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 12,
-   "out_size": 2994086,
-   "ratio": 0.4867,
-   "compress_mbps": null,
-   "decompress_mbps": 180.02
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3137061,
-   "ratio": 0.5099,
-   "compress_mbps": null,
-   "decompress_mbps": 176.42
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3072378,
-   "ratio": 0.4994,
-   "compress_mbps": null,
-   "decompress_mbps": 184.48
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3066968,
-   "ratio": 0.4985,
-   "compress_mbps": null,
-   "decompress_mbps": 187.36
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 0,
-   "out_size": 2992113,
-   "ratio": 0.4863,
-   "compress_mbps": null,
-   "decompress_mbps": 181.46
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3868663,
-   "ratio": 0.3836,
-   "compress_mbps": null,
-   "decompress_mbps": 253.03
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 12,
-   "out_size": 3608138,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 290.53
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3818964,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 282.62
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3660266,
-   "ratio": 0.3629,
-   "compress_mbps": null,
-   "decompress_mbps": 286.75
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3654860,
-   "ratio": 0.3624,
-   "compress_mbps": null,
-   "decompress_mbps": 287.31
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 0,
-   "out_size": 3607217,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 289.16
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2197055,
-   "ratio": 0.3315,
-   "compress_mbps": null,
-   "decompress_mbps": 286.4
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 12,
-   "out_size": 1696488,
-   "ratio": 0.256,
-   "compress_mbps": null,
-   "decompress_mbps": 374.93
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2021047,
-   "ratio": 0.305,
-   "compress_mbps": null,
-   "decompress_mbps": 352.79
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1876257,
-   "ratio": 0.2831,
-   "compress_mbps": null,
-   "decompress_mbps": 355.31
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1806374,
-   "ratio": 0.2726,
-   "compress_mbps": null,
-   "decompress_mbps": 347.95
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 0,
-   "out_size": 1691994,
-   "ratio": 0.2553,
-   "compress_mbps": null,
-   "decompress_mbps": 380.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 5866517,
-   "ratio": 0.2715,
-   "compress_mbps": null,
-   "decompress_mbps": 349.73
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 12,
-   "out_size": 5118130,
-   "ratio": 0.2369,
-   "compress_mbps": null,
-   "decompress_mbps": 329.93
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5605878,
-   "ratio": 0.2595,
-   "compress_mbps": null,
-   "decompress_mbps": 342.11
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5337149,
-   "ratio": 0.247,
-   "compress_mbps": null,
-   "decompress_mbps": 365.6
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5270405,
-   "ratio": 0.2439,
-   "compress_mbps": null,
-   "decompress_mbps": 369.05
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 0,
-   "out_size": 5107588,
-   "ratio": 0.2364,
-   "compress_mbps": null,
-   "decompress_mbps": 398.36
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5575128,
-   "ratio": 0.7688,
-   "compress_mbps": null,
-   "decompress_mbps": 159.66
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 12,
-   "out_size": 5250745,
-   "ratio": 0.724,
-   "compress_mbps": null,
-   "decompress_mbps": 174.01
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5397999,
-   "ratio": 0.7444,
-   "compress_mbps": null,
-   "decompress_mbps": 172.0
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5335405,
-   "ratio": 0.7357,
-   "compress_mbps": null,
-   "decompress_mbps": 173.41
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5323197,
-   "ratio": 0.734,
-   "compress_mbps": null,
-   "decompress_mbps": 175.23
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 0,
-   "out_size": 5242394,
-   "ratio": 0.7229,
-   "compress_mbps": null,
-   "decompress_mbps": 165.88
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 13550569,
-   "ratio": 0.3268,
-   "compress_mbps": null,
-   "decompress_mbps": 275.01
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 12,
-   "out_size": 11520871,
-   "ratio": 0.2779,
-   "compress_mbps": null,
-   "decompress_mbps": 330.5
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12839361,
-   "ratio": 0.3097,
-   "compress_mbps": null,
-   "decompress_mbps": 316.23
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12140474,
-   "ratio": 0.2928,
-   "compress_mbps": null,
-   "decompress_mbps": 326.18
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 11882496,
-   "ratio": 0.2866,
-   "compress_mbps": null,
-   "decompress_mbps": 328.09
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 0,
-   "out_size": 11518290,
-   "ratio": 0.2778,
-   "compress_mbps": null,
-   "decompress_mbps": 338.32
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6293390,
-   "ratio": 0.7426,
-   "compress_mbps": null,
-   "decompress_mbps": 150.88
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 12,
-   "out_size": 5747146,
-   "ratio": 0.6782,
-   "compress_mbps": null,
-   "decompress_mbps": 149.76
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6058381,
-   "ratio": 0.7149,
-   "compress_mbps": null,
-   "decompress_mbps": 143.82
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5998438,
-   "ratio": 0.7078,
-   "compress_mbps": null,
-   "decompress_mbps": 157.28
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5986859,
-   "ratio": 0.7065,
-   "compress_mbps": null,
-   "decompress_mbps": 154.91
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 0,
-   "out_size": 5744697,
-   "ratio": 0.6779,
-   "compress_mbps": null,
-   "decompress_mbps": 145.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 887708,
-   "ratio": 0.1661,
-   "compress_mbps": null,
-   "decompress_mbps": 507.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 12,
-   "out_size": 629349,
-   "ratio": 0.1177,
-   "compress_mbps": null,
-   "decompress_mbps": 667.01
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 793388,
-   "ratio": 0.1484,
-   "compress_mbps": null,
-   "decompress_mbps": 600.84
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 684405,
-   "ratio": 0.128,
-   "compress_mbps": null,
-   "decompress_mbps": 668.37
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 649494,
-   "ratio": 0.1215,
-   "compress_mbps": null,
-   "decompress_mbps": 685.14
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 0,
-   "out_size": 627169,
-   "ratio": 0.1173,
-   "compress_mbps": null,
-   "decompress_mbps": 710.32
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4217525,
-   "ratio": 0.4138,
-   "compress_mbps": null,
-   "decompress_mbps": 105.29
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 12,
-   "out_size": 3679105,
-   "ratio": 0.361,
-   "compress_mbps": null,
-   "decompress_mbps": 115.26
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 3989875,
-   "ratio": 0.3915,
-   "compress_mbps": null,
-   "decompress_mbps": 110.2
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3859436,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 111.7
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3810354,
-   "ratio": 0.3738,
-   "compress_mbps": null,
-   "decompress_mbps": 112.72
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 0,
-   "out_size": 3673380,
-   "ratio": 0.3604,
-   "compress_mbps": null,
-   "decompress_mbps": 110.97
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20192961,
-   "ratio": 0.3942,
-   "compress_mbps": null,
-   "decompress_mbps": 122.7
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 12,
-   "out_size": 18241312,
-   "ratio": 0.3561,
-   "compress_mbps": null,
-   "decompress_mbps": 116.84
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19234937,
-   "ratio": 0.3755,
-   "compress_mbps": null,
-   "decompress_mbps": 112.59
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 18805391,
-   "ratio": 0.3671,
-   "compress_mbps": null,
-   "decompress_mbps": 116.2
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 18713659,
-   "ratio": 0.3654,
-   "compress_mbps": null,
-   "decompress_mbps": 120.86
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 0,
-   "out_size": 18317341,
-   "ratio": 0.3576,
-   "compress_mbps": null,
-   "decompress_mbps": 123.3
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3740775,
-   "ratio": 0.3752,
-   "compress_mbps": null,
-   "decompress_mbps": 135.81
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 12,
-   "out_size": 3447985,
-   "ratio": 0.3458,
-   "compress_mbps": null,
-   "decompress_mbps": 132.57
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3672389,
-   "ratio": 0.3683,
-   "compress_mbps": null,
-   "decompress_mbps": 129.0
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3648644,
-   "ratio": 0.3659,
-   "compress_mbps": null,
-   "decompress_mbps": 133.44
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3625176,
-   "ratio": 0.3636,
-   "compress_mbps": null,
-   "decompress_mbps": 132.48
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 0,
-   "out_size": 3450225,
-   "ratio": 0.346,
-   "compress_mbps": null,
-   "decompress_mbps": 135.63
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3837577,
-   "ratio": 0.1144,
-   "compress_mbps": null,
-   "decompress_mbps": 213.53
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 12,
-   "out_size": 2748273,
-   "ratio": 0.0819,
-   "compress_mbps": null,
-   "decompress_mbps": 233.62
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3599455,
-   "ratio": 0.1073,
-   "compress_mbps": null,
-   "decompress_mbps": 220.32
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3091741,
-   "ratio": 0.0921,
-   "compress_mbps": null,
-   "decompress_mbps": 222.14
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2925243,
-   "ratio": 0.0872,
-   "compress_mbps": null,
-   "decompress_mbps": 225.08
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 0,
-   "out_size": 2740598,
-   "ratio": 0.0817,
-   "compress_mbps": null,
-   "decompress_mbps": 235.5
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3275124,
-   "ratio": 0.5324,
-   "compress_mbps": null,
-   "decompress_mbps": 105.75
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 12,
-   "out_size": 2994086,
-   "ratio": 0.4867,
-   "compress_mbps": null,
-   "decompress_mbps": 98.03
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3137061,
-   "ratio": 0.5099,
-   "compress_mbps": null,
-   "decompress_mbps": 98.21
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3072378,
-   "ratio": 0.4994,
-   "compress_mbps": null,
-   "decompress_mbps": 99.44
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3066968,
-   "ratio": 0.4985,
-   "compress_mbps": null,
-   "decompress_mbps": 99.62
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 0,
-   "out_size": 2992113,
-   "ratio": 0.4863,
-   "compress_mbps": null,
-   "decompress_mbps": 97.22
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3868663,
-   "ratio": 0.3836,
-   "compress_mbps": null,
-   "decompress_mbps": 142.69
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 12,
-   "out_size": 3608138,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 149.33
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3818964,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 142.62
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3660266,
-   "ratio": 0.3629,
-   "compress_mbps": null,
-   "decompress_mbps": 145.65
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3654860,
-   "ratio": 0.3624,
-   "compress_mbps": null,
-   "decompress_mbps": 146.05
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 0,
-   "out_size": 3607217,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 152.57
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2197055,
-   "ratio": 0.3315,
-   "compress_mbps": null,
-   "decompress_mbps": 122.54
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 12,
-   "out_size": 1696488,
-   "ratio": 0.256,
-   "compress_mbps": null,
-   "decompress_mbps": 147.3
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2021047,
-   "ratio": 0.305,
-   "compress_mbps": null,
-   "decompress_mbps": 130.7
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1876257,
-   "ratio": 0.2831,
-   "compress_mbps": null,
-   "decompress_mbps": 139.21
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1806374,
-   "ratio": 0.2726,
-   "compress_mbps": null,
-   "decompress_mbps": 138.26
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 0,
-   "out_size": 1691994,
-   "ratio": 0.2553,
-   "compress_mbps": null,
-   "decompress_mbps": 144.91
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 5866517,
-   "ratio": 0.2715,
-   "compress_mbps": null,
-   "decompress_mbps": 154.54
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 12,
-   "out_size": 5118130,
-   "ratio": 0.2369,
-   "compress_mbps": null,
-   "decompress_mbps": 157.5
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5605878,
-   "ratio": 0.2595,
-   "compress_mbps": null,
-   "decompress_mbps": 151.36
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5337149,
-   "ratio": 0.247,
-   "compress_mbps": null,
-   "decompress_mbps": 154.36
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5270405,
-   "ratio": 0.2439,
-   "compress_mbps": null,
-   "decompress_mbps": 161.93
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 0,
-   "out_size": 5107588,
-   "ratio": 0.2364,
-   "compress_mbps": null,
-   "decompress_mbps": 159.84
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5575128,
-   "ratio": 0.7688,
-   "compress_mbps": null,
-   "decompress_mbps": 108.47
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 12,
-   "out_size": 5250745,
-   "ratio": 0.724,
-   "compress_mbps": null,
-   "decompress_mbps": 111.25
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5397999,
-   "ratio": 0.7444,
-   "compress_mbps": null,
-   "decompress_mbps": 111.49
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5335405,
-   "ratio": 0.7357,
-   "compress_mbps": null,
-   "decompress_mbps": 114.78
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5323197,
-   "ratio": 0.734,
-   "compress_mbps": null,
-   "decompress_mbps": 115.99
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 0,
-   "out_size": 5242394,
-   "ratio": 0.7229,
-   "compress_mbps": null,
-   "decompress_mbps": 107.65
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 13550569,
-   "ratio": 0.3268,
-   "compress_mbps": null,
-   "decompress_mbps": 115.09
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 12,
-   "out_size": 11520871,
-   "ratio": 0.2779,
-   "compress_mbps": null,
-   "decompress_mbps": 125.88
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12839361,
-   "ratio": 0.3097,
-   "compress_mbps": null,
-   "decompress_mbps": 123.59
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12140474,
-   "ratio": 0.2928,
-   "compress_mbps": null,
-   "decompress_mbps": 122.74
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 11882496,
-   "ratio": 0.2866,
-   "compress_mbps": null,
-   "decompress_mbps": 123.85
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 0,
-   "out_size": 11518290,
-   "ratio": 0.2778,
-   "compress_mbps": null,
-   "decompress_mbps": 128.15
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6293390,
-   "ratio": 0.7426,
-   "compress_mbps": null,
-   "decompress_mbps": 104.36
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 12,
-   "out_size": 5747146,
-   "ratio": 0.6782,
-   "compress_mbps": null,
-   "decompress_mbps": 91.78
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6058381,
-   "ratio": 0.7149,
-   "compress_mbps": null,
-   "decompress_mbps": 91.81
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5998438,
-   "ratio": 0.7078,
-   "compress_mbps": null,
-   "decompress_mbps": 91.6
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5986859,
-   "ratio": 0.7065,
-   "compress_mbps": null,
-   "decompress_mbps": 93.99
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 0,
-   "out_size": 5744697,
-   "ratio": 0.6779,
-   "compress_mbps": null,
-   "decompress_mbps": 92.35
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 887708,
-   "ratio": 0.1661,
-   "compress_mbps": null,
-   "decompress_mbps": 192.55
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 12,
-   "out_size": 629349,
-   "ratio": 0.1177,
-   "compress_mbps": null,
-   "decompress_mbps": 228.12
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 793388,
-   "ratio": 0.1484,
-   "compress_mbps": null,
-   "decompress_mbps": 195.16
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 684405,
-   "ratio": 0.128,
-   "compress_mbps": null,
-   "decompress_mbps": 216.09
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 649494,
-   "ratio": 0.1215,
-   "compress_mbps": null,
-   "decompress_mbps": 219.58
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 0,
-   "out_size": 627169,
-   "ratio": 0.1173,
-   "compress_mbps": null,
-   "decompress_mbps": 221.88
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4217525,
-   "ratio": 0.4138,
-   "compress_mbps": null,
-   "decompress_mbps": 228.11
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4217525,
-   "ratio": 0.4138,
-   "compress_mbps": null,
-   "decompress_mbps": 381.87
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4217525,
-   "ratio": 0.4138,
-   "compress_mbps": null,
-   "decompress_mbps": 453.66
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4217525,
-   "ratio": 0.4138,
-   "compress_mbps": null,
-   "decompress_mbps": 740.45
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4217525,
-   "ratio": 0.4138,
-   "compress_mbps": null,
-   "decompress_mbps": 32216.53
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 3989875,
-   "ratio": 0.3915,
-   "compress_mbps": null,
-   "decompress_mbps": 268.9
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 3989875,
-   "ratio": 0.3915,
-   "compress_mbps": null,
-   "decompress_mbps": 389.51
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 3989875,
-   "ratio": 0.3915,
-   "compress_mbps": null,
-   "decompress_mbps": 495.37
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 3989875,
-   "ratio": 0.3915,
-   "compress_mbps": null,
-   "decompress_mbps": 845.35
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 3989875,
-   "ratio": 0.3915,
-   "compress_mbps": null,
-   "decompress_mbps": 30474.61
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3859436,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 263.12
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3859436,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 375.43
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3859436,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 471.32
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3859436,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 796.67
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3859436,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 31492.05
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3810354,
-   "ratio": 0.3738,
-   "compress_mbps": null,
-   "decompress_mbps": 257.69
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3810354,
-   "ratio": 0.3738,
-   "compress_mbps": null,
-   "decompress_mbps": 372.27
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3810354,
-   "ratio": 0.3738,
-   "compress_mbps": null,
-   "decompress_mbps": 445.37
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3810354,
-   "ratio": 0.3738,
-   "compress_mbps": null,
-   "decompress_mbps": 740.49
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3810354,
-   "ratio": 0.3738,
-   "compress_mbps": null,
-   "decompress_mbps": 31629.57
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 12,
-   "out_size": 3679105,
-   "ratio": 0.361,
-   "compress_mbps": null,
-   "decompress_mbps": 288.53
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 12,
-   "out_size": 3679105,
-   "ratio": 0.361,
-   "compress_mbps": null,
-   "decompress_mbps": 421.56
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 12,
-   "out_size": 3679105,
-   "ratio": 0.361,
-   "compress_mbps": null,
-   "decompress_mbps": 501.75
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 12,
-   "out_size": 3679105,
-   "ratio": 0.361,
-   "compress_mbps": null,
-   "decompress_mbps": 901.18
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 12,
-   "out_size": 3679105,
-   "ratio": 0.361,
-   "compress_mbps": null,
-   "decompress_mbps": 55646.49
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 0,
-   "out_size": 3673380,
-   "ratio": 0.3604,
-   "compress_mbps": null,
-   "decompress_mbps": 279.02
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 0,
-   "out_size": 3673380,
-   "ratio": 0.3604,
-   "compress_mbps": null,
-   "decompress_mbps": 411.58
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 0,
-   "out_size": 3673380,
-   "ratio": 0.3604,
-   "compress_mbps": null,
-   "decompress_mbps": 475.54
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 0,
-   "out_size": 3673380,
-   "ratio": 0.3604,
-   "compress_mbps": null,
-   "decompress_mbps": 817.63
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 0,
-   "out_size": 3673380,
-   "ratio": 0.3604,
-   "compress_mbps": null,
-   "decompress_mbps": 49669.26
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20192961,
-   "ratio": 0.3942,
-   "compress_mbps": null,
-   "decompress_mbps": 256.25
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20192961,
-   "ratio": 0.3942,
-   "compress_mbps": null,
-   "decompress_mbps": 370.56
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20192961,
-   "ratio": 0.3942,
-   "compress_mbps": null,
-   "decompress_mbps": 421.53
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20192961,
-   "ratio": 0.3942,
-   "compress_mbps": null,
-   "decompress_mbps": 724.37
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20192961,
-   "ratio": 0.3942,
-   "compress_mbps": null,
-   "decompress_mbps": 20369.53
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19234937,
-   "ratio": 0.3755,
-   "compress_mbps": null,
-   "decompress_mbps": 190.7
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19234937,
-   "ratio": 0.3755,
-   "compress_mbps": null,
-   "decompress_mbps": 367.68
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19234937,
-   "ratio": 0.3755,
-   "compress_mbps": null,
-   "decompress_mbps": 390.49
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19234937,
-   "ratio": 0.3755,
-   "compress_mbps": null,
-   "decompress_mbps": 715.64
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19234937,
-   "ratio": 0.3755,
-   "compress_mbps": null,
-   "decompress_mbps": 20356.95
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 18805391,
-   "ratio": 0.3671,
-   "compress_mbps": null,
-   "decompress_mbps": 202.06
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 18805391,
-   "ratio": 0.3671,
-   "compress_mbps": null,
-   "decompress_mbps": 375.11
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 18805391,
-   "ratio": 0.3671,
-   "compress_mbps": null,
-   "decompress_mbps": 409.22
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 18805391,
-   "ratio": 0.3671,
-   "compress_mbps": null,
-   "decompress_mbps": 740.56
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 18805391,
-   "ratio": 0.3671,
-   "compress_mbps": null,
-   "decompress_mbps": 20083.68
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 18713659,
-   "ratio": 0.3654,
-   "compress_mbps": null,
-   "decompress_mbps": 204.27
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 18713659,
-   "ratio": 0.3654,
-   "compress_mbps": null,
-   "decompress_mbps": 376.49
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 18713659,
-   "ratio": 0.3654,
-   "compress_mbps": null,
-   "decompress_mbps": 414.57
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 18713659,
-   "ratio": 0.3654,
-   "compress_mbps": null,
-   "decompress_mbps": 749.34
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 18713659,
-   "ratio": 0.3654,
-   "compress_mbps": null,
-   "decompress_mbps": 20327.85
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 12,
-   "out_size": 18241312,
-   "ratio": 0.3561,
-   "compress_mbps": null,
-   "decompress_mbps": 185.83
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 12,
-   "out_size": 18241312,
-   "ratio": 0.3561,
-   "compress_mbps": null,
-   "decompress_mbps": 377.25
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 12,
-   "out_size": 18241312,
-   "ratio": 0.3561,
-   "compress_mbps": null,
-   "decompress_mbps": 402.16
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 12,
-   "out_size": 18241312,
-   "ratio": 0.3561,
-   "compress_mbps": null,
-   "decompress_mbps": 739.78
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 12,
-   "out_size": 18241312,
-   "ratio": 0.3561,
-   "compress_mbps": null,
-   "decompress_mbps": 19852.43
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 0,
-   "out_size": 18317341,
-   "ratio": 0.3576,
-   "compress_mbps": null,
-   "decompress_mbps": 256.02
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 0,
-   "out_size": 18317341,
-   "ratio": 0.3576,
-   "compress_mbps": null,
-   "decompress_mbps": 385.57
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 0,
-   "out_size": 18317341,
-   "ratio": 0.3576,
-   "compress_mbps": null,
-   "decompress_mbps": 419.1
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 0,
-   "out_size": 18317341,
-   "ratio": 0.3576,
-   "compress_mbps": null,
-   "decompress_mbps": 765.25
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 0,
-   "out_size": 18317341,
-   "ratio": 0.3576,
-   "compress_mbps": null,
-   "decompress_mbps": 20180.5
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3740775,
-   "ratio": 0.3752,
-   "compress_mbps": null,
-   "decompress_mbps": 266.77
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3740775,
-   "ratio": 0.3752,
-   "compress_mbps": null,
-   "decompress_mbps": 446.13
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3740775,
-   "ratio": 0.3752,
-   "compress_mbps": null,
-   "decompress_mbps": 539.06
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3740775,
-   "ratio": 0.3752,
-   "compress_mbps": null,
-   "decompress_mbps": 841.94
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3740775,
-   "ratio": 0.3752,
-   "compress_mbps": null,
-   "decompress_mbps": 56969.87
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3672389,
-   "ratio": 0.3683,
-   "compress_mbps": null,
-   "decompress_mbps": 282.09
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3672389,
-   "ratio": 0.3683,
-   "compress_mbps": null,
-   "decompress_mbps": 451.84
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3672389,
-   "ratio": 0.3683,
-   "compress_mbps": null,
-   "decompress_mbps": 545.48
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3672389,
-   "ratio": 0.3683,
-   "compress_mbps": null,
-   "decompress_mbps": 888.61
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3672389,
-   "ratio": 0.3683,
-   "compress_mbps": null,
-   "decompress_mbps": 56710.97
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3648644,
-   "ratio": 0.3659,
-   "compress_mbps": null,
-   "decompress_mbps": 294.14
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3648644,
-   "ratio": 0.3659,
-   "compress_mbps": null,
-   "decompress_mbps": 447.37
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3648644,
-   "ratio": 0.3659,
-   "compress_mbps": null,
-   "decompress_mbps": 533.87
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3648644,
-   "ratio": 0.3659,
-   "compress_mbps": null,
-   "decompress_mbps": 913.05
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3648644,
-   "ratio": 0.3659,
-   "compress_mbps": null,
-   "decompress_mbps": 50903.77
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3625176,
-   "ratio": 0.3636,
-   "compress_mbps": null,
-   "decompress_mbps": 287.18
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3625176,
-   "ratio": 0.3636,
-   "compress_mbps": null,
-   "decompress_mbps": 450.05
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3625176,
-   "ratio": 0.3636,
-   "compress_mbps": null,
-   "decompress_mbps": 531.48
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3625176,
-   "ratio": 0.3636,
-   "compress_mbps": null,
-   "decompress_mbps": 909.0
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3625176,
-   "ratio": 0.3636,
-   "compress_mbps": null,
-   "decompress_mbps": 32640.96
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 12,
-   "out_size": 3447985,
-   "ratio": 0.3458,
-   "compress_mbps": null,
-   "decompress_mbps": 283.2
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 12,
-   "out_size": 3447985,
-   "ratio": 0.3458,
-   "compress_mbps": null,
-   "decompress_mbps": 489.08
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 12,
-   "out_size": 3447985,
-   "ratio": 0.3458,
-   "compress_mbps": null,
-   "decompress_mbps": 526.73
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 12,
-   "out_size": 3447985,
-   "ratio": 0.3458,
-   "compress_mbps": null,
-   "decompress_mbps": 912.85
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 12,
-   "out_size": 3447985,
-   "ratio": 0.3458,
-   "compress_mbps": null,
-   "decompress_mbps": 42166.12
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 0,
-   "out_size": 3450225,
-   "ratio": 0.346,
-   "compress_mbps": null,
-   "decompress_mbps": 254.15
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 0,
-   "out_size": 3450225,
-   "ratio": 0.346,
-   "compress_mbps": null,
-   "decompress_mbps": 423.45
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 0,
-   "out_size": 3450225,
-   "ratio": 0.346,
-   "compress_mbps": null,
-   "decompress_mbps": 519.84
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 0,
-   "out_size": 3450225,
-   "ratio": 0.346,
-   "compress_mbps": null,
-   "decompress_mbps": 820.32
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 0,
-   "out_size": 3450225,
-   "ratio": 0.346,
-   "compress_mbps": null,
-   "decompress_mbps": 50532.61
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3837577,
-   "ratio": 0.1144,
-   "compress_mbps": null,
-   "decompress_mbps": 621.33
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3837577,
-   "ratio": 0.1144,
-   "compress_mbps": null,
-   "decompress_mbps": 881.15
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3837577,
-   "ratio": 0.1144,
-   "compress_mbps": null,
-   "decompress_mbps": 836.19
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3837577,
-   "ratio": 0.1144,
-   "compress_mbps": null,
-   "decompress_mbps": 1778.51
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3837577,
-   "ratio": 0.1144,
-   "compress_mbps": null,
-   "decompress_mbps": 18209.58
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3599455,
-   "ratio": 0.1073,
-   "compress_mbps": null,
-   "decompress_mbps": 728.98
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3599455,
-   "ratio": 0.1073,
-   "compress_mbps": null,
-   "decompress_mbps": 936.16
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3599455,
-   "ratio": 0.1073,
-   "compress_mbps": null,
-   "decompress_mbps": 902.56
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3599455,
-   "ratio": 0.1073,
-   "compress_mbps": null,
-   "decompress_mbps": 1834.96
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3599455,
-   "ratio": 0.1073,
-   "compress_mbps": null,
-   "decompress_mbps": 18709.44
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3091741,
-   "ratio": 0.0921,
-   "compress_mbps": null,
-   "decompress_mbps": 867.93
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3091741,
-   "ratio": 0.0921,
-   "compress_mbps": null,
-   "decompress_mbps": 1037.69
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3091741,
-   "ratio": 0.0921,
-   "compress_mbps": null,
-   "decompress_mbps": 1055.96
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3091741,
-   "ratio": 0.0921,
-   "compress_mbps": null,
-   "decompress_mbps": 1918.82
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3091741,
-   "ratio": 0.0921,
-   "compress_mbps": null,
-   "decompress_mbps": 19558.3
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2925243,
-   "ratio": 0.0872,
-   "compress_mbps": null,
-   "decompress_mbps": 961.08
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2925243,
-   "ratio": 0.0872,
-   "compress_mbps": null,
-   "decompress_mbps": 1095.4
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2925243,
-   "ratio": 0.0872,
-   "compress_mbps": null,
-   "decompress_mbps": 1112.21
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2925243,
-   "ratio": 0.0872,
-   "compress_mbps": null,
-   "decompress_mbps": 1908.45
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2925243,
-   "ratio": 0.0872,
-   "compress_mbps": null,
-   "decompress_mbps": 19734.43
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 12,
-   "out_size": 2748273,
-   "ratio": 0.0819,
-   "compress_mbps": null,
-   "decompress_mbps": 862.94
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 12,
-   "out_size": 2748273,
-   "ratio": 0.0819,
-   "compress_mbps": null,
-   "decompress_mbps": 1110.43
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 12,
-   "out_size": 2748273,
-   "ratio": 0.0819,
-   "compress_mbps": null,
-   "decompress_mbps": 1126.48
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 12,
-   "out_size": 2748273,
-   "ratio": 0.0819,
-   "compress_mbps": null,
-   "decompress_mbps": 1936.59
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 12,
-   "out_size": 2748273,
-   "ratio": 0.0819,
-   "compress_mbps": null,
-   "decompress_mbps": 18871.34
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 0,
-   "out_size": 2740598,
-   "ratio": 0.0817,
-   "compress_mbps": null,
-   "decompress_mbps": 1052.39
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 0,
-   "out_size": 2740598,
-   "ratio": 0.0817,
-   "compress_mbps": null,
-   "decompress_mbps": 1131.25
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 0,
-   "out_size": 2740598,
-   "ratio": 0.0817,
-   "compress_mbps": null,
-   "decompress_mbps": 1151.02
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 0,
-   "out_size": 2740598,
-   "ratio": 0.0817,
-   "compress_mbps": null,
-   "decompress_mbps": 1971.24
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 0,
-   "out_size": 2740598,
-   "ratio": 0.0817,
-   "compress_mbps": null,
-   "decompress_mbps": 19271.42
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3275124,
-   "ratio": 0.5324,
-   "compress_mbps": null,
-   "decompress_mbps": 200.1
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3275124,
-   "ratio": 0.5324,
-   "compress_mbps": null,
-   "decompress_mbps": 283.51
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3275124,
-   "ratio": 0.5324,
-   "compress_mbps": null,
-   "decompress_mbps": 366.91
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3275124,
-   "ratio": 0.5324,
-   "compress_mbps": null,
-   "decompress_mbps": 582.07
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3275124,
-   "ratio": 0.5324,
-   "compress_mbps": null,
-   "decompress_mbps": 62047.25
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3137061,
-   "ratio": 0.5099,
-   "compress_mbps": null,
-   "decompress_mbps": 175.35
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3137061,
-   "ratio": 0.5099,
-   "compress_mbps": null,
-   "decompress_mbps": 274.18
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3137061,
-   "ratio": 0.5099,
-   "compress_mbps": null,
-   "decompress_mbps": 328.83
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3137061,
-   "ratio": 0.5099,
-   "compress_mbps": null,
-   "decompress_mbps": 538.93
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3137061,
-   "ratio": 0.5099,
-   "compress_mbps": null,
-   "decompress_mbps": 61882.98
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3072378,
-   "ratio": 0.4994,
-   "compress_mbps": null,
-   "decompress_mbps": 186.36
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3072378,
-   "ratio": 0.4994,
-   "compress_mbps": null,
-   "decompress_mbps": 277.42
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3072378,
-   "ratio": 0.4994,
-   "compress_mbps": null,
-   "decompress_mbps": 335.97
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3072378,
-   "ratio": 0.4994,
-   "compress_mbps": null,
-   "decompress_mbps": 568.75
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3072378,
-   "ratio": 0.4994,
-   "compress_mbps": null,
-   "decompress_mbps": 62981.04
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3066968,
-   "ratio": 0.4985,
-   "compress_mbps": null,
-   "decompress_mbps": 191.08
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3066968,
-   "ratio": 0.4985,
-   "compress_mbps": null,
-   "decompress_mbps": 281.4
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3066968,
-   "ratio": 0.4985,
-   "compress_mbps": null,
-   "decompress_mbps": 345.1
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3066968,
-   "ratio": 0.4985,
-   "compress_mbps": null,
-   "decompress_mbps": 573.97
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3066968,
-   "ratio": 0.4985,
-   "compress_mbps": null,
-   "decompress_mbps": 63136.92
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 12,
-   "out_size": 2994086,
-   "ratio": 0.4867,
-   "compress_mbps": null,
-   "decompress_mbps": 175.54
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 12,
-   "out_size": 2994086,
-   "ratio": 0.4867,
-   "compress_mbps": null,
-   "decompress_mbps": 273.58
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 12,
-   "out_size": 2994086,
-   "ratio": 0.4867,
-   "compress_mbps": null,
-   "decompress_mbps": 322.86
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 12,
-   "out_size": 2994086,
-   "ratio": 0.4867,
-   "compress_mbps": null,
-   "decompress_mbps": 548.5
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 12,
-   "out_size": 2994086,
-   "ratio": 0.4867,
-   "compress_mbps": null,
-   "decompress_mbps": 62852.85
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 0,
-   "out_size": 2992113,
-   "ratio": 0.4863,
-   "compress_mbps": null,
-   "decompress_mbps": 181.13
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 0,
-   "out_size": 2992113,
-   "ratio": 0.4863,
-   "compress_mbps": null,
-   "decompress_mbps": 274.44
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 0,
-   "out_size": 2992113,
-   "ratio": 0.4863,
-   "compress_mbps": null,
-   "decompress_mbps": 322.1
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 0,
-   "out_size": 2992113,
-   "ratio": 0.4863,
-   "compress_mbps": null,
-   "decompress_mbps": 557.6
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 0,
-   "out_size": 2992113,
-   "ratio": 0.4863,
-   "compress_mbps": null,
-   "decompress_mbps": 61948.98
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3868663,
-   "ratio": 0.3836,
-   "compress_mbps": null,
-   "decompress_mbps": 303.24
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3868663,
-   "ratio": 0.3836,
-   "compress_mbps": null,
-   "decompress_mbps": 517.47
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3868663,
-   "ratio": 0.3836,
-   "compress_mbps": null,
-   "decompress_mbps": 626.79
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3868663,
-   "ratio": 0.3836,
-   "compress_mbps": null,
-   "decompress_mbps": 1036.48
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3868663,
-   "ratio": 0.3836,
-   "compress_mbps": null,
-   "decompress_mbps": 54937.82
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3818964,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 396.99
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3818964,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 540.97
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3818964,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 629.85
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3818964,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 1066.18
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3818964,
-   "ratio": 0.3787,
-   "compress_mbps": null,
-   "decompress_mbps": 52174.13
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3660266,
-   "ratio": 0.3629,
-   "compress_mbps": null,
-   "decompress_mbps": 414.51
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3660266,
-   "ratio": 0.3629,
-   "compress_mbps": null,
-   "decompress_mbps": 545.87
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3660266,
-   "ratio": 0.3629,
-   "compress_mbps": null,
-   "decompress_mbps": 674.41
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3660266,
-   "ratio": 0.3629,
-   "compress_mbps": null,
-   "decompress_mbps": 1116.96
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3660266,
-   "ratio": 0.3629,
-   "compress_mbps": null,
-   "decompress_mbps": 41175.43
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3654860,
-   "ratio": 0.3624,
-   "compress_mbps": null,
-   "decompress_mbps": 415.71
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3654860,
-   "ratio": 0.3624,
-   "compress_mbps": null,
-   "decompress_mbps": 548.15
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3654860,
-   "ratio": 0.3624,
-   "compress_mbps": null,
-   "decompress_mbps": 678.92
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3654860,
-   "ratio": 0.3624,
-   "compress_mbps": null,
-   "decompress_mbps": 1111.01
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3654860,
-   "ratio": 0.3624,
-   "compress_mbps": null,
-   "decompress_mbps": 56164.87
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 12,
-   "out_size": 3608138,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 408.26
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 12,
-   "out_size": 3608138,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 554.93
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 12,
-   "out_size": 3608138,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 669.58
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 12,
-   "out_size": 3608138,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 1103.44
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 12,
-   "out_size": 3608138,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 54181.47
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 0,
-   "out_size": 3607217,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 460.98
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 0,
-   "out_size": 3607217,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 575.42
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 0,
-   "out_size": 3607217,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 708.14
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 0,
-   "out_size": 3607217,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 1162.51
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 0,
-   "out_size": 3607217,
-   "ratio": 0.3577,
-   "compress_mbps": null,
-   "decompress_mbps": 54445.54
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2197055,
-   "ratio": 0.3315,
-   "compress_mbps": null,
-   "decompress_mbps": 265.26
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2197055,
-   "ratio": 0.3315,
-   "compress_mbps": null,
-   "decompress_mbps": 426.56
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2197055,
-   "ratio": 0.3315,
-   "compress_mbps": null,
-   "decompress_mbps": 529.89
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2197055,
-   "ratio": 0.3315,
-   "compress_mbps": null,
-   "decompress_mbps": 1008.63
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2197055,
-   "ratio": 0.3315,
-   "compress_mbps": null,
-   "decompress_mbps": 60506.36
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2021047,
-   "ratio": 0.305,
-   "compress_mbps": null,
-   "decompress_mbps": 335.12
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2021047,
-   "ratio": 0.305,
-   "compress_mbps": null,
-   "decompress_mbps": 463.32
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2021047,
-   "ratio": 0.305,
-   "compress_mbps": null,
-   "decompress_mbps": 583.98
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2021047,
-   "ratio": 0.305,
-   "compress_mbps": null,
-   "decompress_mbps": 1166.2
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2021047,
-   "ratio": 0.305,
-   "compress_mbps": null,
-   "decompress_mbps": 61520.57
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1876257,
-   "ratio": 0.2831,
-   "compress_mbps": null,
-   "decompress_mbps": 337.43
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1876257,
-   "ratio": 0.2831,
-   "compress_mbps": null,
-   "decompress_mbps": 466.82
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1876257,
-   "ratio": 0.2831,
-   "compress_mbps": null,
-   "decompress_mbps": 554.95
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1876257,
-   "ratio": 0.2831,
-   "compress_mbps": null,
-   "decompress_mbps": 1066.85
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1876257,
-   "ratio": 0.2831,
-   "compress_mbps": null,
-   "decompress_mbps": 62120.41
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1806374,
-   "ratio": 0.2726,
-   "compress_mbps": null,
-   "decompress_mbps": 343.55
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1806374,
-   "ratio": 0.2726,
-   "compress_mbps": null,
-   "decompress_mbps": 451.72
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1806374,
-   "ratio": 0.2726,
-   "compress_mbps": null,
-   "decompress_mbps": 530.25
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1806374,
-   "ratio": 0.2726,
-   "compress_mbps": null,
-   "decompress_mbps": 992.1
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1806374,
-   "ratio": 0.2726,
-   "compress_mbps": null,
-   "decompress_mbps": 60809.67
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 12,
-   "out_size": 1696488,
-   "ratio": 0.256,
-   "compress_mbps": null,
-   "decompress_mbps": 351.4
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 12,
-   "out_size": 1696488,
-   "ratio": 0.256,
-   "compress_mbps": null,
-   "decompress_mbps": 531.13
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 12,
-   "out_size": 1696488,
-   "ratio": 0.256,
-   "compress_mbps": null,
-   "decompress_mbps": 586.33
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 12,
-   "out_size": 1696488,
-   "ratio": 0.256,
-   "compress_mbps": null,
-   "decompress_mbps": 1171.33
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 12,
-   "out_size": 1696488,
-   "ratio": 0.256,
-   "compress_mbps": null,
-   "decompress_mbps": 61962.06
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 0,
-   "out_size": 1691994,
-   "ratio": 0.2553,
-   "compress_mbps": null,
-   "decompress_mbps": 368.25
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 0,
-   "out_size": 1691994,
-   "ratio": 0.2553,
-   "compress_mbps": null,
-   "decompress_mbps": 532.31
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 0,
-   "out_size": 1691994,
-   "ratio": 0.2553,
-   "compress_mbps": null,
-   "decompress_mbps": 596.38
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 0,
-   "out_size": 1691994,
-   "ratio": 0.2553,
-   "compress_mbps": null,
-   "decompress_mbps": 1166.12
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 0,
-   "out_size": 1691994,
-   "ratio": 0.2553,
-   "compress_mbps": null,
-   "decompress_mbps": 60097.3
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 5866517,
-   "ratio": 0.2715,
-   "compress_mbps": null,
-   "decompress_mbps": 366.29
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 5866517,
-   "ratio": 0.2715,
-   "compress_mbps": null,
-   "decompress_mbps": 552.24
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 5866517,
-   "ratio": 0.2715,
-   "compress_mbps": null,
-   "decompress_mbps": 578.19
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 5866517,
-   "ratio": 0.2715,
-   "compress_mbps": null,
-   "decompress_mbps": 1053.14
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 5866517,
-   "ratio": 0.2715,
-   "compress_mbps": null,
-   "decompress_mbps": 18892.56
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5605878,
-   "ratio": 0.2595,
-   "compress_mbps": null,
-   "decompress_mbps": 324.79
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5605878,
-   "ratio": 0.2595,
-   "compress_mbps": null,
-   "decompress_mbps": 565.63
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5605878,
-   "ratio": 0.2595,
-   "compress_mbps": null,
-   "decompress_mbps": 590.32
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5605878,
-   "ratio": 0.2595,
-   "compress_mbps": null,
-   "decompress_mbps": 1121.34
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5605878,
-   "ratio": 0.2595,
-   "compress_mbps": null,
-   "decompress_mbps": 17875.07
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5337149,
-   "ratio": 0.247,
-   "compress_mbps": null,
-   "decompress_mbps": 348.46
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5337149,
-   "ratio": 0.247,
-   "compress_mbps": null,
-   "decompress_mbps": 517.17
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5337149,
-   "ratio": 0.247,
-   "compress_mbps": null,
-   "decompress_mbps": 530.75
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5337149,
-   "ratio": 0.247,
-   "compress_mbps": null,
-   "decompress_mbps": 1092.67
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5337149,
-   "ratio": 0.247,
-   "compress_mbps": null,
-   "decompress_mbps": 19356.62
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5270405,
-   "ratio": 0.2439,
-   "compress_mbps": null,
-   "decompress_mbps": 361.27
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5270405,
-   "ratio": 0.2439,
-   "compress_mbps": null,
-   "decompress_mbps": 525.7
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5270405,
-   "ratio": 0.2439,
-   "compress_mbps": null,
-   "decompress_mbps": 518.74
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5270405,
-   "ratio": 0.2439,
-   "compress_mbps": null,
-   "decompress_mbps": 1052.09
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5270405,
-   "ratio": 0.2439,
-   "compress_mbps": null,
-   "decompress_mbps": 20627.31
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 12,
-   "out_size": 5118130,
-   "ratio": 0.2369,
-   "compress_mbps": null,
-   "decompress_mbps": 298.4
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 12,
-   "out_size": 5118130,
-   "ratio": 0.2369,
-   "compress_mbps": null,
-   "decompress_mbps": 530.73
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 12,
-   "out_size": 5118130,
-   "ratio": 0.2369,
-   "compress_mbps": null,
-   "decompress_mbps": 524.94
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 12,
-   "out_size": 5118130,
-   "ratio": 0.2369,
-   "compress_mbps": null,
-   "decompress_mbps": 1058.29
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 12,
-   "out_size": 5118130,
-   "ratio": 0.2369,
-   "compress_mbps": null,
-   "decompress_mbps": 23041.77
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 0,
-   "out_size": 5107588,
-   "ratio": 0.2364,
-   "compress_mbps": null,
-   "decompress_mbps": 415.85
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 0,
-   "out_size": 5107588,
-   "ratio": 0.2364,
-   "compress_mbps": null,
-   "decompress_mbps": 550.21
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 0,
-   "out_size": 5107588,
-   "ratio": 0.2364,
-   "compress_mbps": null,
-   "decompress_mbps": 543.08
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 0,
-   "out_size": 5107588,
-   "ratio": 0.2364,
-   "compress_mbps": null,
-   "decompress_mbps": 1128.6
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 0,
-   "out_size": 5107588,
-   "ratio": 0.2364,
-   "compress_mbps": null,
-   "decompress_mbps": 19356.8
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5575128,
-   "ratio": 0.7688,
-   "compress_mbps": null,
-   "decompress_mbps": 207.63
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5575128,
-   "ratio": 0.7688,
-   "compress_mbps": null,
-   "decompress_mbps": 372.33
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5575128,
-   "ratio": 0.7688,
-   "compress_mbps": null,
-   "decompress_mbps": 395.05
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5575128,
-   "ratio": 0.7688,
-   "compress_mbps": null,
-   "decompress_mbps": 564.74
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5575128,
-   "ratio": 0.7688,
-   "compress_mbps": null,
-   "decompress_mbps": 41022.56
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5397999,
-   "ratio": 0.7444,
-   "compress_mbps": null,
-   "decompress_mbps": 239.95
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5397999,
-   "ratio": 0.7444,
-   "compress_mbps": null,
-   "decompress_mbps": 375.59
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5397999,
-   "ratio": 0.7444,
-   "compress_mbps": null,
-   "decompress_mbps": 391.58
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5397999,
-   "ratio": 0.7444,
-   "compress_mbps": null,
-   "decompress_mbps": 558.7
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5397999,
-   "ratio": 0.7444,
-   "compress_mbps": null,
-   "decompress_mbps": 61406.17
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5335405,
-   "ratio": 0.7357,
-   "compress_mbps": null,
-   "decompress_mbps": 238.65
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5335405,
-   "ratio": 0.7357,
-   "compress_mbps": null,
-   "decompress_mbps": 373.33
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5335405,
-   "ratio": 0.7357,
-   "compress_mbps": null,
-   "decompress_mbps": 387.28
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5335405,
-   "ratio": 0.7357,
-   "compress_mbps": null,
-   "decompress_mbps": 560.52
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5335405,
-   "ratio": 0.7357,
-   "compress_mbps": null,
-   "decompress_mbps": 57010.9
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5323197,
-   "ratio": 0.734,
-   "compress_mbps": null,
-   "decompress_mbps": 239.1
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5323197,
-   "ratio": 0.734,
-   "compress_mbps": null,
-   "decompress_mbps": 376.03
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5323197,
-   "ratio": 0.734,
-   "compress_mbps": null,
-   "decompress_mbps": 385.85
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5323197,
-   "ratio": 0.734,
-   "compress_mbps": null,
-   "decompress_mbps": 558.61
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5323197,
-   "ratio": 0.734,
-   "compress_mbps": null,
-   "decompress_mbps": 60227.58
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 12,
-   "out_size": 5250745,
-   "ratio": 0.724,
-   "compress_mbps": null,
-   "decompress_mbps": 241.73
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 12,
-   "out_size": 5250745,
-   "ratio": 0.724,
-   "compress_mbps": null,
-   "decompress_mbps": 377.51
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 12,
-   "out_size": 5250745,
-   "ratio": 0.724,
-   "compress_mbps": null,
-   "decompress_mbps": 393.77
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 12,
-   "out_size": 5250745,
-   "ratio": 0.724,
-   "compress_mbps": null,
-   "decompress_mbps": 581.69
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 12,
-   "out_size": 5250745,
-   "ratio": 0.724,
-   "compress_mbps": null,
-   "decompress_mbps": 60784.97
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 0,
-   "out_size": 5242394,
-   "ratio": 0.7229,
-   "compress_mbps": null,
-   "decompress_mbps": 201.16
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 0,
-   "out_size": 5242394,
-   "ratio": 0.7229,
-   "compress_mbps": null,
-   "decompress_mbps": 370.29
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 0,
-   "out_size": 5242394,
-   "ratio": 0.7229,
-   "compress_mbps": null,
-   "decompress_mbps": 386.94
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 0,
-   "out_size": 5242394,
-   "ratio": 0.7229,
-   "compress_mbps": null,
-   "decompress_mbps": 560.72
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 0,
-   "out_size": 5242394,
-   "ratio": 0.7229,
-   "compress_mbps": null,
-   "decompress_mbps": 59619.6
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 13550569,
-   "ratio": 0.3268,
-   "compress_mbps": null,
-   "decompress_mbps": 273.29
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 13550569,
-   "ratio": 0.3268,
-   "compress_mbps": null,
-   "decompress_mbps": 379.8
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 13550569,
-   "ratio": 0.3268,
-   "compress_mbps": null,
-   "decompress_mbps": 433.19
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 13550569,
-   "ratio": 0.3268,
-   "compress_mbps": null,
-   "decompress_mbps": 830.23
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 13550569,
-   "ratio": 0.3268,
-   "compress_mbps": null,
-   "decompress_mbps": 20061.63
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12839361,
-   "ratio": 0.3097,
-   "compress_mbps": null,
-   "decompress_mbps": 332.29
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12839361,
-   "ratio": 0.3097,
-   "compress_mbps": null,
-   "decompress_mbps": 393.85
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12839361,
-   "ratio": 0.3097,
-   "compress_mbps": null,
-   "decompress_mbps": 463.63
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12839361,
-   "ratio": 0.3097,
-   "compress_mbps": null,
-   "decompress_mbps": 896.31
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12839361,
-   "ratio": 0.3097,
-   "compress_mbps": null,
-   "decompress_mbps": 20050.94
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12140474,
-   "ratio": 0.2928,
-   "compress_mbps": null,
-   "decompress_mbps": 339.99
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12140474,
-   "ratio": 0.2928,
-   "compress_mbps": null,
-   "decompress_mbps": 395.42
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12140474,
-   "ratio": 0.2928,
-   "compress_mbps": null,
-   "decompress_mbps": 472.31
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12140474,
-   "ratio": 0.2928,
-   "compress_mbps": null,
-   "decompress_mbps": 868.51
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12140474,
-   "ratio": 0.2928,
-   "compress_mbps": null,
-   "decompress_mbps": 19971.61
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 11882496,
-   "ratio": 0.2866,
-   "compress_mbps": null,
-   "decompress_mbps": 339.52
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 11882496,
-   "ratio": 0.2866,
-   "compress_mbps": null,
-   "decompress_mbps": 395.36
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 11882496,
-   "ratio": 0.2866,
-   "compress_mbps": null,
-   "decompress_mbps": 467.55
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 11882496,
-   "ratio": 0.2866,
-   "compress_mbps": null,
-   "decompress_mbps": 835.06
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 11882496,
-   "ratio": 0.2866,
-   "compress_mbps": null,
-   "decompress_mbps": 19818.02
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 12,
-   "out_size": 11520871,
-   "ratio": 0.2779,
-   "compress_mbps": null,
-   "decompress_mbps": 343.84
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 12,
-   "out_size": 11520871,
-   "ratio": 0.2779,
-   "compress_mbps": null,
-   "decompress_mbps": 415.37
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 12,
-   "out_size": 11520871,
-   "ratio": 0.2779,
-   "compress_mbps": null,
-   "decompress_mbps": 483.27
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 12,
-   "out_size": 11520871,
-   "ratio": 0.2779,
-   "compress_mbps": null,
-   "decompress_mbps": 873.74
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 12,
-   "out_size": 11520871,
-   "ratio": 0.2779,
-   "compress_mbps": null,
-   "decompress_mbps": 19714.8
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 0,
-   "out_size": 11518290,
-   "ratio": 0.2778,
-   "compress_mbps": null,
-   "decompress_mbps": 357.73
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 0,
-   "out_size": 11518290,
-   "ratio": 0.2778,
-   "compress_mbps": null,
-   "decompress_mbps": 419.03
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 0,
-   "out_size": 11518290,
-   "ratio": 0.2778,
-   "compress_mbps": null,
-   "decompress_mbps": 483.53
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 0,
-   "out_size": 11518290,
-   "ratio": 0.2778,
-   "compress_mbps": null,
-   "decompress_mbps": 879.37
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 0,
-   "out_size": 11518290,
-   "ratio": 0.2778,
-   "compress_mbps": null,
-   "decompress_mbps": 20167.71
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6293390,
-   "ratio": 0.7426,
-   "compress_mbps": null,
-   "decompress_mbps": 206.03
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6293390,
-   "ratio": 0.7426,
-   "compress_mbps": null,
-   "decompress_mbps": 326.43
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6293390,
-   "ratio": 0.7426,
-   "compress_mbps": null,
-   "decompress_mbps": 352.32
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6293390,
-   "ratio": 0.7426,
-   "compress_mbps": null,
-   "decompress_mbps": 493.96
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6293390,
-   "ratio": 0.7426,
-   "compress_mbps": null,
-   "decompress_mbps": 33963.28
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6058381,
-   "ratio": 0.7149,
-   "compress_mbps": null,
-   "decompress_mbps": 160.85
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6058381,
-   "ratio": 0.7149,
-   "compress_mbps": null,
-   "decompress_mbps": 272.83
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6058381,
-   "ratio": 0.7149,
-   "compress_mbps": null,
-   "decompress_mbps": 300.12
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6058381,
-   "ratio": 0.7149,
-   "compress_mbps": null,
-   "decompress_mbps": 458.05
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6058381,
-   "ratio": 0.7149,
-   "compress_mbps": null,
-   "decompress_mbps": 58159.89
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5998438,
-   "ratio": 0.7078,
-   "compress_mbps": null,
-   "decompress_mbps": 177.24
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5998438,
-   "ratio": 0.7078,
-   "compress_mbps": null,
-   "decompress_mbps": 314.79
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5998438,
-   "ratio": 0.7078,
-   "compress_mbps": null,
-   "decompress_mbps": 318.66
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5998438,
-   "ratio": 0.7078,
-   "compress_mbps": null,
-   "decompress_mbps": 506.58
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5998438,
-   "ratio": 0.7078,
-   "compress_mbps": null,
-   "decompress_mbps": 39379.53
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5986859,
-   "ratio": 0.7065,
-   "compress_mbps": null,
-   "decompress_mbps": 175.27
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5986859,
-   "ratio": 0.7065,
-   "compress_mbps": null,
-   "decompress_mbps": 309.81
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5986859,
-   "ratio": 0.7065,
-   "compress_mbps": null,
-   "decompress_mbps": 311.12
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5986859,
-   "ratio": 0.7065,
-   "compress_mbps": null,
-   "decompress_mbps": 501.05
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5986859,
-   "ratio": 0.7065,
-   "compress_mbps": null,
-   "decompress_mbps": 43243.59
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 12,
-   "out_size": 5747146,
-   "ratio": 0.6782,
-   "compress_mbps": null,
-   "decompress_mbps": 178.99
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 12,
-   "out_size": 5747146,
-   "ratio": 0.6782,
-   "compress_mbps": null,
-   "decompress_mbps": 294.23
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 12,
-   "out_size": 5747146,
-   "ratio": 0.6782,
-   "compress_mbps": null,
-   "decompress_mbps": 327.48
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 12,
-   "out_size": 5747146,
-   "ratio": 0.6782,
-   "compress_mbps": null,
-   "decompress_mbps": 546.89
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 12,
-   "out_size": 5747146,
-   "ratio": 0.6782,
-   "compress_mbps": null,
-   "decompress_mbps": 58569.16
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 0,
-   "out_size": 5744697,
-   "ratio": 0.6779,
-   "compress_mbps": null,
-   "decompress_mbps": 172.16
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 0,
-   "out_size": 5744697,
-   "ratio": 0.6779,
-   "compress_mbps": null,
-   "decompress_mbps": 286.67
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 0,
-   "out_size": 5744697,
-   "ratio": 0.6779,
-   "compress_mbps": null,
-   "decompress_mbps": 326.86
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 0,
-   "out_size": 5744697,
-   "ratio": 0.6779,
-   "compress_mbps": null,
-   "decompress_mbps": 548.73
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 0,
-   "out_size": 5744697,
-   "ratio": 0.6779,
-   "compress_mbps": null,
-   "decompress_mbps": 36346.59
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 887708,
-   "ratio": 0.1661,
-   "compress_mbps": null,
-   "decompress_mbps": 471.9
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 887708,
-   "ratio": 0.1661,
-   "compress_mbps": null,
-   "decompress_mbps": 746.19
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 887708,
-   "ratio": 0.1661,
-   "compress_mbps": null,
-   "decompress_mbps": 914.01
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 887708,
-   "ratio": 0.1661,
-   "compress_mbps": null,
-   "decompress_mbps": 1626.22
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 887708,
-   "ratio": 0.1661,
-   "compress_mbps": null,
-   "decompress_mbps": 60323.01
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 793388,
-   "ratio": 0.1484,
-   "compress_mbps": null,
-   "decompress_mbps": 579.26
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 793388,
-   "ratio": 0.1484,
-   "compress_mbps": null,
-   "decompress_mbps": 842.65
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 793388,
-   "ratio": 0.1484,
-   "compress_mbps": null,
-   "decompress_mbps": 1079.59
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 793388,
-   "ratio": 0.1484,
-   "compress_mbps": null,
-   "decompress_mbps": 1830.39
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 793388,
-   "ratio": 0.1484,
-   "compress_mbps": null,
-   "decompress_mbps": 63650.69
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 684405,
-   "ratio": 0.128,
-   "compress_mbps": null,
-   "decompress_mbps": 638.08
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 684405,
-   "ratio": 0.128,
-   "compress_mbps": null,
-   "decompress_mbps": 926.48
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 684405,
-   "ratio": 0.128,
-   "compress_mbps": null,
-   "decompress_mbps": 1207.56
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 684405,
-   "ratio": 0.128,
-   "compress_mbps": null,
-   "decompress_mbps": 1822.08
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 684405,
-   "ratio": 0.128,
-   "compress_mbps": null,
-   "decompress_mbps": 63200.09
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 649494,
-   "ratio": 0.1215,
-   "compress_mbps": null,
-   "decompress_mbps": 663.57
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 649494,
-   "ratio": 0.1215,
-   "compress_mbps": null,
-   "decompress_mbps": 961.66
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 649494,
-   "ratio": 0.1215,
-   "compress_mbps": null,
-   "decompress_mbps": 1221.17
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 649494,
-   "ratio": 0.1215,
-   "compress_mbps": null,
-   "decompress_mbps": 1802.4
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 649494,
-   "ratio": 0.1215,
-   "compress_mbps": null,
-   "decompress_mbps": 63802.05
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 12,
-   "out_size": 629349,
-   "ratio": 0.1177,
-   "compress_mbps": null,
-   "decompress_mbps": 622.67
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 12,
-   "out_size": 629349,
-   "ratio": 0.1177,
-   "compress_mbps": null,
-   "decompress_mbps": 1000.66
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 12,
-   "out_size": 629349,
-   "ratio": 0.1177,
-   "compress_mbps": null,
-   "decompress_mbps": 1227.99
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 12,
-   "out_size": 629349,
-   "ratio": 0.1177,
-   "compress_mbps": null,
-   "decompress_mbps": 1878.91
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 12,
-   "out_size": 629349,
-   "ratio": 0.1177,
-   "compress_mbps": null,
-   "decompress_mbps": 63578.45
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 0,
-   "out_size": 627169,
-   "ratio": 0.1173,
-   "compress_mbps": null,
-   "decompress_mbps": 708.9
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 0,
-   "out_size": 627169,
-   "ratio": 0.1173,
-   "compress_mbps": null,
-   "decompress_mbps": 1007.78
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 0,
-   "out_size": 627169,
-   "ratio": 0.1173,
-   "compress_mbps": null,
-   "decompress_mbps": 1250.21
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 0,
-   "out_size": 627169,
-   "ratio": 0.1173,
-   "compress_mbps": null,
-   "decompress_mbps": 1884.54
-  },
-  {
-   "compressor": "memcpy",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 0,
-   "out_size": 627169,
-   "ratio": 0.1173,
-   "compress_mbps": null,
-   "decompress_mbps": 63058.59
-  }
- ]
+"meta": {
+"date": "2026-07-18T17:07:56Z",
+"machine": "Linux chungus2 x86_64",
+"git_commit": "3f5fffbd",
+"toolchain": "leanprover/lean4:v4.30.0-rc2",
+"experiment": "decode-density: fixed encoder (libdeflate levels + zopfli, level 0 = zopfli), ratio = encoder compression ratio, decompress_mbps = each decoder on identical streams; compressor field holds the decoder name"
+},
+"results": [
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4217525,
+"ratio": 0.4138,
+"compress_mbps": null,
+"decompress_mbps": 224.28
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4217525,
+"ratio": 0.4138,
+"compress_mbps": null,
+"decompress_mbps": 386.5
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4217525,
+"ratio": 0.4138,
+"compress_mbps": null,
+"decompress_mbps": 449.31
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4217525,
+"ratio": 0.4138,
+"compress_mbps": null,
+"decompress_mbps": 777.75
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4217525,
+"ratio": 0.4138,
+"compress_mbps": null,
+"decompress_mbps": 44782.95
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": null,
+"decompress_mbps": 285.79
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": null,
+"decompress_mbps": 394.17
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": null,
+"decompress_mbps": 490.83
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": null,
+"decompress_mbps": 872.22
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": null,
+"decompress_mbps": 39568.8
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 280.24
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 376.56
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 469.68
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 814.84
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 43215.81
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": null,
+"decompress_mbps": 274.96
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": null,
+"decompress_mbps": 378.58
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": null,
+"decompress_mbps": 443.5
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": null,
+"decompress_mbps": 758.48
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": null,
+"decompress_mbps": 42990.09
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": null,
+"decompress_mbps": 294.66
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": null,
+"decompress_mbps": 430.4
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": null,
+"decompress_mbps": 504.88
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": null,
+"decompress_mbps": 905.49
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": null,
+"decompress_mbps": 56649.91
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 0,
+"out_size": 3673380,
+"ratio": 0.3604,
+"compress_mbps": null,
+"decompress_mbps": 281.87
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 0,
+"out_size": 3673380,
+"ratio": 0.3604,
+"compress_mbps": null,
+"decompress_mbps": 416.25
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 0,
+"out_size": 3673380,
+"ratio": 0.3604,
+"compress_mbps": null,
+"decompress_mbps": 471.04
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 0,
+"out_size": 3673380,
+"ratio": 0.3604,
+"compress_mbps": null,
+"decompress_mbps": 822.46
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 0,
+"out_size": 3673380,
+"ratio": 0.3604,
+"compress_mbps": null,
+"decompress_mbps": 40815.25
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": null,
+"decompress_mbps": 254.43
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": null,
+"decompress_mbps": 373.37
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": null,
+"decompress_mbps": 422.66
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": null,
+"decompress_mbps": 735.55
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": null,
+"decompress_mbps": 19512.74
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": null,
+"decompress_mbps": 192.35
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": null,
+"decompress_mbps": 372.25
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": null,
+"decompress_mbps": 389.22
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": null,
+"decompress_mbps": 719.49
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": null,
+"decompress_mbps": 19610.58
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": null,
+"decompress_mbps": 204.46
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": null,
+"decompress_mbps": 378.73
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": null,
+"decompress_mbps": 408.41
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": null,
+"decompress_mbps": 746.55
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": null,
+"decompress_mbps": 20068.97
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": null,
+"decompress_mbps": 206.27
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": null,
+"decompress_mbps": 379.87
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": null,
+"decompress_mbps": 415.28
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": null,
+"decompress_mbps": 755.3
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": null,
+"decompress_mbps": 20261.38
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 187.09
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 381.39
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 399.65
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 747.35
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 19889.26
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 0,
+"out_size": 18317341,
+"ratio": 0.3576,
+"compress_mbps": null,
+"decompress_mbps": 261.25
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 0,
+"out_size": 18317341,
+"ratio": 0.3576,
+"compress_mbps": null,
+"decompress_mbps": 387.18
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 0,
+"out_size": 18317341,
+"ratio": 0.3576,
+"compress_mbps": null,
+"decompress_mbps": 412.66
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 0,
+"out_size": 18317341,
+"ratio": 0.3576,
+"compress_mbps": null,
+"decompress_mbps": 766.3
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 0,
+"out_size": 18317341,
+"ratio": 0.3576,
+"compress_mbps": null,
+"decompress_mbps": 19853.24
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 261.11
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 449.51
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 542.04
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 860.58
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 39274.34
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 282.81
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 457.16
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 546.32
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 910.17
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 40412.73
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 300.08
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 451.57
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 534.45
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 917.54
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 51542.26
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 291.29
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 458.45
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 531.1
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 893.37
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 44963.99
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 285.19
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 489.53
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 510.85
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 893.73
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 55465.49
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 262.71
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 429.53
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 520.36
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 839.62
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 33280.38
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 631.02
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 886.69
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 833.85
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 1792.72
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 20349.65
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 678.92
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 935.17
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 905.24
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 1856.54
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 20250.86
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 873.51
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 1045.5
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 1043.51
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 1889.31
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 19194.77
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 978.09
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 1090.59
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 1076.71
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 1929.12
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 19429.38
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 876.41
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 1104.7
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 1076.89
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 1968.07
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 20105.85
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 1078.42
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 1108.12
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 1110.1
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 1987.24
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 20661.4
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 198.95
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 282.98
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 366.46
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 583.87
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 62106.36
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 179.17
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 277.41
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 326.76
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 553.72
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 63273.78
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 190.09
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 279.96
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 336.01
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 571.37
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 61338.89
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 195.14
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 282.97
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 342.92
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 582.16
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 61441.67
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 180.59
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 278.44
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 319.36
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 560.88
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 63727.37
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 185.86
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 278.05
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 321.37
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 561.04
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 62994.56
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 302.55
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 523.48
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 628.37
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 1038.76
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 54525.79
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 403.77
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 546.12
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 633.43
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 1080.5
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 32880.92
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 422.91
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 553.15
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 672.79
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 1104.22
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 57793.85
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 425.45
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 552.04
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 679.12
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 1095.31
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 44622.86
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 415.12
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 554.88
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 670.5
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 1110.01
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 38186.06
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 463.36
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 572.19
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 713.46
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 1140.97
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 44246.8
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 267.42
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 437.41
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 543.85
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 1014.13
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 61907.44
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 341.23
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 472.46
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 584.99
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 1169.14
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 62261.77
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 354.43
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 471.62
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 554.72
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 1071.79
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 62988.39
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 360.15
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 459.3
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 528.95
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 974.27
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 62089.89
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 364.36
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 541.04
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 592.89
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 1170.28
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 60885.83
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 0,
+"out_size": 1691994,
+"ratio": 0.2553,
+"compress_mbps": null,
+"decompress_mbps": 374.15
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 0,
+"out_size": 1691994,
+"ratio": 0.2553,
+"compress_mbps": null,
+"decompress_mbps": 543.8
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 0,
+"out_size": 1691994,
+"ratio": 0.2553,
+"compress_mbps": null,
+"decompress_mbps": 595.7
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 0,
+"out_size": 1691994,
+"ratio": 0.2553,
+"compress_mbps": null,
+"decompress_mbps": 1158.46
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 0,
+"out_size": 1691994,
+"ratio": 0.2553,
+"compress_mbps": null,
+"decompress_mbps": 62906.89
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 372.49
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 563.85
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 673.01
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 1058.72
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 17127.35
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 326.97
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 575.98
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 675.88
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 1111.61
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 18814.98
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 353.53
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 514.77
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 540.65
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 1107.02
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 18310.13
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 366.75
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 527.21
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 542.66
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 1095.49
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 18200.49
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 303.87
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 609.96
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 661.96
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 1112.01
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 20154.69
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 0,
+"out_size": 5107588,
+"ratio": 0.2364,
+"compress_mbps": null,
+"decompress_mbps": 426.42
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 0,
+"out_size": 5107588,
+"ratio": 0.2364,
+"compress_mbps": null,
+"decompress_mbps": 554.94
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 0,
+"out_size": 5107588,
+"ratio": 0.2364,
+"compress_mbps": null,
+"decompress_mbps": 559.71
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 0,
+"out_size": 5107588,
+"ratio": 0.2364,
+"compress_mbps": null,
+"decompress_mbps": 1153.69
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 0,
+"out_size": 5107588,
+"ratio": 0.2364,
+"compress_mbps": null,
+"decompress_mbps": 18585.7
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 210.05
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 373.58
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 394.86
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 581.99
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 61460.74
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 242.79
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 377.13
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 392.24
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 578.18
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 61281.03
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 246.4
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 375.88
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 387.61
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 564.87
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 57851.66
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323197,
+"ratio": 0.734,
+"compress_mbps": null,
+"decompress_mbps": 248.08
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323197,
+"ratio": 0.734,
+"compress_mbps": null,
+"decompress_mbps": 379.3
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323197,
+"ratio": 0.734,
+"compress_mbps": null,
+"decompress_mbps": 387.42
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323197,
+"ratio": 0.734,
+"compress_mbps": null,
+"decompress_mbps": 567.32
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323197,
+"ratio": 0.734,
+"compress_mbps": null,
+"decompress_mbps": 62157.85
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 12,
+"out_size": 5250745,
+"ratio": 0.724,
+"compress_mbps": null,
+"decompress_mbps": 247.88
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 12,
+"out_size": 5250745,
+"ratio": 0.724,
+"compress_mbps": null,
+"decompress_mbps": 380.11
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 12,
+"out_size": 5250745,
+"ratio": 0.724,
+"compress_mbps": null,
+"decompress_mbps": 395.21
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 12,
+"out_size": 5250745,
+"ratio": 0.724,
+"compress_mbps": null,
+"decompress_mbps": 585.25
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 12,
+"out_size": 5250745,
+"ratio": 0.724,
+"compress_mbps": null,
+"decompress_mbps": 61042.5
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 0,
+"out_size": 5242394,
+"ratio": 0.7229,
+"compress_mbps": null,
+"decompress_mbps": 208.6
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 0,
+"out_size": 5242394,
+"ratio": 0.7229,
+"compress_mbps": null,
+"decompress_mbps": 372.48
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 0,
+"out_size": 5242394,
+"ratio": 0.7229,
+"compress_mbps": null,
+"decompress_mbps": 387.03
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 0,
+"out_size": 5242394,
+"ratio": 0.7229,
+"compress_mbps": null,
+"decompress_mbps": 574.37
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 0,
+"out_size": 5242394,
+"ratio": 0.7229,
+"compress_mbps": null,
+"decompress_mbps": 62018.5
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 13550569,
+"ratio": 0.3268,
+"compress_mbps": null,
+"decompress_mbps": 274.69
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 13550569,
+"ratio": 0.3268,
+"compress_mbps": null,
+"decompress_mbps": 387.9
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 13550569,
+"ratio": 0.3268,
+"compress_mbps": null,
+"decompress_mbps": 435.67
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 13550569,
+"ratio": 0.3268,
+"compress_mbps": null,
+"decompress_mbps": 837.23
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 13550569,
+"ratio": 0.3268,
+"compress_mbps": null,
+"decompress_mbps": 19650.93
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 12839361,
+"ratio": 0.3097,
+"compress_mbps": null,
+"decompress_mbps": 340.5
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 12839361,
+"ratio": 0.3097,
+"compress_mbps": null,
+"decompress_mbps": 399.36
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 12839361,
+"ratio": 0.3097,
+"compress_mbps": null,
+"decompress_mbps": 460.59
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 12839361,
+"ratio": 0.3097,
+"compress_mbps": null,
+"decompress_mbps": 906.53
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 12839361,
+"ratio": 0.3097,
+"compress_mbps": null,
+"decompress_mbps": 20284.8
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12140474,
+"ratio": 0.2928,
+"compress_mbps": null,
+"decompress_mbps": 348.23
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12140474,
+"ratio": 0.2928,
+"compress_mbps": null,
+"decompress_mbps": 403.13
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12140474,
+"ratio": 0.2928,
+"compress_mbps": null,
+"decompress_mbps": 467.92
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12140474,
+"ratio": 0.2928,
+"compress_mbps": null,
+"decompress_mbps": 870.02
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12140474,
+"ratio": 0.2928,
+"compress_mbps": null,
+"decompress_mbps": 19746.76
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 11882496,
+"ratio": 0.2866,
+"compress_mbps": null,
+"decompress_mbps": 350.8
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 11882496,
+"ratio": 0.2866,
+"compress_mbps": null,
+"decompress_mbps": 404.8
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 11882496,
+"ratio": 0.2866,
+"compress_mbps": null,
+"decompress_mbps": 466.19
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 11882496,
+"ratio": 0.2866,
+"compress_mbps": null,
+"decompress_mbps": 840.03
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 11882496,
+"ratio": 0.2866,
+"compress_mbps": null,
+"decompress_mbps": 19602.73
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 12,
+"out_size": 11520871,
+"ratio": 0.2779,
+"compress_mbps": null,
+"decompress_mbps": 353.01
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 12,
+"out_size": 11520871,
+"ratio": 0.2779,
+"compress_mbps": null,
+"decompress_mbps": 422.02
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 12,
+"out_size": 11520871,
+"ratio": 0.2779,
+"compress_mbps": null,
+"decompress_mbps": 477.62
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 12,
+"out_size": 11520871,
+"ratio": 0.2779,
+"compress_mbps": null,
+"decompress_mbps": 877.38
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 12,
+"out_size": 11520871,
+"ratio": 0.2779,
+"compress_mbps": null,
+"decompress_mbps": 19450.41
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 0,
+"out_size": 11518290,
+"ratio": 0.2778,
+"compress_mbps": null,
+"decompress_mbps": 367.46
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 0,
+"out_size": 11518290,
+"ratio": 0.2778,
+"compress_mbps": null,
+"decompress_mbps": 426.45
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 0,
+"out_size": 11518290,
+"ratio": 0.2778,
+"compress_mbps": null,
+"decompress_mbps": 485.38
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 0,
+"out_size": 11518290,
+"ratio": 0.2778,
+"compress_mbps": null,
+"decompress_mbps": 881.73
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 0,
+"out_size": 11518290,
+"ratio": 0.2778,
+"compress_mbps": null,
+"decompress_mbps": 18768.21
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6293390,
+"ratio": 0.7426,
+"compress_mbps": null,
+"decompress_mbps": 205.4
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6293390,
+"ratio": 0.7426,
+"compress_mbps": null,
+"decompress_mbps": 327.92
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6293390,
+"ratio": 0.7426,
+"compress_mbps": null,
+"decompress_mbps": 355.5
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6293390,
+"ratio": 0.7426,
+"compress_mbps": null,
+"decompress_mbps": 507.48
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6293390,
+"ratio": 0.7426,
+"compress_mbps": null,
+"decompress_mbps": 59779.61
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6058381,
+"ratio": 0.7149,
+"compress_mbps": null,
+"decompress_mbps": 165.4
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6058381,
+"ratio": 0.7149,
+"compress_mbps": null,
+"decompress_mbps": 275.55
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6058381,
+"ratio": 0.7149,
+"compress_mbps": null,
+"decompress_mbps": 298.54
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6058381,
+"ratio": 0.7149,
+"compress_mbps": null,
+"decompress_mbps": 467.75
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6058381,
+"ratio": 0.7149,
+"compress_mbps": null,
+"decompress_mbps": 60912.79
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 5998438,
+"ratio": 0.7078,
+"compress_mbps": null,
+"decompress_mbps": 178.97
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 5998438,
+"ratio": 0.7078,
+"compress_mbps": null,
+"decompress_mbps": 318.39
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 5998438,
+"ratio": 0.7078,
+"compress_mbps": null,
+"decompress_mbps": 319.88
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 5998438,
+"ratio": 0.7078,
+"compress_mbps": null,
+"decompress_mbps": 522.55
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 5998438,
+"ratio": 0.7078,
+"compress_mbps": null,
+"decompress_mbps": 59118.42
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 5986859,
+"ratio": 0.7065,
+"compress_mbps": null,
+"decompress_mbps": 178.07
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 5986859,
+"ratio": 0.7065,
+"compress_mbps": null,
+"decompress_mbps": 311.37
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 5986859,
+"ratio": 0.7065,
+"compress_mbps": null,
+"decompress_mbps": 313.34
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 5986859,
+"ratio": 0.7065,
+"compress_mbps": null,
+"decompress_mbps": 510.07
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 5986859,
+"ratio": 0.7065,
+"compress_mbps": null,
+"decompress_mbps": 56443.3
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 12,
+"out_size": 5747146,
+"ratio": 0.6782,
+"compress_mbps": null,
+"decompress_mbps": 182.82
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 12,
+"out_size": 5747146,
+"ratio": 0.6782,
+"compress_mbps": null,
+"decompress_mbps": 296.62
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 12,
+"out_size": 5747146,
+"ratio": 0.6782,
+"compress_mbps": null,
+"decompress_mbps": 329.74
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 12,
+"out_size": 5747146,
+"ratio": 0.6782,
+"compress_mbps": null,
+"decompress_mbps": 561.62
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 12,
+"out_size": 5747146,
+"ratio": 0.6782,
+"compress_mbps": null,
+"decompress_mbps": 59726.59
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 0,
+"out_size": 5744697,
+"ratio": 0.6779,
+"compress_mbps": null,
+"decompress_mbps": 177.2
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 0,
+"out_size": 5744697,
+"ratio": 0.6779,
+"compress_mbps": null,
+"decompress_mbps": 287.1
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 0,
+"out_size": 5744697,
+"ratio": 0.6779,
+"compress_mbps": null,
+"decompress_mbps": 326.7
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 0,
+"out_size": 5744697,
+"ratio": 0.6779,
+"compress_mbps": null,
+"decompress_mbps": 558.23
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 0,
+"out_size": 5744697,
+"ratio": 0.6779,
+"compress_mbps": null,
+"decompress_mbps": 60149.79
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 887708,
+"ratio": 0.1661,
+"compress_mbps": null,
+"decompress_mbps": 479.63
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 887708,
+"ratio": 0.1661,
+"compress_mbps": null,
+"decompress_mbps": 762.88
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 887708,
+"ratio": 0.1661,
+"compress_mbps": null,
+"decompress_mbps": 912.18
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 887708,
+"ratio": 0.1661,
+"compress_mbps": null,
+"decompress_mbps": 1664.62
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 887708,
+"ratio": 0.1661,
+"compress_mbps": null,
+"decompress_mbps": 63809.24
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 793388,
+"ratio": 0.1484,
+"compress_mbps": null,
+"decompress_mbps": 596.87
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 793388,
+"ratio": 0.1484,
+"compress_mbps": null,
+"decompress_mbps": 854.07
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 793388,
+"ratio": 0.1484,
+"compress_mbps": null,
+"decompress_mbps": 1076.18
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 793388,
+"ratio": 0.1484,
+"compress_mbps": null,
+"decompress_mbps": 1824.15
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 793388,
+"ratio": 0.1484,
+"compress_mbps": null,
+"decompress_mbps": 61720.2
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 684405,
+"ratio": 0.128,
+"compress_mbps": null,
+"decompress_mbps": 658.1
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 684405,
+"ratio": 0.128,
+"compress_mbps": null,
+"decompress_mbps": 936.92
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 684405,
+"ratio": 0.128,
+"compress_mbps": null,
+"decompress_mbps": 1189.73
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 684405,
+"ratio": 0.128,
+"compress_mbps": null,
+"decompress_mbps": 1824.93
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 684405,
+"ratio": 0.128,
+"compress_mbps": null,
+"decompress_mbps": 65032.74
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 649494,
+"ratio": 0.1215,
+"compress_mbps": null,
+"decompress_mbps": 684.64
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 649494,
+"ratio": 0.1215,
+"compress_mbps": null,
+"decompress_mbps": 965.09
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 649494,
+"ratio": 0.1215,
+"compress_mbps": null,
+"decompress_mbps": 1178.07
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 649494,
+"ratio": 0.1215,
+"compress_mbps": null,
+"decompress_mbps": 1811.98
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 649494,
+"ratio": 0.1215,
+"compress_mbps": null,
+"decompress_mbps": 64472.61
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 12,
+"out_size": 629349,
+"ratio": 0.1177,
+"compress_mbps": null,
+"decompress_mbps": 639.92
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 12,
+"out_size": 629349,
+"ratio": 0.1177,
+"compress_mbps": null,
+"decompress_mbps": 983.62
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 12,
+"out_size": 629349,
+"ratio": 0.1177,
+"compress_mbps": null,
+"decompress_mbps": 1187.88
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 12,
+"out_size": 629349,
+"ratio": 0.1177,
+"compress_mbps": null,
+"decompress_mbps": 1878.29
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 12,
+"out_size": 629349,
+"ratio": 0.1177,
+"compress_mbps": null,
+"decompress_mbps": 64293.72
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 0,
+"out_size": 627169,
+"ratio": 0.1173,
+"compress_mbps": null,
+"decompress_mbps": 728.02
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 0,
+"out_size": 627169,
+"ratio": 0.1173,
+"compress_mbps": null,
+"decompress_mbps": 1001.81
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 0,
+"out_size": 627169,
+"ratio": 0.1173,
+"compress_mbps": null,
+"decompress_mbps": 1211.48
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 0,
+"out_size": 627169,
+"ratio": 0.1173,
+"compress_mbps": null,
+"decompress_mbps": 1884.9
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 0,
+"out_size": 627169,
+"ratio": 0.1173,
+"compress_mbps": null,
+"decompress_mbps": 60159.27
+},
+{
+"compressor": "go",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4217525,
+"ratio": 0.4138,
+"compress_mbps": null,
+"decompress_mbps": 192.06
+},
+{
+"compressor": "go",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": null,
+"decompress_mbps": 221.08
+},
+{
+"compressor": "go",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": null,
+"decompress_mbps": 202.07
+},
+{
+"compressor": "go",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 205.34
+},
+{
+"compressor": "go",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": null,
+"decompress_mbps": 203.21
+},
+{
+"compressor": "go",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 0,
+"out_size": 3673380,
+"ratio": 0.3604,
+"compress_mbps": null,
+"decompress_mbps": 214.43
+},
+{
+"compressor": "go",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": null,
+"decompress_mbps": 231.18
+},
+{
+"compressor": "go",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 231.96
+},
+{
+"compressor": "go",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": null,
+"decompress_mbps": 224.51
+},
+{
+"compressor": "go",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": null,
+"decompress_mbps": 232.7
+},
+{
+"compressor": "go",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": null,
+"decompress_mbps": 234.15
+},
+{
+"compressor": "go",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 0,
+"out_size": 18317341,
+"ratio": 0.3576,
+"compress_mbps": null,
+"decompress_mbps": 238.76
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 230.41
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 235.41
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 225.26
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 232.08
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 233
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 233.65
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 580.78
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 784.5
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 599.89
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 670.78
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 741.92
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 749.65
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 168.31
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 160.64
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 155.39
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 166
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 169.75
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 160.99
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 253.4
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 269.43
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 262.57
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 269.49
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 270.57
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 285.93
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 227.09
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 283.58
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 256.09
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 262.67
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 260.9
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 0,
+"out_size": 1691994,
+"ratio": 0.2553,
+"compress_mbps": null,
+"decompress_mbps": 285.32
+},
+{
+"compressor": "go",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 306.97
+},
+{
+"compressor": "go",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 324.28
+},
+{
+"compressor": "go",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 316.81
+},
+{
+"compressor": "go",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 323.75
+},
+{
+"compressor": "go",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 328.64
+},
+{
+"compressor": "go",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 0,
+"out_size": 5107588,
+"ratio": 0.2364,
+"compress_mbps": null,
+"decompress_mbps": 344.93
+},
+{
+"compressor": "go",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 182.22
+},
+{
+"compressor": "go",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 12,
+"out_size": 5250745,
+"ratio": 0.724,
+"compress_mbps": null,
+"decompress_mbps": 188.68
+},
+{
+"compressor": "go",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 187.28
+},
+{
+"compressor": "go",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 186.08
+},
+{
+"compressor": "go",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323197,
+"ratio": 0.734,
+"compress_mbps": null,
+"decompress_mbps": 188.75
+},
+{
+"compressor": "go",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 0,
+"out_size": 5242394,
+"ratio": 0.7229,
+"compress_mbps": null,
+"decompress_mbps": 186.36
+},
+{
+"compressor": "go",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 13550569,
+"ratio": 0.3268,
+"compress_mbps": null,
+"decompress_mbps": 225.06
+},
+{
+"compressor": "go",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 12,
+"out_size": 11520871,
+"ratio": 0.2779,
+"compress_mbps": null,
+"decompress_mbps": 256.66
+},
+{
+"compressor": "go",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 12839361,
+"ratio": 0.3097,
+"compress_mbps": null,
+"decompress_mbps": 242.54
+},
+{
+"compressor": "go",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12140474,
+"ratio": 0.2928,
+"compress_mbps": null,
+"decompress_mbps": 247.96
+},
+{
+"compressor": "go",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 11882496,
+"ratio": 0.2866,
+"compress_mbps": null,
+"decompress_mbps": 250.83
+},
+{
+"compressor": "go",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 0,
+"out_size": 11518290,
+"ratio": 0.2778,
+"compress_mbps": null,
+"decompress_mbps": 256.89
+},
+{
+"compressor": "go",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6293390,
+"ratio": 0.7426,
+"compress_mbps": null,
+"decompress_mbps": 166.3
+},
+{
+"compressor": "go",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 12,
+"out_size": 5747146,
+"ratio": 0.6782,
+"compress_mbps": null,
+"decompress_mbps": 140.99
+},
+{
+"compressor": "go",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6058381,
+"ratio": 0.7149,
+"compress_mbps": null,
+"decompress_mbps": 144.96
+},
+{
+"compressor": "go",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 5998438,
+"ratio": 0.7078,
+"compress_mbps": null,
+"decompress_mbps": 152.03
+},
+{
+"compressor": "go",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 5986859,
+"ratio": 0.7065,
+"compress_mbps": null,
+"decompress_mbps": 149.13
+},
+{
+"compressor": "go",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 0,
+"out_size": 5744697,
+"ratio": 0.6779,
+"compress_mbps": null,
+"decompress_mbps": 136.8
+},
+{
+"compressor": "go",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 887708,
+"ratio": 0.1661,
+"compress_mbps": null,
+"decompress_mbps": 440.5
+},
+{
+"compressor": "go",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 12,
+"out_size": 629349,
+"ratio": 0.1177,
+"compress_mbps": null,
+"decompress_mbps": 615.59
+},
+{
+"compressor": "go",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 793388,
+"ratio": 0.1484,
+"compress_mbps": null,
+"decompress_mbps": 507.61
+},
+{
+"compressor": "go",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 684405,
+"ratio": 0.128,
+"compress_mbps": null,
+"decompress_mbps": 581.96
+},
+{
+"compressor": "go",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 649494,
+"ratio": 0.1215,
+"compress_mbps": null,
+"decompress_mbps": 607.22
+},
+{
+"compressor": "go",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 0,
+"out_size": 627169,
+"ratio": 0.1173,
+"compress_mbps": null,
+"decompress_mbps": 618.22
+},
+{
+"compressor": "js",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4217525,
+"ratio": 0.4138,
+"compress_mbps": null,
+"decompress_mbps": 110.32
+},
+{
+"compressor": "js",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": null,
+"decompress_mbps": 121.35
+},
+{
+"compressor": "js",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": null,
+"decompress_mbps": 135.89
+},
+{
+"compressor": "js",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 135.35
+},
+{
+"compressor": "js",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": null,
+"decompress_mbps": 122.04
+},
+{
+"compressor": "js",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 0,
+"out_size": 3673380,
+"ratio": 0.3604,
+"compress_mbps": null,
+"decompress_mbps": 129.36
+},
+{
+"compressor": "js",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": null,
+"decompress_mbps": 157.13
+},
+{
+"compressor": "js",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 151.8
+},
+{
+"compressor": "js",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": null,
+"decompress_mbps": 155.7
+},
+{
+"compressor": "js",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": null,
+"decompress_mbps": 184.47
+},
+{
+"compressor": "js",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": null,
+"decompress_mbps": 161.51
+},
+{
+"compressor": "js",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 0,
+"out_size": 18317341,
+"ratio": 0.3576,
+"compress_mbps": null,
+"decompress_mbps": 179.47
+},
+{
+"compressor": "js",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 139.97
+},
+{
+"compressor": "js",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 140.17
+},
+{
+"compressor": "js",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 142.22
+},
+{
+"compressor": "js",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 135.12
+},
+{
+"compressor": "js",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 134.98
+},
+{
+"compressor": "js",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 135.73
+},
+{
+"compressor": "js",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 247.01
+},
+{
+"compressor": "js",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 288.55
+},
+{
+"compressor": "js",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 285.59
+},
+{
+"compressor": "js",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 315.73
+},
+{
+"compressor": "js",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 325.56
+},
+{
+"compressor": "js",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 282.97
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 103.44
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 100.24
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 111.59
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 112.08
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 100.54
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 86.65
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 147.38
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 179.06
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 162.32
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 176.1
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 161.28
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 178.95
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 116.87
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 143.07
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 147.34
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 143.54
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 144.39
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 0,
+"out_size": 1691994,
+"ratio": 0.2553,
+"compress_mbps": null,
+"decompress_mbps": 107.62
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 171.56
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 169.28
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 157
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 167.34
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 175.15
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 0,
+"out_size": 5107588,
+"ratio": 0.2364,
+"compress_mbps": null,
+"decompress_mbps": 190.12
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 99.87
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 12,
+"out_size": 5250745,
+"ratio": 0.724,
+"compress_mbps": null,
+"decompress_mbps": 98.34
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 104.89
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 100.16
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323197,
+"ratio": 0.734,
+"compress_mbps": null,
+"decompress_mbps": 107.95
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 0,
+"out_size": 5242394,
+"ratio": 0.7229,
+"compress_mbps": null,
+"decompress_mbps": 112.69
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 13550569,
+"ratio": 0.3268,
+"compress_mbps": null,
+"decompress_mbps": 141.66
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 12,
+"out_size": 11520871,
+"ratio": 0.2779,
+"compress_mbps": null,
+"decompress_mbps": 158.68
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 12839361,
+"ratio": 0.3097,
+"compress_mbps": null,
+"decompress_mbps": 148.82
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12140474,
+"ratio": 0.2928,
+"compress_mbps": null,
+"decompress_mbps": 154.56
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 11882496,
+"ratio": 0.2866,
+"compress_mbps": null,
+"decompress_mbps": 162.66
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 0,
+"out_size": 11518290,
+"ratio": 0.2778,
+"compress_mbps": null,
+"decompress_mbps": 145.3
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6293390,
+"ratio": 0.7426,
+"compress_mbps": null,
+"decompress_mbps": 100.14
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 12,
+"out_size": 5747146,
+"ratio": 0.6782,
+"compress_mbps": null,
+"decompress_mbps": 107.98
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6058381,
+"ratio": 0.7149,
+"compress_mbps": null,
+"decompress_mbps": 102.33
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 5998438,
+"ratio": 0.7078,
+"compress_mbps": null,
+"decompress_mbps": 94.73
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 5986859,
+"ratio": 0.7065,
+"compress_mbps": null,
+"decompress_mbps": 105.01
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 0,
+"out_size": 5744697,
+"ratio": 0.6779,
+"compress_mbps": null,
+"decompress_mbps": 96.26
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 887708,
+"ratio": 0.1661,
+"compress_mbps": null,
+"decompress_mbps": 183.84
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 12,
+"out_size": 629349,
+"ratio": 0.1177,
+"compress_mbps": null,
+"decompress_mbps": 269.82
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 793388,
+"ratio": 0.1484,
+"compress_mbps": null,
+"decompress_mbps": 181.01
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 684405,
+"ratio": 0.128,
+"compress_mbps": null,
+"decompress_mbps": 241.09
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 649494,
+"ratio": 0.1215,
+"compress_mbps": null,
+"decompress_mbps": 241.61
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 0,
+"out_size": 627169,
+"ratio": 0.1173,
+"compress_mbps": null,
+"decompress_mbps": 150.18
+},
+{
+"compressor": "zig",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4217525,
+"ratio": 0.4138,
+"compress_mbps": null,
+"decompress_mbps": 221.52
+},
+{
+"compressor": "zig",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": null,
+"decompress_mbps": 279.11
+},
+{
+"compressor": "zig",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": null,
+"decompress_mbps": 271.68
+},
+{
+"compressor": "zig",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 268.18
+},
+{
+"compressor": "zig",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": null,
+"decompress_mbps": 261.3
+},
+{
+"compressor": "zig",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 0,
+"out_size": 3673380,
+"ratio": 0.3604,
+"compress_mbps": null,
+"decompress_mbps": 280.48
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": null,
+"decompress_mbps": 235.66
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 217.47
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": null,
+"decompress_mbps": 217.25
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": null,
+"decompress_mbps": 227.9
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": null,
+"decompress_mbps": 231.3
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 0,
+"out_size": 18317341,
+"ratio": 0.3576,
+"compress_mbps": null,
+"decompress_mbps": 252.69
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 231.68
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 267.47
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 260.13
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 267.23
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 269.92
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 250.54
+},
+{
+"compressor": "zig",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 681.98
+},
+{
+"compressor": "zig",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 850.06
+},
+{
+"compressor": "zig",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 740.59
+},
+{
+"compressor": "zig",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 837.02
+},
+{
+"compressor": "zig",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 898.09
+},
+{
+"compressor": "zig",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 929.1
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 175.52
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 180.02
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 176.42
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 184.48
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 187.36
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 181.46
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 253.03
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 290.53
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 282.62
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 286.75
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 287.31
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 289.16
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 286.4
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 374.93
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 352.79
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 355.31
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 347.95
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 0,
+"out_size": 1691994,
+"ratio": 0.2553,
+"compress_mbps": null,
+"decompress_mbps": 380.13
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 349.73
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 329.93
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 342.11
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 365.6
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 369.05
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 0,
+"out_size": 5107588,
+"ratio": 0.2364,
+"compress_mbps": null,
+"decompress_mbps": 398.36
+},
+{
+"compressor": "zig",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 159.66
+},
+{
+"compressor": "zig",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 12,
+"out_size": 5250745,
+"ratio": 0.724,
+"compress_mbps": null,
+"decompress_mbps": 174.01
+},
+{
+"compressor": "zig",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 172.0
+},
+{
+"compressor": "zig",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 173.41
+},
+{
+"compressor": "zig",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323197,
+"ratio": 0.734,
+"compress_mbps": null,
+"decompress_mbps": 175.23
+},
+{
+"compressor": "zig",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 0,
+"out_size": 5242394,
+"ratio": 0.7229,
+"compress_mbps": null,
+"decompress_mbps": 165.88
+},
+{
+"compressor": "zig",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 13550569,
+"ratio": 0.3268,
+"compress_mbps": null,
+"decompress_mbps": 275.01
+},
+{
+"compressor": "zig",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 12,
+"out_size": 11520871,
+"ratio": 0.2779,
+"compress_mbps": null,
+"decompress_mbps": 330.5
+},
+{
+"compressor": "zig",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 12839361,
+"ratio": 0.3097,
+"compress_mbps": null,
+"decompress_mbps": 316.23
+},
+{
+"compressor": "zig",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12140474,
+"ratio": 0.2928,
+"compress_mbps": null,
+"decompress_mbps": 326.18
+},
+{
+"compressor": "zig",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 11882496,
+"ratio": 0.2866,
+"compress_mbps": null,
+"decompress_mbps": 328.09
+},
+{
+"compressor": "zig",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 0,
+"out_size": 11518290,
+"ratio": 0.2778,
+"compress_mbps": null,
+"decompress_mbps": 338.32
+},
+{
+"compressor": "zig",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6293390,
+"ratio": 0.7426,
+"compress_mbps": null,
+"decompress_mbps": 150.88
+},
+{
+"compressor": "zig",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 12,
+"out_size": 5747146,
+"ratio": 0.6782,
+"compress_mbps": null,
+"decompress_mbps": 149.76
+},
+{
+"compressor": "zig",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6058381,
+"ratio": 0.7149,
+"compress_mbps": null,
+"decompress_mbps": 143.82
+},
+{
+"compressor": "zig",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 5998438,
+"ratio": 0.7078,
+"compress_mbps": null,
+"decompress_mbps": 157.28
+},
+{
+"compressor": "zig",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 5986859,
+"ratio": 0.7065,
+"compress_mbps": null,
+"decompress_mbps": 154.91
+},
+{
+"compressor": "zig",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 0,
+"out_size": 5744697,
+"ratio": 0.6779,
+"compress_mbps": null,
+"decompress_mbps": 145.13
+},
+{
+"compressor": "zig",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 887708,
+"ratio": 0.1661,
+"compress_mbps": null,
+"decompress_mbps": 507.13
+},
+{
+"compressor": "zig",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 12,
+"out_size": 629349,
+"ratio": 0.1177,
+"compress_mbps": null,
+"decompress_mbps": 667.01
+},
+{
+"compressor": "zig",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 793388,
+"ratio": 0.1484,
+"compress_mbps": null,
+"decompress_mbps": 600.84
+},
+{
+"compressor": "zig",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 684405,
+"ratio": 0.128,
+"compress_mbps": null,
+"decompress_mbps": 668.37
+},
+{
+"compressor": "zig",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 649494,
+"ratio": 0.1215,
+"compress_mbps": null,
+"decompress_mbps": 685.14
+},
+{
+"compressor": "zig",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 0,
+"out_size": 627169,
+"ratio": 0.1173,
+"compress_mbps": null,
+"decompress_mbps": 710.32
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4217525,
+"ratio": 0.4138,
+"compress_mbps": null,
+"decompress_mbps": 105.29
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": null,
+"decompress_mbps": 115.26
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": null,
+"decompress_mbps": 110.2
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 111.7
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": null,
+"decompress_mbps": 112.72
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 0,
+"out_size": 3673380,
+"ratio": 0.3604,
+"compress_mbps": null,
+"decompress_mbps": 110.97
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": null,
+"decompress_mbps": 122.7
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 116.84
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": null,
+"decompress_mbps": 112.59
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": null,
+"decompress_mbps": 116.2
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": null,
+"decompress_mbps": 120.86
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 0,
+"out_size": 18317341,
+"ratio": 0.3576,
+"compress_mbps": null,
+"decompress_mbps": 123.3
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 135.81
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 132.57
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 129.0
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 133.44
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 132.48
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 135.63
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 213.53
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 233.62
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 220.32
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 222.14
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 225.08
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 235.5
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 105.75
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 98.03
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 98.21
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 99.44
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 99.62
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 97.22
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 142.69
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 149.33
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 142.62
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 145.65
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 146.05
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 152.57
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 122.54
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 147.3
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 130.7
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 139.21
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 138.26
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 0,
+"out_size": 1691994,
+"ratio": 0.2553,
+"compress_mbps": null,
+"decompress_mbps": 144.91
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 154.54
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 157.5
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 151.36
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 154.36
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 161.93
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 0,
+"out_size": 5107588,
+"ratio": 0.2364,
+"compress_mbps": null,
+"decompress_mbps": 159.84
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 108.47
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 12,
+"out_size": 5250745,
+"ratio": 0.724,
+"compress_mbps": null,
+"decompress_mbps": 111.25
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 111.49
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 114.78
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323197,
+"ratio": 0.734,
+"compress_mbps": null,
+"decompress_mbps": 115.99
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 0,
+"out_size": 5242394,
+"ratio": 0.7229,
+"compress_mbps": null,
+"decompress_mbps": 107.65
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 13550569,
+"ratio": 0.3268,
+"compress_mbps": null,
+"decompress_mbps": 115.09
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 12,
+"out_size": 11520871,
+"ratio": 0.2779,
+"compress_mbps": null,
+"decompress_mbps": 125.88
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 12839361,
+"ratio": 0.3097,
+"compress_mbps": null,
+"decompress_mbps": 123.59
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12140474,
+"ratio": 0.2928,
+"compress_mbps": null,
+"decompress_mbps": 122.74
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 11882496,
+"ratio": 0.2866,
+"compress_mbps": null,
+"decompress_mbps": 123.85
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 0,
+"out_size": 11518290,
+"ratio": 0.2778,
+"compress_mbps": null,
+"decompress_mbps": 128.15
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6293390,
+"ratio": 0.7426,
+"compress_mbps": null,
+"decompress_mbps": 104.36
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 12,
+"out_size": 5747146,
+"ratio": 0.6782,
+"compress_mbps": null,
+"decompress_mbps": 91.78
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6058381,
+"ratio": 0.7149,
+"compress_mbps": null,
+"decompress_mbps": 91.81
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 5998438,
+"ratio": 0.7078,
+"compress_mbps": null,
+"decompress_mbps": 91.6
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 5986859,
+"ratio": 0.7065,
+"compress_mbps": null,
+"decompress_mbps": 93.99
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 0,
+"out_size": 5744697,
+"ratio": 0.6779,
+"compress_mbps": null,
+"decompress_mbps": 92.35
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 887708,
+"ratio": 0.1661,
+"compress_mbps": null,
+"decompress_mbps": 192.55
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 12,
+"out_size": 629349,
+"ratio": 0.1177,
+"compress_mbps": null,
+"decompress_mbps": 228.12
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 793388,
+"ratio": 0.1484,
+"compress_mbps": null,
+"decompress_mbps": 195.16
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 684405,
+"ratio": 0.128,
+"compress_mbps": null,
+"decompress_mbps": 216.09
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 649494,
+"ratio": 0.1215,
+"compress_mbps": null,
+"decompress_mbps": 219.58
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 0,
+"out_size": 627169,
+"ratio": 0.1173,
+"compress_mbps": null,
+"decompress_mbps": 221.88
+}
+]
 }


### PR DESCRIPTION
This PR routes the decode-density benchmark through the verified exact-size fastloop, so `silesia_decode_ranking` reflects the fast path that ZIP extraction already runs in production. The two native-decode call sites in the decode-density harness (`nativeDecompress` and the `decodeForAB` A/B diagnostic) switch from `Zip.Native.Inflate.inflate data (sizeHint := origSize)` — where `sizeHint` only pre-reserves capacity — to `Zip.Native.Inflate.inflateSized data (sizeHint := origSize) (exact := true)`, which engages the branch-free `uset` exact-size fastloop shipped to ZIP extraction in https://github.com/kim-em/lean-zip/pull/2840. `inflateSized_agrees` proves `inflateSized = inflate` unconditionally, so the dashboard measures byte-identical output, only faster on the exact-size path.

The refreshed `bench/results/decode_density.json` and the two decode SVGs (`silesia_decode_ranking`, `silesia_decode_density`) re-record the native rows through the fastloop. The committed baseline (da9d9c0e) predated https://github.com/kim-em/lean-zip/pull/2799, https://github.com/kim-em/lean-zip/pull/2819 and https://github.com/kim-em/lean-zip/pull/2840, so this also brings the stale decode dashboard current. The go/js/zig/ocaml comparator rows are preserved from the prior run — they decode byte-identical libdeflate/zopfli streams, unaffected by this change (the toolchains are not built on this box; per the #2808 dashboard-refresh caveat, preserving rather than dropping their curves).

Because the committed baseline is stale and cross-session single-pass Silesia carries large noise, the honest measure of what this routing buys is a same-build paired A/B (push no-hint vs exact-size fastloop, 20 pairs/file, pinned to one core): silesia **+5.95%** (95% CI [1.055, 1.064]), canterbury **+3.42%** — in line with the ~+6.2% the issue predicted. `bench/README.md` now notes that the headline native decode number is the known-exact-size production path (what ZIP extraction uses).

Closes https://github.com/kim-em/lean-zip/issues/2845.

🤖 Prepared with Claude Code