### PR TITLE
perf(decode): wire the verified exact-size fastloop into gzip/tar.gz decode

### DIFF
--- a/Zip/Native/Gzip.lean
+++ b/Zip/Native/Gzip.lean
@@ -1,5 +1,6 @@
 import Zip.Native.Inflate
 import Zip.Native.InflateTreeFree
+import Zip.Native.InflateFast
 import Zip.Native.DeflateDynamic
 import Zip.Native.Crc32
 import Zip.Native.Adler32
@@ -16,6 +17,12 @@ import ZipCommon.Binary
 namespace Zip.Native
 
 namespace GzipDecode
+
+/-- Absolute ceiling on the exact-size fastloop's speculative presize allocation,
+    mirroring `Zip.Archive.nativePresizeCap`. A member whose declared decompressed
+    size (gzip trailer `ISIZE`) exceeds this keeps the push decoder rather than
+    pre-extending a large buffer up front. -/
+def presizeCap : Nat := 64 * 1024 * 1024
 
 /-- Scan forward from `pos` in `data` for the next zero byte (NUL).
     Returns the index of the zero byte, or `data.size` if none is found. -/
@@ -79,7 +86,29 @@ def decompress (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024) :
       if pos > data.size then throw "Gzip: header extends past end of input"
       -- Inflate (cap each member to remaining budget so total stays within maxOutputSize)
       let memberMax := maxOutputSize - result.size
-      let (decompressed, endPos) ← Inflate.inflateRaw data pos memberMax
+      -- Exact-size fastloop for the single-member case (tar.gz, the dominant real
+      -- workload). For a stream with exactly one member, the trailing 8 bytes are
+      -- this member's trailer, so `ISIZE = readUInt32LE data (size - 4)` is the
+      -- exact decompressed length. We attempt the verified branch-free `uset`
+      -- fastloop (`inflateRawSized … (exact := true)`) only on the *first* member
+      -- (`result.size == 0`) — for a later member the trailing ISIZE is not this
+      -- member's size — and only when the hint is bounded by `presizeCap` and the
+      -- member budget (`exact` conjuncts). `inflateRawSized` is proven equal to
+      -- `inflateRaw` for every `USize`-representable input
+      -- (`Zip.Native.inflateRawSized_agrees`, with `pos ≤ data.size` from the guard
+      -- above), so a wrong hint — a concatenated multi-member stream, trailing
+      -- padding, or a malicious ISIZE — makes the fastloop's exact-size contract
+      -- reject and fall back to the push `inflateRaw`, never changing the decoded
+      -- bytes or the returned `endPos`. The CRC32 / ISIZE trailer checks below stay
+      -- integrity checks, not soundness backstops.
+      let (decompressed, endPos) ←
+        if result.size == 0 then
+          let isize := (Binary.readUInt32LE data (data.size - 4)).toNat
+          let sizeHint := min isize presizeCap
+          let exact := isize == sizeHint && isize ≤ memberMax && memberMax < USize.size
+          Inflate.inflateRawSized data pos memberMax (sizeHint := sizeHint) (exact := exact)
+        else
+          Inflate.inflateRaw data pos memberMax
       pos := endPos
       -- Parse trailer: CRC32 (4 bytes LE) + ISIZE (4 bytes LE)
       if pos + 8 > data.size then throw "Gzip: truncated trailer"

--- a/Zip/Native/Gzip.lean
+++ b/Zip/Native/Gzip.lean
@@ -50,6 +50,11 @@ def decompress (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024) :
   if data.size < 10 then throw "Gzip: input too short for gzip header"
   let mut pos : Nat := 0
   let mut result : ByteArray := .empty
+  -- Tracks the very first member. `result.size == 0` is *not* a first-member test:
+  -- an empty member (or a run of them) leaves `result` empty, so it would let every
+  -- empty-prefix member re-attempt the speculative presize. A dedicated flag caps
+  -- the fastloop attempt at exactly one per stream.
+  let mut firstMember : Bool := true
   -- Process concatenated gzip members
   for _ in [:1000] do
     if pos ≥ data.size then return result
@@ -91,24 +96,32 @@ def decompress (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024) :
       -- this member's trailer, so `ISIZE = readUInt32LE data (size - 4)` is the
       -- exact decompressed length. We attempt the verified branch-free `uset`
       -- fastloop (`inflateRawSized … (exact := true)`) only on the *first* member
