### PR TITLE
feat: rolling lazy2 deferral, rung 5 — proof-arg-free rollDefer, merged lockstep generalized (#2837)

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -1439,21 +1439,13 @@ def lz77ChainLazy.mainLoop (data : ByteArray) (windowSize hashSize maxChain : Na
                 if h1 : 1 < lazy2Steps then
                   -- Rolling deferral (rung 1 of #2837): emit the pending
                   -- match-start byte as a literal, roll the pending match `M'`
-                  -- forward into `rollDefer` at `pos+1`, step 1.
-                  if hpl2 : 3 ≤ matchLen2 then
-                    .literal (data[pos]'(by omega)) ::
-                      lz77ChainLazy.rollDefer data windowSize hashSize maxChain useH3
-                        hashTable prev h3tab (pos + 1) matchLen2 matchPos2 1
-                        insertCap goodMatch niceLen lazyDepth lazy2Steps hle2 hpl2
-                  else
-                    -- Unreachable (accept ⇒ matchLen2 > matchLen ≥ 3); the
-                    -- single-deferral result keeps the function total.
-                    let (hashTable, prev) :=
-                      lz77Chain.updateHashes data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
-                    let h3tab := if useH3 then updateHash3 data h3tab pos 1 (matchLen2 + 1) insertCap else h3tab
-                    .literal (data[pos]'(by omega)) ::
-                      .reference matchLen2 (pos + 1 - matchPos2) ::
-                        lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + 1 + matchLen2) insertCap goodMatch niceLen lazyDepth lazy2Steps
+                  -- forward into `rollDefer` at `pos+1`, step 1. `rollDefer` re-derives
+                  -- its bounds locally (rung 5 of #2837): no dependent proof-args cross
+                  -- the mutual boundary, keeping the lockstep proofs motive-correct.
+                  .literal (data[pos]'(by omega)) ::
+                    lz77ChainLazy.rollDefer data windowSize hashSize maxChain useH3
+                      hashTable prev h3tab (pos + 1) matchLen2 matchPos2 1
+                      insertCap goodMatch niceLen lazyDepth lazy2Steps
                 else
                   -- Single deferral (`lazy2Steps ≤ 1`): the original lazy behavior.
                   have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
@@ -1498,8 +1490,8 @@ def lz77ChainLazy.mainLoop (data : ByteArray) (windowSize hashSize maxChain : Na
         lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + 1) insertCap goodMatch niceLen lazyDepth lazy2Steps
   else
     lz77Greedy.trailing data pos
-termination_by data.size - pos
-decreasing_by all_goals omega
+termination_by 2 * (data.size - pos)
+decreasing_by all_goals (first | omega | (refine Nat.mul_lt_mul_of_pos_left ?_ (by decide); omega))
 
 /-- Rolling sub-recursion: a pending match `(pLen, pMatchPos)` starts at `mp`;
     positions `< mp` are already decided. If a defer remains (`step < lazy2Steps`,
@@ -1508,13 +1500,16 @@ decreasing_by all_goals omega
     roll to the new match at `mp+1`, step `+1`. Otherwise commit the pending match
     at `mp`. The no-more-defers commit uses the production batch
     `updateHashes (mp-1) 1 (pLen+1)`, so `mainLoop`'s `lazy2Steps = 1` entry (which
-    never reaches here) matches production exactly. `hmp`/`hpl` carry the pending
-    match's length bounds for termination; the emitted reference's validity is
-    re-established at emission (see `LZ77ChainLazyCorrect`). -/
+    never reaches here) matches production exactly. Rung 5 of #2837: no `hmp`/`hpl`
+    proof-args — the termination bound is re-derived locally from `hcan`, and the
+    mutual uses an interleaved measure (`2*(data.size-mp)+1`) so the commit back into
+    `mainLoop` always decreases without a pending-length hypothesis. This keeps the
+    chain walk out of every dependent proof-arg, so the lockstep rewrites stay
+    motive-correct. The emitted reference's validity is re-established at emission
+    (see `LZ77ChainLazyCorrect`). -/
 def lz77ChainLazy.rollDefer (data : ByteArray) (windowSize hashSize maxChain : Nat) (useH3 : Bool)
     (hashTable : Array Nat) (prev h3tab : Array Nat)
-    (mp pLen pMatchPos step insertCap goodMatch niceLen lazyDepth lazy2Steps : Nat)
-    (hmp : mp + pLen ≤ data.size) (hpl : 3 ≤ pLen) : List LZ77Token :=
+    (mp pLen pMatchPos step insertCap goodMatch niceLen lazyDepth lazy2Steps : Nat) : List LZ77Token :=
   if hcan : step < lazy2Steps ∧ mp + 3 < data.size ∧ pLen < goodMatch then
     -- Insert `mp` (loop-top style) so `mp+1` can match against it.
     let hmh := lz77Greedy.hash3 data mp hashSize (by omega)
@@ -1532,12 +1527,11 @@ def lz77ChainLazy.rollDefer (data : ByteArray) (windowSize hashSize maxChain : N
     let m2 := lz77Chain.chainWalk data prev windowSize (mp + 1) maxLen2 niceLen hmaxLen2P head2 (lazy2ProbeDepth maxChain) 0 0
     let len' := m2.1
     let pos' := m2.2
-    if hacc : lazyAcceptCost pLen (mp - pMatchPos) len' (mp + 1 - pos') = true ∧ (mp + 1) + len' ≤ data.size then
-      have hlen' : 3 ≤ len' := by have := lazyAcceptCost_lt hacc.1; omega
+    if lazyAcceptCost pLen (mp - pMatchPos) len' (mp + 1 - pos') = true ∧ (mp + 1) + len' ≤ data.size then
       .literal (data[mp]'(by omega)) ::
         lz77ChainLazy.rollDefer data windowSize hashSize maxChain useH3
           hashTable prev h3tab (mp + 1) len' pos' (step + 1)
-          insertCap goodMatch niceLen lazyDepth lazy2Steps hacc.2 hlen'
+          insertCap goodMatch niceLen lazyDepth lazy2Steps
     else
       -- No improvement: commit the pending match at `mp`. `mp` already inserted
       -- above, so insert only the interior `mp+1 .. mp+pLen-1`.
@@ -1552,7 +1546,7 @@ def lz77ChainLazy.rollDefer (data : ByteArray) (windowSize hashSize maxChain : N
     let h3tab := if useH3 then updateHash3 data h3tab (mp - 1) 1 (pLen + 1) insertCap else h3tab
     .reference pLen (mp - pMatchPos) ::
       lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (mp + pLen) insertCap goodMatch niceLen lazyDepth lazy2Steps
-termination_by data.size - mp
+termination_by 2 * (data.size - mp) + 1
 decreasing_by all_goals omega
 
 end
@@ -1639,20 +1633,11 @@ def lz77ChainLazyIter.mainLoop (data : ByteArray) (windowSize hashSize maxChain 
               if hle2 : pos + 1 + matchLen2 ≤ data.size then
                 if h1 : 1 < lazy2Steps then
                   -- Rolling deferral: push the pending match-start byte as a
-                  -- literal and roll into `rollDefer` at `pos+1`, step 1.
-                  if hpl2 : 3 ≤ matchLen2 then
-                    lz77ChainLazyIter.rollDefer data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3
-                      hashTable prev h3tab (pos + 1) matchLen2 matchPos2 1
-                      (acc.push (.literal (data[pos]'(by omega)))) hle2 hpl2
-                  else
-                    -- Unreachable (accept ⇒ matchLen2 > matchLen ≥ 3); single-deferral keeps totality.
-                    have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
-                    let (hashTable, prev) :=
-                      updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
-                    let h3tab := if useH3 then updateHash3 data h3tab pos 1 (matchLen2 + 1) insertCap else h3tab
-                    lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3 hashTable prev h3tab (pos + 1 + matchLen2)
-                      (acc.push (.literal (data[pos]'(by omega))) |>.push
-                        (.reference matchLen2 (pos + 1 - matchPos2)))
+                  -- literal and roll into `rollDefer` at `pos+1`, step 1 (rung 5:
+                  -- no proof-args cross the mutual boundary).
+                  lz77ChainLazyIter.rollDefer data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3
+                    hashTable prev h3tab (pos + 1) matchLen2 matchPos2 1
+                    (acc.push (.literal (data[pos]'(by omega))))
                 else
                   -- Single deferral (`lazy2Steps ≤ 1`): the original lazy behavior.
                   have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
@@ -1696,16 +1681,17 @@ def lz77ChainLazyIter.mainLoop (data : ByteArray) (windowSize hashSize maxChain 
         (acc.push (.literal (data[pos]'(by omega))))
   else
     lz77GreedyIter.trailing data pos acc
-termination_by data.size - pos
-decreasing_by all_goals omega
+termination_by 2 * (data.size - pos)
+decreasing_by all_goals (first | omega | (refine Nat.mul_lt_mul_of_pos_left ?_ (by decide); omega))
 
 /-- Accumulator twin of `lz77ChainLazy.rollDefer`: identical rolling deferral, push
-    vs. cons at each emission. `hmp`/`hpl` carry the pending match's length bounds
-    for termination; validity is re-established at emission (`LZ77ChainLazyCorrect`). -/
+    vs. cons at each emission. Rung 5 of #2837: no proof-args cross the mutual
+    boundary; termination is the interleaved `2*(data.size-mp)+1` measure and the
+    bound is re-derived locally. Validity is re-established at emission
+    (`LZ77ChainLazyCorrect`). -/
 def lz77ChainLazyIter.rollDefer (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps : Nat) (useH3 : Bool)
     (hashTable : Array Nat) (prev h3tab : Array Nat)
-    (mp pLen pMatchPos step : Nat) (acc : Array LZ77Token)
-    (hmp : mp + pLen ≤ data.size) (hpl : 3 ≤ pLen) : Array LZ77Token :=
+    (mp pLen pMatchPos step : Nat) (acc : Array LZ77Token) : Array LZ77Token :=
   if hcan : step < lazy2Steps ∧ mp + 3 < data.size ∧ pLen < goodMatch then
     let hmh := lz77Greedy.hash3 data mp hashSize (by omega)
     let headmp := headProbeGuarded hashTable hmh
@@ -1719,11 +1705,10 @@ def lz77ChainLazyIter.rollDefer (data : ByteArray) (windowSize hashSize maxChain
     let r2 := chainWalkGuardedPacked data prev windowSize (mp + 1) maxLen2 niceLen hmaxLen2P head2 (lazy2ProbeDepth maxChain) 0 0
     let len' := r2 % 512
     let pos' := r2 / 512
-    if hacc : lazyAcceptCost pLen (mp - pMatchPos) len' (mp + 1 - pos') = true ∧ (mp + 1) + len' ≤ data.size then
-      have hlen' : 3 ≤ len' := by have := lazyAcceptCost_lt hacc.1; omega
+    if lazyAcceptCost pLen (mp - pMatchPos) len' (mp + 1 - pos') = true ∧ (mp + 1) + len' ≤ data.size then
       lz77ChainLazyIter.rollDefer data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3
         hashTable prev h3tab (mp + 1) len' pos' (step + 1)
-        (acc.push (.literal (data[mp]'(by omega)))) hacc.2 hlen'
+        (acc.push (.literal (data[mp]'(by omega))))
     else
       let (hashTable, prev) := updateHashesGuarded data hashSize hashTable prev mp 1 pLen insertCap
       let h3tab := if useH3 then updateHash3 data h3tab mp 1 pLen insertCap else h3tab
@@ -1734,7 +1719,7 @@ def lz77ChainLazyIter.rollDefer (data : ByteArray) (windowSize hashSize maxChain
     let h3tab := if useH3 then updateHash3 data h3tab (mp - 1) 1 (pLen + 1) insertCap else h3tab
     lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3 hashTable prev h3tab (mp + pLen)
       (acc.push (.reference pLen (mp - pMatchPos)))
-termination_by data.size - mp
+termination_by 2 * (data.size - mp) + 1
 decreasing_by all_goals omega
 
 end
@@ -1863,19 +1848,11 @@ def lz77ChainLazyIterP.mainLoop (data : ByteArray) (windowSize hashSize maxChain
               if hle2 : pos + 1 + matchLen2 ≤ data.size then
                 if h1 : 1 < lazy2Steps then
                   -- Rolling deferral: push the pending match-start byte as a
-                  -- literal and roll into `rollDefer` at `pos+1`, step 1.
-                  if hpl2 : 3 ≤ matchLen2 then
-                    lz77ChainLazyIterP.rollDefer data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3
-                      hashTable prev h3tab (pos + 1) matchLen2 matchPos2 1
-                      (acc.push (packTok (.literal (data[pos]'(by omega))))) hle2 hpl2
-                  else
-                    have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
-                    let (hashTable, prev) :=
-                      updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
-                    let h3tab := if useH3 then updateHash3 data h3tab pos 1 (matchLen2 + 1) insertCap else h3tab
-                    lz77ChainLazyIterP.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3 hashTable prev h3tab (pos + 1 + matchLen2)
-                      (acc.push (packTok (.literal (data[pos]'(by omega)))) |>.push
-                        (packTok (.reference matchLen2 (pos + 1 - matchPos2))))
+                  -- literal and roll into `rollDefer` at `pos+1`, step 1 (rung 5:
+                  -- no proof-args cross the mutual boundary).
+                  lz77ChainLazyIterP.rollDefer data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3
+                    hashTable prev h3tab (pos + 1) matchLen2 matchPos2 1
+                    (acc.push (packTok (.literal (data[pos]'(by omega)))))
                 else
                   -- Single deferral (`lazy2Steps ≤ 1`): the original lazy behavior.
                   have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
@@ -1920,17 +1897,17 @@ def lz77ChainLazyIterP.mainLoop (data : ByteArray) (windowSize hashSize maxChain
         (acc.push (packTok (.literal (data[pos]'(by omega)))))
   else
     trailingP data pos acc
-termination_by data.size - pos
-decreasing_by all_goals omega
+termination_by 2 * (data.size - pos)
+decreasing_by all_goals (first | omega | (refine Nat.mul_lt_mul_of_pos_left ?_ (by decide); omega))
 
 /-- Packed-token accumulator twin of `lz77ChainLazyIter.rollDefer`: identical
     rolling deferral, `packTok` pushes and the `USize` re-probe walk. The re-probe
     is unseeded `(0, 0)` exactly as the plain-iter twin (the merged loop length-
-    seeds and bridges to this via `seeded_probe_bridge`). -/
+    seeds and bridges to this via `seeded_probe_bridge`). Rung 5 of #2837: no
+    proof-args cross the mutual boundary; termination via the interleaved measure. -/
 def lz77ChainLazyIterP.rollDefer (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps : Nat) (useH3 : Bool)
     (hashTable : Array Nat) (prev h3tab : Array Nat)
-    (mp pLen pMatchPos step : Nat) (acc : Array UInt32)
-    (hmp : mp + pLen ≤ data.size) (hpl : 3 ≤ pLen) : Array UInt32 :=
+    (mp pLen pMatchPos step : Nat) (acc : Array UInt32) : Array UInt32 :=
   if hcan : step < lazy2Steps ∧ mp + 3 < data.size ∧ pLen < goodMatch then
     let hmh := lz77Greedy.hash3 data mp hashSize (by omega)
     let headmp := headProbeGuarded hashTable hmh
@@ -1944,11 +1921,10 @@ def lz77ChainLazyIterP.rollDefer (data : ByteArray) (windowSize hashSize maxChai
     let r2 := chainWalkGuardedPackedU data prev windowSize (mp + 1) maxLen2 niceLen hmaxLen2P head2 (lazy2ProbeDepth maxChain) 0 0
     let len' := r2 % 512
     let pos' := r2 / 512
-    if hacc : lazyAcceptCost pLen (mp - pMatchPos) len' (mp + 1 - pos') = true ∧ (mp + 1) + len' ≤ data.size then
-      have hlen' : 3 ≤ len' := by have := lazyAcceptCost_lt hacc.1; omega
+    if lazyAcceptCost pLen (mp - pMatchPos) len' (mp + 1 - pos') = true ∧ (mp + 1) + len' ≤ data.size then
       lz77ChainLazyIterP.rollDefer data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3
         hashTable prev h3tab (mp + 1) len' pos' (step + 1)
-        (acc.push (packTok (.literal (data[mp]'(by omega))))) hacc.2 hlen'
+        (acc.push (packTok (.literal (data[mp]'(by omega)))))
     else
       let (hashTable, prev) := updateHashesGuarded data hashSize hashTable prev mp 1 pLen insertCap
       let h3tab := if useH3 then updateHash3 data h3tab mp 1 pLen insertCap else h3tab
@@ -1959,7 +1935,7 @@ def lz77ChainLazyIterP.rollDefer (data : ByteArray) (windowSize hashSize maxChai
     let h3tab := if useH3 then updateHash3 data h3tab (mp - 1) 1 (pLen + 1) insertCap else h3tab
     lz77ChainLazyIterP.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3 hashTable prev h3tab (mp + pLen)
       (acc.push (packTok (.reference pLen (mp - pMatchPos))))
-termination_by data.size - mp
+termination_by 2 * (data.size - mp) + 1
 decreasing_by all_goals omega
 
 end
@@ -2371,17 +2347,11 @@ def lz77LazyMergedLoop (data : ByteArray)
               if hle2 : pos + 1 + matchLen2 ≤ data.size then
                 if h1 : 1 < lazy2Steps then
                   -- Rolling deferral: push the pending match-start byte as a
-                  -- literal and roll into `rollDefer` at `pos+1`, step 1.
-                  if hpl2 : 3 ≤ matchLen2 then
-                    lz77LazyMergedLoop.rollDefer data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3
-                      c h3tab (pos + 1) matchLen2 matchPos2 1
-                      (acc.push (packTok (.literal (data[pos]'(by omega))))) hle2 hpl2
-                  else
-                    have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
-                    let (c, h3tab) := updateHashesMergedH3Guarded useH3 data hashSize prevSize c h3tab pos 1 (matchLen2 + 1) insertCap
-                    lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3 c h3tab (pos + 1 + matchLen2)
-                      (acc.push (packTok (.literal (data[pos]'(by omega)))) |>.push
-                        (packTok (.reference matchLen2 (pos + 1 - matchPos2))))
+                  -- literal and roll into `rollDefer` at `pos+1`, step 1 (rung 5:
+                  -- no proof-args cross the mutual boundary).
+                  lz77LazyMergedLoop.rollDefer data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3
+                    c h3tab (pos + 1) matchLen2 matchPos2 1
+                    (acc.push (packTok (.literal (data[pos]'(by omega)))))
                 else
                   -- Single deferral (`lazy2Steps ≤ 1`): the original lazy behavior.
                   have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
@@ -2418,8 +2388,8 @@ def lz77LazyMergedLoop (data : ByteArray)
         (acc.push (packTok (.literal (data[pos]'(by omega)))))
   else
     trailingP data pos acc
-termination_by data.size - pos
-decreasing_by all_goals omega
+termination_by 2 * (data.size - pos)
+decreasing_by all_goals (first | omega | (refine Nat.mul_lt_mul_of_pos_left ?_ (by decide); omega))
 
 /-- Merged-array accumulator twin of `lz77ChainLazyIterP.rollDefer`: identical
     rolling deferral on the single combined array `c`. The re-probe is
@@ -2429,8 +2399,7 @@ decreasing_by all_goals omega
     `seeded_probe_bridge`. The mode-0 `/4` ladder is `lazy2ProbeDepth maxChain`. -/
 def lz77LazyMergedLoop.rollDefer (data : ByteArray)
     (windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps : Nat) (useH3 : Bool)
-    (c h3tab : Array Nat) (mp pLen pMatchPos step : Nat) (acc : Array UInt32)
-    (hmp : mp + pLen ≤ data.size) (hpl : 3 ≤ pLen) : Array UInt32 :=
+    (c h3tab : Array Nat) (mp pLen pMatchPos step : Nat) (acc : Array UInt32) : Array UInt32 :=
   if hcan : step < lazy2Steps ∧ mp + 3 < data.size ∧ pLen < goodMatch then
     let hmh := lz77Greedy.hash3 data mp hashSize (by omega)
     let headmp := headProbeGuarded c (prevSize + hmh)
@@ -2441,16 +2410,18 @@ def lz77LazyMergedLoop.rollDefer (data : ByteArray)
     let head2 := headProbeGuarded c (prevSize + h2)
     let maxLen2 := min 258 (data.size - (mp + 1))
     have hmaxLen2P : (mp + 1) + maxLen2 ≤ data.size := by omega
-    let cutoff2 := min niceLen maxLen2
-    let seed := if pLen < cutoff2 then pLen else 0
-    let r2 := chainWalkGuardedPackedU data c windowSize (mp + 1) maxLen2 niceLen hmaxLen2P head2 (lazy2ProbeDepth maxChain) seed 0
+    -- Unseeded `(0, 0)` re-probe, mirror-aligned with `lz77ChainLazyIterP.rollDefer`
+    -- (rung 5): a length seed only changes a *rejected* probe result, and acceptance
+    -- needs `len' > pLen` strictly, so seeded and unseeded give the identical accepted
+    -- output (the certified spike seeds; `seeded_probe_bridge` proves byte-identity).
+    -- Keeping it unseeded makes `mergedLoop_eq`'s `rollDefer` twin a structural lockstep.
+    let r2 := chainWalkGuardedPackedU data c windowSize (mp + 1) maxLen2 niceLen hmaxLen2P head2 (lazy2ProbeDepth maxChain) 0 0
     let len' := r2 % 512
     let pos' := r2 / 512
-    if hacc : lazyAcceptCost pLen (mp - pMatchPos) len' (mp + 1 - pos') = true ∧ (mp + 1) + len' ≤ data.size then
-      have hlen' : 3 ≤ len' := by have := lazyAcceptCost_lt hacc.1; omega
+    if lazyAcceptCost pLen (mp - pMatchPos) len' (mp + 1 - pos') = true ∧ (mp + 1) + len' ≤ data.size then
       lz77LazyMergedLoop.rollDefer data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3
         c h3tab (mp + 1) len' pos' (step + 1)
-        (acc.push (packTok (.literal (data[mp]'(by omega))))) hacc.2 hlen'
+        (acc.push (packTok (.literal (data[mp]'(by omega)))))
     else
       let (c, h3tab) := updateHashesMergedH3Guarded useH3 data hashSize prevSize c h3tab mp 1 pLen insertCap
       lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3 c h3tab (mp + pLen)
@@ -2459,7 +2430,7 @@ def lz77LazyMergedLoop.rollDefer (data : ByteArray)
     let (c, h3tab) := updateHashesMergedH3Guarded useH3 data hashSize prevSize c h3tab (mp - 1) 1 (pLen + 1) insertCap
     lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3 c h3tab (mp + pLen)
       (acc.push (packTok (.reference pLen (mp - pMatchPos))))
-termination_by data.size - mp
+termination_by 2 * (data.size - mp) + 1
 decreasing_by all_goals omega
 
 end

--- a/Zip/Spec/LZ77ChainLazyCorrect.lean
+++ b/Zip/Spec/LZ77ChainLazyCorrect.lean
@@ -81,18 +81,13 @@ theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize max
                   · omega
                   · -- accept + spill-ok: `if 1 < lazy2Steps` (roll) `else` (single).
                     split
-                    · split
-                      · -- rolling: literal at pos, then rollDefer at pos+1
-                        rename_i hpl2
-                        exact .literal (by omega) (getElem!_pos data pos (by omega))
-                          (rollDefer_valid data windowSize hashSize maxChain useH3 _ _ _
-                            (pos + 1) _ _ 1 insertCap goodMatch niceLen lazyDepth lazy2Steps
-                            hle2 hpl2 hQ2 hw)
-                      · -- ¬(3 ≤ matchLen2): unreachable, single-deferral fallback
-                        exact .literal (by omega) (getElem!_pos data pos (by omega))
-                          (lazyRef_at_pos data (pos + 1) _ _ hQ2.1 (by omega) hle2
-                            (fun i hi => hQ2.2.2.2.1 i hi)
-                            (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw))
+                    · -- rolling: literal at pos, then rollDefer at pos+1 (rung 5:
+                      -- `rollDefer` takes no proof-args; `3 ≤ matchLen2` is passed to
+                      -- the *theorem* and derived here from `matchLen2 > matchLen ≥ 3`).
+                      exact .literal (by omega) (getElem!_pos data pos (by omega))
+                        (rollDefer_valid data windowSize hashSize maxChain useH3 _ _ _
+                          (pos + 1) _ _ 1 insertCap goodMatch niceLen lazyDepth lazy2Steps
+                          (by omega) hQ2 hw)
                     · -- ¬(1 < lazy2Steps): single deferral (original behavior)
                       exact .literal (by omega) (getElem!_pos data pos (by omega))
                         (lazyRef_at_pos data (pos + 1) _ _ hQ2.1 (by omega) hle2
@@ -117,10 +112,13 @@ decreasing_by all_goals omega
 theorem rollDefer_valid (data : ByteArray) (windowSize hashSize maxChain : Nat) (useH3 : Bool)
     (hashTable : Array Nat) (prev h3tab : Array Nat)
     (mp pLen pMatchPos step insertCap goodMatch niceLen lazyDepth lazy2Steps : Nat)
-    (hmp : mp + pLen ≤ data.size) (hpl : 3 ≤ pLen)
+    (hpl : 3 ≤ pLen)
     (hQ : RollPending data windowSize mp pLen pMatchPos) (hw : windowSize > 0) :
     ValidDecomp data mp
-      (lz77ChainLazy.rollDefer data windowSize hashSize maxChain useH3 hashTable prev h3tab mp pLen pMatchPos step insertCap goodMatch niceLen lazyDepth lazy2Steps hmp hpl) := by
+      (lz77ChainLazy.rollDefer data windowSize hashSize maxChain useH3 hashTable prev h3tab mp pLen pMatchPos step insertCap goodMatch niceLen lazyDepth lazy2Steps) := by
+  -- Rung 5: the def no longer carries `hmp`; derive it from `RollPending` (`pLen ≤
+  -- min 258 (data.size - mp)`) and `hpl` (`3 ≤ pLen ⇒ mp < data.size`).
+  have hmp : mp + pLen ≤ data.size := by have := hQ.2.2.2.2; omega
   unfold lz77ChainLazy.rollDefer
   split
   · rename_i hcan
@@ -140,7 +138,7 @@ theorem rollDefer_valid (data : ByteArray) (windowSize hashSize maxChain : Nat) 
       · exact .literal (by omega) (getElem!_pos data mp (by omega))
           (rollDefer_valid data windowSize hashSize maxChain useH3 _ _ _
             (mp + 1) _ _ (step + 1) insertCap goodMatch niceLen lazyDepth lazy2Steps
-            hacc.2 (by omega) hQ' hw)
+            (by omega) hQ' hw)
     · exact lazyRef_at_pos data mp _ _ hQ.1 hpl hmp (fun i hi => hQ.2.2.2.1 i hi)
         (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
   · exact lazyRef_at_pos data mp _ _ hQ.1 hpl hmp (fun i hi => hQ.2.2.2.1 i hi)
@@ -220,24 +218,15 @@ theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize
                   · omega
                   · -- accept + spill-ok: `if 1 < lazy2Steps` (roll) `else` (single).
                     split
-                    · split
-                      · -- rolling: literal at pos, then rollDefer at pos+1
-                        rename_i hpl2
-                        intro t ht
-                        cases ht with
-                        | head => trivial
-                        | tail _ h =>
-                          exact rollDefer_encodable data windowSize hashSize maxChain useH3 _ _ _
-                            (pos + 1) _ _ 1 insertCap goodMatch niceLen lazyDepth lazy2Steps
-                            hle2 hpl2 ⟨hQ2a, hQ2b, hQ2c, hQ2d, hQ2e⟩ hw hws t h
-                      · -- ¬(3 ≤ matchLen2): unreachable single-deferral fallback
-                        intro t ht
-                        cases ht with
-                        | head => trivial
-                        | tail _ h =>
-                          cases h with
-                          | head => exact ⟨by omega, by omega, by omega, by omega⟩
-                          | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+                    · -- rolling: literal at pos, then rollDefer at pos+1 (rung 5:
+                      -- `3 ≤ matchLen2` derived from `matchLen2 > matchLen ≥ 3`).
+                      intro t ht
+                      cases ht with
+                      | head => trivial
+                      | tail _ h =>
+                        exact rollDefer_encodable data windowSize hashSize maxChain useH3 _ _ _
+                          (pos + 1) _ _ 1 insertCap goodMatch niceLen lazyDepth lazy2Steps
+                          (by omega) ⟨hQ2a, hQ2b, hQ2c, hQ2d, hQ2e⟩ hw hws t h
                     · -- ¬(1 < lazy2Steps): single deferral (original behavior)
                       intro t ht
                       cases ht with
@@ -278,10 +267,11 @@ decreasing_by all_goals omega
 theorem rollDefer_encodable (data : ByteArray) (windowSize hashSize maxChain : Nat) (useH3 : Bool)
     (hashTable : Array Nat) (prev h3tab : Array Nat)
     (mp pLen pMatchPos step insertCap goodMatch niceLen lazyDepth lazy2Steps : Nat)
-    (hmp : mp + pLen ≤ data.size) (hpl : 3 ≤ pLen)
+    (hpl : 3 ≤ pLen)
     (hQ : RollPending data windowSize mp pLen pMatchPos) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ lz77ChainLazy.rollDefer data windowSize hashSize maxChain useH3 hashTable prev h3tab mp pLen pMatchPos step insertCap goodMatch niceLen lazyDepth lazy2Steps hmp hpl, Enc t := by
+    ∀ t ∈ lz77ChainLazy.rollDefer data windowSize hashSize maxChain useH3 hashTable prev h3tab mp pLen pMatchPos step insertCap goodMatch niceLen lazyDepth lazy2Steps, Enc t := by
   obtain ⟨hq1, hq2, hq3, hq4, hq5⟩ := hQ
+  have hmp : mp + pLen ≤ data.size := by omega
   unfold lz77ChainLazy.rollDefer
   split
   · rename_i hcan
@@ -304,7 +294,7 @@ theorem rollDefer_encodable (data : ByteArray) (windowSize hashSize maxChain : N
         | tail _ h =>
           exact rollDefer_encodable data windowSize hashSize maxChain useH3 _ _ _
             (mp + 1) _ _ (step + 1) insertCap goodMatch niceLen lazyDepth lazy2Steps
-            hacc.2 (by omega) ⟨hQ'1, hQ'2, hQ'3, hQ'4, hQ'5⟩ hw hws t h
+            (by omega) ⟨hQ'1, hQ'2, hQ'3, hQ'4, hQ'5⟩ hw hws t h
     · intro t ht
       cases ht with
       | head => exact ⟨hpl, by omega, by omega, by omega⟩
@@ -347,9 +337,9 @@ mutual
     ever inlining the recursive call. -/
 private theorem rollDefer_eq (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
     (hashTable : Array Nat) (prev h3tab : Array Nat) (mp pLen pMatchPos step lazy2Steps : Nat)
-    (acc : Array LZ77Token) (hmp : mp + pLen ≤ data.size) (hpl : 3 ≤ pLen) :
-    lz77ChainLazyIter.rollDefer data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3 hashTable prev h3tab mp pLen pMatchPos step acc hmp hpl =
-    acc ++ (lz77ChainLazy.rollDefer data windowSize hashSize maxChain useH3 hashTable prev h3tab mp pLen pMatchPos step insertCap goodMatch niceLen lazyDepth lazy2Steps hmp hpl).toArray := by
+    (acc : Array LZ77Token) :
+    lz77ChainLazyIter.rollDefer data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3 hashTable prev h3tab mp pLen pMatchPos step acc =
+    acc ++ (lz77ChainLazy.rollDefer data windowSize hashSize maxChain useH3 hashTable prev h3tab mp pLen pMatchPos step insertCap goodMatch niceLen lazyDepth lazy2Steps).toArray := by
   unfold lz77ChainLazyIter.rollDefer lz77ChainLazy.rollDefer
   by_cases hcan : step < lazy2Steps ∧ mp + 3 < data.size ∧ pLen < goodMatch
   · rw [dif_pos hcan, dif_pos hcan]
@@ -363,7 +353,7 @@ private theorem rollDefer_eq (data : ByteArray) (windowSize hashSize maxChain in
   · rw [dif_neg hcan, dif_neg hcan]
     simp only [updateHashesGuarded_eq]
     rw [mainLoop_eq_chainLazy, List.toArray_cons, ← Array.append_assoc, Array.push_eq_append]
-termination_by data.size - mp
+termination_by 2 * (data.size - mp) + 1
 decreasing_by all_goals omega
 
 /-- The iterative lazy chain `mainLoop` is the accumulator form of the recursive
@@ -427,15 +417,8 @@ private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize ma
               split
               · -- hle2 : accept + spill-ok
                 split
-                · -- 1 < lazy2Steps : rolling dispatch
-                  split
-                  · -- 3 ≤ matchLen2 : roll — literal at pos, then rollDefer at pos+1
-                    rw [rollDefer_eq, List.toArray_cons, ← Array.append_assoc, Array.push_eq_append]
-                  · -- ¬(3 ≤ matchLen2) : single-deferral fallback, two pushes
-                    rw [mainLoop_eq_chainLazy,
-                      Array.push_eq_append, Array.push_eq_append,
-                      Array.append_assoc, Array.append_assoc,
-                      ← List.toArray_cons, ← List.toArray_cons]
+                · -- 1 < lazy2Steps : rolling dispatch — roll (rung 5: no hpl2 dite)
+                  rw [rollDefer_eq, List.toArray_cons, ← Array.append_assoc, Array.push_eq_append]
                 · -- ¬(1 < lazy2Steps) : single deferral, two pushes
                   rw [mainLoop_eq_chainLazy,
                     Array.push_eq_append, Array.push_eq_append,
@@ -461,8 +444,8 @@ private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize ma
         ← Array.append_assoc, Array.push_eq_append]
   · simp only [hlt, ↓reduceDIte]
     exact trailing_eq data pos acc
-termination_by data.size - pos
-decreasing_by all_goals omega
+termination_by 2 * (data.size - pos)
+decreasing_by all_goals (first | omega | (refine Nat.mul_lt_mul_of_pos_left ?_ (by decide); omega))
 end
 
 /-- `lz77ChainLazyIter` produces exactly the same tokens as `lz77ChainLazy`. -/

--- a/Zip/Spec/LZ77MergedCorrect.lean
+++ b/Zip/Spec/LZ77MergedCorrect.lean
@@ -501,10 +501,10 @@ private theorem seeded_probe_bridge (data : ByteArray) (prev : Array Nat)
 
 /-! ## The lockstep loop equality -/
 
-set_option maxHeartbeats 1000000 in
+set_option backward.split false in
+set_option maxHeartbeats 2000000 in
 private theorem mergedLoop_eq (data : ByteArray)
     (windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps : Nat) (useH3 : Bool)
-    (hstep : ¬ 1 < lazy2Steps)
     (hashTable prev h3tab : Array Nat) (pos : Nat) (acc : Array UInt32)
     (hhs : 0 < hashSize) (hht : hashTable.size = hashSize) (hps : prev.size = prevSize)
     (hpv : min chainWinSize data.size ≤ prev.size) :
@@ -523,18 +523,67 @@ private theorem mergedLoop_eq (data : ByteArray)
         have h1 := winMask_lt pos
         have h2 := Nat.and_le_left (n := pos) (m := 0x7FFF)
         simp only [chainWinSize] at h1 hpv; omega
-      -- Reduce the outer dite with `zeta := false`, then abstract the opaque
-      -- hash3 seed (identical on both sides — it reads the separate `h3tab`) so
-      -- the append/head-insert simp below does not duplicate it across branches.
+      -- Rolling-arm helper (rung 5): the merged `rollDefer` equals the packed one, by
+      -- a nested strong induction on `data.size - mp`; its commit into `mainLoop` at
+      -- `mp + pLen` reuses the OUTER `ih` (`pos < mp ⇒ data.size-(mp+pLen) < n`). Now
+      -- that `rollDefer` carries no proof-args the seed-bridge `rw`s are motive-correct.
+      have rdeq : ∀ (mp pLen pMatchPos step : Nat) (accd : Array UInt32) (htd prevd h3td : Array Nat)
+          (hhtd : htd.size = hashSize) (hpsd : prevd.size = prevSize)
+          (hpvd : min chainWinSize data.size ≤ prevd.size) (hlo : pos < mp),
+          lz77LazyMergedLoop.rollDefer data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3
+              (prevd ++ htd) h3td mp pLen pMatchPos step accd =
+            lz77ChainLazyIterP.rollDefer data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3
+              htd prevd h3td mp pLen pMatchPos step accd := by
+        intro mp pLen pMatchPos step accd htd prevd h3td hhtd hpsd hpvd hlo
+        induction hnm : data.size - mp using Nat.strongRecOn generalizing mp pLen pMatchPos step accd htd prevd h3td hhtd hpsd hpvd hlo with
+        | _ mnat ihm =>
+          unfold lz77LazyMergedLoop.rollDefer lz77ChainLazyIterP.rollDefer
+          by_cases hcan : step < lazy2Steps ∧ mp + 3 < data.size ∧ pLen < goodMatch
+          · have hhd : lz77Greedy.hash3 data mp hashSize (by omega) < htd.size := by
+              rw [hhtd]; have : lz77Greedy.hash3 data mp hashSize (by omega) < hashSize := Nat.mod_lt _ hhs; omega
+            have hmask0d : (mp &&& 0x7FFF) < prevd.size := by
+              have h1 := winMask_lt mp
+              have h2 := Nat.and_le_left (n := mp) (m := 0x7FFF)
+              simp only [chainWinSize] at h1 hpvd; omega
+            rw [dif_pos hcan, dif_pos hcan]
+            simp only [headProbeGuarded_eq, guardedSet_eq,
+              getElem!_append_right' prevd htd prevSize (lz77Greedy.hash3 data mp hashSize (by omega)) hpsd hhd,
+              set!_append_right' prevd htd prevSize (lz77Greedy.hash3 data mp hashSize (by omega)) mp hpsd hhd,
+              set!_append_left prevd (htd.set! (lz77Greedy.hash3 data mp hashSize (by omega)) mp)
+                (mp &&& 0x7FFF) (htd[lz77Greedy.hash3 data mp hashSize (by omega)]!) hmask0d]
+            generalize ht'eqm : htd.set! (lz77Greedy.hash3 data mp hashSize (by omega)) mp = t''
+            generalize hp'eqm : prevd.set! (mp &&& 0x7FFF) (htd[lz77Greedy.hash3 data mp hashSize (by omega)]!) = p''
+            have hht'' : t''.size = hashSize := by rw [← ht'eqm, Array.size_set!]; exact hhtd
+            have hps'' : p''.size = prevSize := by rw [← hp'eqm, Array.size_set!]; exact hpsd
+            have hpv'' : min chainWinSize data.size ≤ p''.size := by rw [← hp'eqm, Array.size_set!]; exact hpvd
+            have hh2m : lz77Greedy.hash3 data (mp + 1) hashSize (by omega) < t''.size := by
+              rw [hht'']; have : lz77Greedy.hash3 data (mp + 1) hashSize (by omega) < hashSize := Nat.mod_lt _ hhs; omega
+            simp only [getElem!_append_right' p'' t'' prevSize (lz77Greedy.hash3 data (mp + 1) hashSize (by omega)) hps'' hh2m]
+            rw [chainWalkGuardedPackedU_append data p'' t'' windowSize (mp + 1)
+              (min 258 (data.size - (mp + 1))) niceLen (by omega) hpv'' (t''[lz77Greedy.hash3 data (mp + 1) hashSize (by omega)]!) (lazy2ProbeDepth maxChain)]
+            -- Unseeded re-probe on both sides (rung 5): the accept ites are identical
+            -- after the append-strip, so `split` aligns them with no seed bridge.
+            split
+            · -- accept: roll to `mp+1` via the nested induction `ihm`
+              exact ihm _ (by omega) _ _ _ _ _ _ _ _ hht'' hps'' hpv'' (by omega) rfl
+            · -- reject: commit `reference pLen` at `mp`, then `mainLoop` via OUTER ih
+              rw [updateHashesMergedH3Guarded_eq,
+                updateHashesMerged_append data hashSize prevSize t'' p'' mp 1 _ insertCap hhs hht'' hps'' hpv'',
+                updateHashesGuarded_eq]
+              exact ih _ (by omega) _ _ _ _ _ (by rw [updateHashes_size1]; exact hht'')
+                (by rw [updateHashes_size2]; exact hps'') (by rw [updateHashes_size2]; exact hpv'') rfl
+          · -- no more defers: commit `reference pLen`, then `mainLoop` via OUTER ih
+            rw [dif_neg hcan, dif_neg hcan]
+            rw [updateHashesMergedH3Guarded_eq,
+              updateHashesMerged_append data hashSize prevSize htd prevd (mp - 1) 1 _ insertCap hhs hhtd hpsd hpvd,
+              updateHashesGuarded_eq]
+            exact ih _ (by omega) _ _ _ _ _ (by rw [updateHashes_size1]; exact hhtd)
+              (by rw [updateHashes_size2]; exact hpsd) (by rw [updateHashes_size2]; exact hpvd) rfl
+      -- Main loop lockstep. With `rollDefer` proof-arg-free the `generalize`s below
+      -- survive the live rolling arm (the walk lands only in `Nat` positions).
       simp (config := { zeta := false }) only [hlt, ↓reduceDIte]
       generalize hsd : h3Seed useH3 data h3tab windowSize pos hlt = sd
       generalize hash3Single data pos hlt = hsg
-      -- Prune the dead `1 < lazy2Steps` rolling dispatch on both sides (rung-4 hstep
-      -- checkpoint). It sits under the lookahead `have` binders, so a folded
-      -- (`zeta := false`) simp cannot reach it — this zeta-true `dif_neg hstep`
-      -- reduces those `dite`s so the later `generalize`s (whose explicit `rollDefer`
-      -- proof-args would otherwise block abstracting the head-inserted table) apply.
-      simp only [dif_neg hstep]
       simp only [headProbeGuarded_eq, guardedSet_eq,
         getElem!_append_right' prev hashTable prevSize (lz77Greedy.hash3 data pos hashSize hlt) hps hh,
         set!_append_right' prev hashTable prevSize (lz77Greedy.hash3 data pos hashSize hlt) pos hps hh,
@@ -547,9 +596,6 @@ private theorem mergedLoop_eq (data : ByteArray)
       have hpv' : min chainWinSize data.size ≤ p'.size := by rw [← hp'eq, Array.size_set!]; exact hpv
       rw [chainWalkGuardedPackedU_append data p' t' windowSize pos (min 258 (data.size - pos))
         niceLen (by omega) hpv' (hashTable[lz77Greedy.hash3 data pos hashSize hlt]!) maxChain (sd % 512) (sd / 512)]
-      -- Abstract the (now identical on both sides) main walk result so `split`'s
-      -- normalisation does not carry its many `matchLen`/`matchPos`/interior-insert
-      -- copies (which the split-tier `updateHash3` range multiplied).
       generalize chainWalkGuardedPackedU data p' windowSize pos (min 258 (data.size - pos)) niceLen
         (by omega) (hashTable[lz77Greedy.hash3 data pos hashSize hlt]!) maxChain (sd % 512) (sd / 512) = rmain
       split
@@ -566,9 +612,7 @@ private theorem mergedLoop_eq (data : ByteArray)
               (min 258 (data.size - (pos + 1))) niceLen (by omega) hpv'
               (t'[lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!) lazyDepth]
             split
-            · -- goodMatch-T: bridge the *seeded* `pos+1` probe to the unseeded one.
-              -- The seeding lemma makes the lazy decision (and, on accept, the probe
-              -- result itself) identical, so the branch tree stays in lockstep.
+            · -- goodMatch-T: bridge the seeded `pos+1` probe to the unseeded one.
               have hbr := seeded_probe_bridge data p' windowSize (pos + 1)
                 (min 258 (data.size - (pos + 1))) niceLen (by omega) (by omega)
                 (t'[lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!) lazyDepth
@@ -582,12 +626,18 @@ private theorem mergedLoop_eq (data : ByteArray)
                 rcases hbr.2 with heq | hfalse
                 · rw [heq]
                   split
-                  · rw [updateHashesMergedH3Guarded_eq,
-                      updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
-                      updateHashesGuarded_eq]
-                    exact ih _ (by omega) _ _ _ _ _ (by rw [updateHashes_size1]; exact hht')
-                      (by rw [updateHashes_size2]; exact hps') (by rw [updateHashes_size2]; exact hpv') rfl
-                  · rw [updateHashesMergedH3Guarded_eq,
+                  · -- hle2-T: rolling dispatch `if 1 < lazy2Steps`
+                    split
+                    · -- roll: forward to `rollDefer` at `pos+1` via `rdeq`
+                      rw [rdeq] <;> first | exact hht' | exact hps' | exact hpv' | omega
+                    · -- ¬(1 < lazy2Steps): single-deferral two-push commit
+                      rw [updateHashesMergedH3Guarded_eq,
+                        updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
+                        updateHashesGuarded_eq]
+                      exact ih _ (by omega) _ _ _ _ _ (by rw [updateHashes_size1]; exact hht')
+                        (by rw [updateHashes_size2]; exact hps') (by rw [updateHashes_size2]; exact hpv') rfl
+                  · -- ¬hle2: reference(matchLen) at pos
+                    rw [updateHashesMergedH3Guarded_eq,
                       updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
                       updateHashesGuarded_eq]
                     exact ih _ (by omega) _ _ _ _ _ (by rw [updateHashes_size1]; exact hht')
@@ -684,7 +734,7 @@ theorem lz77ChainLazyIterPMerged_eq (data : ByteArray) (maxChain windowSize inse
   · dsimp only
     rw [← Array.replicate_append_replicate]
     exact mergedLoop_eq data windowSize 65536 (min chainWinSize data.size) maxChain insertCap
-      goodMatch niceLen lazyDepth 1 useH3 (by omega) (Array.replicate 65536 data.size)
+      goodMatch niceLen lazyDepth 1 useH3 (Array.replicate 65536 data.size)
       (Array.replicate (min chainWinSize data.size) data.size) (Array.replicate 32768 data.size) 0 _
       (by omega) (by rw [Array.size_replicate]) (by rw [Array.size_replicate])
       (Nat.le_of_eq (by rw [Array.size_replicate]))

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -90,12 +90,11 @@ mutual
     so both sides land on the same walk; `Array.map_push` commutes `packTok` through
     each push. -/
 private theorem rollDefer_P_eq (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps : Nat) (useH3 : Bool)
-    (hashTable : Array Nat) (prev h3tab : Array Nat) (mp pLen pMatchPos step : Nat) (acc : Array LZ77Token)
-    (hmp : mp + pLen ≤ data.size) (hpl : 3 ≤ pLen) :
+    (hashTable : Array Nat) (prev h3tab : Array Nat) (mp pLen pMatchPos step : Nat) (acc : Array LZ77Token) :
     lz77ChainLazyIterP.rollDefer data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3 hashTable prev h3tab mp pLen pMatchPos step
-        (acc.map packTok) hmp hpl =
+        (acc.map packTok) =
       (lz77ChainLazyIter.rollDefer data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth lazy2Steps useH3 hashTable prev h3tab mp pLen pMatchPos step
-        acc hmp hpl).map packTok := by
+        acc).map packTok := by
   unfold lz77ChainLazyIterP.rollDefer lz77ChainLazyIter.rollDefer
   by_cases hcan : step < lazy2Steps ∧ mp + 3 < data.size ∧ pLen < goodMatch
   · rw [dif_pos hcan, dif_pos hcan]
@@ -110,7 +109,7 @@ private theorem rollDefer_P_eq (data : ByteArray) (windowSize hashSize maxChain 
   · rw [dif_neg hcan, dif_neg hcan]
     simp only [← Array.map_push]
     rw [mainLoopLazyP_eq]
-termination_by data.size - mp
+termination_by 2 * (data.size - mp) + 1
 decreasing_by all_goals omega
 
 /-- The packed lazy `mainLoop` is the packed image of the boxed one, generalized to
@@ -133,7 +132,7 @@ private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChai
     generalize h3Seed useH3 data h3tab windowSize pos hlt = sd
     generalize hash3Single data pos hlt = hsg
     simp (config := { maxSteps := 4000000 }) only [chainWalkGuardedPackedU_eq]
-    -- Branch tree: hge / hle / h3lt / gate / lazyAccept / hle2 / h1 / hpl2
+    -- Branch tree: hge / hle / h3lt / gate / lazyAccept / hle2 / h1 (rung 5: no hpl2)
     split
     · split
       · split
@@ -141,11 +140,8 @@ private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChai
           · split
             · split
               · split
-                · split
-                  · -- roll arm: literal push, then rollDefer
-                    rw [← Array.map_push, rollDefer_P_eq]
-                  · -- ¬hpl2: single-deferral fallback, two pushes
-                    rw [← Array.map_push, ← Array.map_push, mainLoopLazyP_eq]
+                · -- roll arm: literal push, then rollDefer
+                  rw [← Array.map_push, rollDefer_P_eq]
                 · -- ¬h1: single deferral, two pushes
                   rw [← Array.map_push, ← Array.map_push, mainLoopLazyP_eq]
               · -- ¬hle2: reference(matchLen)
@@ -162,8 +158,8 @@ private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChai
       rw [← Array.map_push, mainLoopLazyP_eq]
   · simp only [hlt, ↓reduceDIte]
     exact trailingP_eq data pos acc
-termination_by data.size - pos
-decreasing_by all_goals omega
+termination_by 2 * (data.size - pos)
+decreasing_by all_goals (first | omega | (refine Nat.mul_lt_mul_of_pos_left ?_ (by decide); omega))
 
 end
 


### PR DESCRIPTION
This PR complete the #2837 proof tower with the def-side refactor Kim ordered: all four `rollDefer` twins (boxed/iter/packed/merged) drop their dependent proof-arguments — whose types contained the lookahead walk and made every walk-touching rewrite motive-incorrect — carrying the bound in the guard as the certified spike does, with termination via an interleaved mutual measure (`2*(size-pos)` vs `2*(size-mp)+1`). The merged re-probe becomes unseeded, mirror-aligned with the packed twin (byte-neutral: the seed only changed rejected probe values). On the cleaner shape, `mergedLoop_eq` generalizes past its restriction with a structural nested twin — the whole correctness tower now holds for ALL `lazy2Steps`, and the rung-1/3/4 contracts are re-proven proof-arg-free.

Verified: production byte-identical at the default (size+checksum vs pre-refactor binary, {dickens, xml} × L{4,6,7,8}); `lazy2Steps = 4` reproduces the certified spike byte-for-byte on all 12 Silesia files; the generated hot loop gains no allocations and is simpler than before (3613 vs 4157 lines, 128 vs 149 branches); pinned sandwich neutral (dickens L6 1400 vs 1428 ms, xml 272 vs 269 ms). Zero new `sorry`; `lake exe test` green. No perf overlay attached — nothing that executes differs at the default; the knob flip is the next, separately-measured PR.

🤖 Prepared with Claude Code