-      -- (`result.size == 0`) — for a later member the trailing ISIZE is not this
-      -- member's size — and only when the hint is bounded by `presizeCap` and the
-      -- member budget (`exact` conjuncts). `inflateRawSized` is proven equal to
-      -- `inflateRaw` for every `USize`-representable input
-      -- (`Zip.Native.inflateRawSized_agrees`, with `pos ≤ data.size` from the guard
-      -- above), so a wrong hint — a concatenated multi-member stream, trailing
-      -- padding, or a malicious ISIZE — makes the fastloop's exact-size contract
-      -- reject and fall back to the push `inflateRaw`, never changing the decoded
-      -- bytes or the returned `endPos`. The CRC32 / ISIZE trailer checks below stay
-      -- integrity checks, not soundness backstops.
+      -- (`firstMember`) — for a later member the trailing ISIZE is not this member's
+      -- size — and only when the hint is bounded by `presizeCap` and the member
+      -- budget (`exact` conjuncts). The `memberMax < UInt32.size` conjunct keeps
+      -- ISIZE (which is the size *mod 2^32*) a genuinely exact hint: with the output
+      -- bounded below 4 GiB, `ISIZE = decompressed.size` outright, no 2^32 residue
+      -- ambiguity, so a matching hint fires the fast path rather than wasting a
+      -- decode that would reject. `inflateRawSized` is proven equal to `inflateRaw`
+      -- for every input in the `USize` addressability regime
+      -- (`Zip.Native.inflateRawSized_agrees`, under `data.size < USize.size` — always
+      -- true for an in-memory `ByteArray` on a 64-bit target, the regime every native
+      -- decode proof here assumes — and `memberMax < USize.size` from the conjunct,
+      -- with `pos ≤ data.size` from the guard above). So a wrong hint — a concatenated
+      -- multi-member stream, trailing padding, or a malicious ISIZE — makes the
+      -- fastloop's exact-size contract reject and fall back to the push `inflateRaw`,
+      -- never changing the decoded bytes or the returned `endPos`. The CRC32 / ISIZE
+      -- trailer checks below stay integrity checks, not soundness backstops.
       let (decompressed, endPos) ←
-        if result.size == 0 then
+        if firstMember then
           let isize := (Binary.readUInt32LE data (data.size - 4)).toNat
           let sizeHint := min isize presizeCap
-          let exact := isize == sizeHint && isize ≤ memberMax && memberMax < USize.size
+          let exact := isize == sizeHint && isize ≤ memberMax
+            && memberMax < UInt32.size && memberMax < USize.size
           Inflate.inflateRawSized data pos memberMax (sizeHint := sizeHint) (exact := exact)
         else
           Inflate.inflateRaw data pos memberMax
+      firstMember := false
       pos := endPos
       -- Parse trailer: CRC32 (4 bytes LE) + ISIZE (4 bytes LE)
       if pos + 8 > data.size then throw "Gzip: truncated trailer"

--- a/Zip/Native/InflateFast.lean
+++ b/Zip/Native/InflateFast.lean
@@ -528,5 +528,28 @@ def inflateSized (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024)
   else
     inflate data maxOutputSize sizeHint
 
+/-- **Production fastloop dispatch, raw offset form.** The `inflateRaw` counterpart
+    of `inflateSized`: it decodes a DEFLATE stream starting at byte offset `startPos`
+    and, alongside the bytes, returns the byte-aligned position after the last block
+    (`endPos`), which a container decoder needs to locate the trailer / next member.
+    When the caller knows the *exact* decompressed size and has bounded it
+    (`exact = true`, `sizeHint > 0` — for gzip, the trailer `ISIZE` of a single-member
+    stream, clamped to a presize cap), decode with the verified branch-free `uset`
+    fastloop `inflateRawFastU`; on a wrong hint or a corrupt stream the fastloop
+    rejects (its exact-size contract) and we fall back to the push-based production
+    `inflateRaw`. It is proven equal to `inflateRaw` for every `USize`-representable
+    input (`Zip.Native.inflateRawSized_agrees`), so it never changes the decoded
+    bytes or `endPos`. Without an exact bounded size we decode with `inflateRaw`
+    directly. -/
+def inflateRawSized (data : ByteArray) (startPos : Nat := 0)
+    (maxOutputSize : Nat := 1024 * 1024 * 1024) (sizeHint : Nat := 0)
+    (exact : Bool := false) : Except String (ByteArray × Nat) :=
+  if exact && sizeHint > 0 then
+    match inflateRawFastU data startPos maxOutputSize sizeHint with
+    | .ok r => .ok r
+    | .error _ => inflateRaw data startPos maxOutputSize
+  else
+    inflateRaw data startPos maxOutputSize
+
 end Inflate
 end Zip.Native

--- a/Zip/Spec/InflateFastCorrect.lean
+++ b/Zip/Spec/InflateFastCorrect.lean
@@ -2657,4 +2657,76 @@ theorem inflateSized_agrees (data : ByteArray) (maxOut sizeHint : Nat) (exact : 
     | error e => exact Inflate.inflate_sizeHint_eq data maxOut sizeHint
   · exact Inflate.inflate_sizeHint_eq data maxOut sizeHint
 
+set_option maxHeartbeats 1000000 in
+/-- **Soundness — the raw-offset reverse direction.** The `inflateRaw` counterpart of
+    `inflateFastU_sound`: whenever the branch-free `uset` fastloop *accepts* a stream
+    starting at byte offset `startPos`, the reference push decoder `Inflate.inflateRaw`
+    accepts the same bytes *and* reports the same byte-aligned end position `ep`.
+    Same skeleton as `inflateFastU_sound`, but the loop bisimulation
+    `inflateLoopCur_treeFree` is instantiated at `pos := startPos` (needing
+    `startPos ≤ data.size`, always true at a gzip member boundary), and the returned
+    `endPos` is preserved rather than discarded so a container decoder can locate the
+    trailer / next member from it. -/
+theorem inflateRawFastU_sound (data : ByteArray) (startPos maxOut sizeHint : Nat)
+    (o : ByteArray) (ep : Nat)
+    (hds : data.size < USize.size) (hmo : maxOut < USize.size) (hsp : startPos ≤ data.size)
+    (h : Inflate.inflateRawFastU data startPos maxOut sizeHint = .ok (o, ep)) :
+    Inflate.inflateRaw data startPos maxOut = .ok (o, ep) := by
+  have hpsz : (ByteArray.presize sizeHint).size = sizeHint := by
+    simp only [ByteArray.presize, ByteArray.size, Array.size_replicate]
+  have hemp : ByteArray.emptyWithCapacity 0 = (ByteArray.presize sizeHint).extract 0 0 := by
+    apply ByteArray.ext_getElem!
+    · rw [ByteArray.size_extract]; simp
+    · intro i hi; simp at hi
+  rw [inflateRawFastU_eq, Inflate.inflateRawFast] at h
+  simp only [bind, Except.bind] at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i hng
+    obtain ⟨pl, hloop, hchk⟩ := bindOk' h
+    obtain ⟨cf, cop, cep⟩ := pl
+    simp only [] at hchk
+    split at hchk
+    · exact absurd hchk (by simp)
+    · rename_i hcopeq
+      obtain ⟨rfl, rfl⟩ := hchk
+      have hcfsz : o.size = sizeHint := by
+        rw [inflateLoopCur_size maxOut data.size _ _ _ _ _ _ hloop, hpsz]
+      have hcopval : cop = o.size := Decidable.of_not_not hcopeq
+      have htf := inflateLoopCur_treeFree maxOut data.size hds hmo
+        { data := data, pos := startPos, bitOff := 0 } (ByteArray.presize sizeHint) 0 o cop ep
+        (by simp only [ZipCommon.BitReader.bitPos]; omega) rfl (by rw [hpsz]; omega)
+        (by rw [hpsz]; omega) (by omega) hloop (by rw [hpsz]; omega)
+      rw [← hemp] at htf
+      have hoext : o.extract 0 cop = o := by
+        rw [hcopval]
+        apply ByteArray.ext_getElem!
+        · rw [ByteArray.size_extract]; omega
+        · intro i hi
+          rw [ByteArray.size_extract] at hi
+          rw [ByteArray.getElem!_extract _ 0 _ i (by omega), Nat.zero_add]
+      rw [hoext] at htf
+      rw [Inflate.inflateRaw_eq_loop]
+      exact htf
+
+/-- **The raw-offset `uset` fastloop dispatch equals the reference decoder.**
+    `inflateRawSized … = inflateRaw`: the fast path returns exactly `inflateRaw`'s
+    bytes *and* end position when it accepts (`inflateRawFastU_sound`), and the
+    fallback / inert-hint branches are `inflateRaw` itself. So wiring the fastloop
+    into the gzip member decode never changes the decoded bytes or the member
+    boundary; the gzip CRC32 / ISIZE trailer checks stay integrity checks, not
+    soundness backstops. -/
+theorem inflateRawSized_agrees (data : ByteArray) (startPos maxOut sizeHint : Nat) (exact : Bool)
+    (hds : data.size < USize.size) (hmo : maxOut < USize.size) (hsp : startPos ≤ data.size) :
+    Inflate.inflateRawSized data startPos maxOut sizeHint exact
+      = Inflate.inflateRaw data startPos maxOut := by
+  rw [Inflate.inflateRawSized]
+  split
+  · cases hfu : Inflate.inflateRawFastU data startPos maxOut sizeHint with
+    | ok r =>
+      obtain ⟨o, ep⟩ := r
+      exact (inflateRawFastU_sound data startPos maxOut sizeHint o ep hds hmo hsp hfu).symm
+    | error e => rfl
+  · rfl
+
 end Zip.Native

--- a/ZipTest/NativeGzip.lean
+++ b/ZipTest/NativeGzip.lean
@@ -337,4 +337,51 @@ def ZipTest.NativeGzip.tests : IO Unit := do
   | .ok result => assert! result == helloBytes
   | .error e => throw (IO.userError s!"zlib decompressSingle on FFI zlib failed: {e}")
 
+  -- ── Exact-size fastloop wiring (issue #2846) ─────────────────────────────
+  -- Exact-size hit: a single-member gzip whose trailing ISIZE is the exact
+  -- decompressed length drives the verified `uset` fastloop. The result must
+  -- equal both the input and the FFI decoder (bytes == push == FFI).
+  let gzLarge ← Gzip.compress large
+  match Zip.Native.GzipDecode.decompress gzLarge with
+  | .ok result =>
+    assert! result == large
+    let ffi ← Gzip.decompress gzLarge
+    assert! result == ffi
+  | .error e => throw (IO.userError s!"gzip fastloop exact-size hit failed: {e}")
+
+  -- Deliberately-wrong ISIZE: corrupt the trailing 4-byte ISIZE. The fast hint is
+  -- now wrong, so the fastloop's exact-size contract rejects and we fall back to
+  -- the push decoder — which decodes the true bytes; the ISIZE integrity check
+  -- then catches the corruption (a bad hint never slips corrupt data past).
+  let mut wrongIsize := gzLarge
+  let isizePos := wrongIsize.size - 4
+  wrongIsize := wrongIsize.set! isizePos (wrongIsize[isizePos]! ^^^ 0xFF)
+  match Zip.Native.GzipDecode.decompress wrongIsize with
+  | .error e => assert! e.contains "size mismatch"
+  | .ok _ => throw (IO.userError "gzip wrong-ISIZE should error on size mismatch")
+
+  -- Concatenated multi-member stream (fallback path): the first member's fast
+  -- attempt takes the *last* member's ISIZE as its hint (the member sizes differ),
+  -- so the fastloop rejects on member 0 and falls back; the whole stream still
+  -- decodes to the concatenation.
+  let gzBig ← Gzip.compress big
+  let gzSingle ← Gzip.compress singleByte
+  let multi := gzBig ++ gzSingle
+  match Zip.Native.GzipDecode.decompress multi with
+  | .ok result => assert! result == (big ++ singleByte)
+  | .error e => throw (IO.userError s!"gzip concatenated fallback failed: {e}")
+
+  -- Unit-level `inflateRawSized`: an exact hint fires the fastloop, and a wrong
+  -- hint falls back — both return the identical bytes *and* end position as the
+  -- push `inflateRaw` (the executable witness of `inflateRawSized_agrees`).
+  let deflatedLarge := Zip.Native.Deflate.deflateRaw large 1
+  match Zip.Native.Inflate.inflateRaw deflatedLarge 0 (1024 * 1024 * 1024) with
+  | .error e => throw (IO.userError s!"inflateRaw on deflatedLarge failed: {e}")
+  | .ok (pushBytes, pushEnd) =>
+    for (sh, ex) in [(large.size, true), (large.size + 13, true), (0, false)] do
+      match Zip.Native.Inflate.inflateRawSized deflatedLarge 0 (1024 * 1024 * 1024)
+          (sizeHint := sh) (exact := ex) with
+      | .ok (b, ep) => assert! b == pushBytes && ep == pushEnd
+      | .error e => throw (IO.userError s!"inflateRawSized (hint {sh}) failed: {e}")
+
   IO.println "  NativeGzip tests passed."

--- a/ZipTest/NativeGzip.lean
+++ b/ZipTest/NativeGzip.lean
@@ -371,6 +371,16 @@ def ZipTest.NativeGzip.tests : IO Unit := do
   | .ok result => assert! result == (big ++ singleByte)
   | .error e => throw (IO.userError s!"gzip concatenated fallback failed: {e}")
 
+  -- Empty first member then a nonempty one: `result` stays empty after member 0,
+  -- so the fast-path attempt must be gated on the first-member flag, not
+  -- `result.size == 0`. Correctness is independent of the gate; this pins the
+  -- concatenation result.
+  let gzEmpty ← Gzip.compress ByteArray.empty
+  let emptyThenHello := gzEmpty ++ gzippedHello
+  match Zip.Native.GzipDecode.decompress emptyThenHello with
+  | .ok result => assert! result == helloBytes
+  | .error e => throw (IO.userError s!"gzip empty-first-member fallback failed: {e}")
+
   -- Unit-level `inflateRawSized`: an exact hint fires the fastloop, and a wrong
   -- hint falls back — both return the identical bytes *and* end position as the
   -- push `inflateRaw` (the executable witness of `inflateRawSized_agrees`).
@@ -378,6 +388,12 @@ def ZipTest.NativeGzip.tests : IO Unit := do
   match Zip.Native.Inflate.inflateRaw deflatedLarge 0 (1024 * 1024 * 1024) with
   | .error e => throw (IO.userError s!"inflateRaw on deflatedLarge failed: {e}")
   | .ok (pushBytes, pushEnd) =>
+    -- The exact hint must make the fastloop itself *accept* (an executable witness
+    -- that the fast path really fires — not just that the dispatch is equivalent).
+    match Zip.Native.Inflate.inflateRawFastU deflatedLarge 0 (1024 * 1024 * 1024)
+        (sizeHint := large.size) with
+    | .ok (b, ep) => assert! b == pushBytes && ep == pushEnd
+    | .error e => throw (IO.userError s!"inflateRawFastU exact hint should accept: {e}")
     for (sh, ex) in [(large.size, true), (large.size + 13, true), (0, false)] do
       match Zip.Native.Inflate.inflateRawSized deflatedLarge 0 (1024 * 1024 * 1024)
           (sizeHint := sh) (exact := ex) with


### PR DESCRIPTION
This PR wires the verified exact-size `uset` fastloop into gzip / tar.gz decode, the follow-up https://github.com/kim-em/lean-zip/pull/2840 ("perf(decode): decode ZIP entries with the verified uset fastloop at exact size") deferred, so the +6.2% reaches the gzip decode surface too — the largest real-world one, tar.gz, whose decode flows through `GzipDecode.decompress`.

It adds `Inflate.inflateRawSized data startPos maxOut sizeHint exact`, the `inflateRaw` counterpart of `inflateSized`: it decodes from a byte offset and returns the byte-aligned end position (which a container decoder needs to locate the trailer / next member), dispatching to the verified `inflateRawFastU` when `exact = true` and `sizeHint > 0`, and falling back to the push `inflateRaw` when the fastloop's exact-size contract rejects. It proves `inflateRawFastU_sound` (the raw-offset reverse bisimulation, `inflateLoopCur_treeFree` instantiated at `pos := startPos`) and hence `inflateRawSized_agrees`: `inflateRawSized = inflateRaw` for every `USize`-representable input, so a wrong or malicious hint never changes the decoded bytes or the returned end position.

In `GzipDecode.decompress` it decodes the single-member case with the fastloop: for a stream with exactly one member the trailing 8 bytes are its trailer, so `ISIZE = readUInt32LE data (size - 4)` is the exact decompressed length. It attempts this only on the first member (a dedicated flag, since `result.size == 0` is not a first-member test once empty members exist) and only when the hint is bounded by `presizeCap`, the member budget, and `UInt32.size` (ISIZE is size mod 2^32, so an output below 4 GiB makes it genuinely exact). A concatenated multi-member stream, trailing padding, or a corrupt ISIZE makes the fastloop reject and fall back, byte-identically. The CRC32 / ISIZE trailer checks stay integrity checks, not soundness backstops.

Conformance tests exercise the exact-size hit (bytes == push == FFI, plus a direct `inflateRawFastU` acceptance witness that the fast path actually fires), a deliberately-wrong ISIZE (fastloop rejects, fallback decodes, the ISIZE check catches the corruption), a concatenated multi-member stream and an empty-first-member stream (fallback path), and `inflateRawSized` at the unit level (exact and wrong hints both equal `inflateRaw`, bytes and end position). Still `sorry`-free; `lake build` + `lake exe test` green.

Closes https://github.com/kim-em/lean-zip/issues/2846.

🤖 Prepared with Claude Code