### PR TITLE
ci: pin strict L6 miniz-domination on silesia.tar as a required gate (#2837)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,64 @@ jobs:
       - name: Test bench package
         run: cd bench && lake -R test
 
+  l6-gate:
+    # Cold single-shot L6 whole-tar dominance gate. Fetches Silesia, assembles
+    # the whole silesia.tar, builds the dev-only `bench` exe (needs the Rust
+    # miniz_oxide shim, like the `bench` job), and runs bench/l6_tar_gate.sh:
+    # it FAILS if lean native DEFLATE L6 stops strictly beating miniz_oxide L6
+    # on the whole tar in size AND cold single-shot time. Cold is load-bearing
+    # — see bench/l6_tar_gate.sh for why an in-process warm loop would mask the
+    # regression this gate exists to catch.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev pkg-config cargo bc
+
+      - name: Install elan
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Cache Lake build
+        id: cache
+        uses: actions/cache@v4
+        with:
+          # Mirror the `bench` job: the bench package builds the parent Zip
+          # library into the root .lake/, then its own targets into bench/.lake/.
+          path: |
+            .lake
+            bench/.lake
+          key: bench-v2-${{ hashFiles('lean-toolchain', 'lakefile.lean', 'Zip/**/*.lean', 'c/**', 'bench/lean-toolchain', 'bench/lake-manifest.json', 'bench/lakefile.lean', 'bench/**/*.lean', 'bench/c/**', 'bench/rust/**') }}
+          restore-keys: bench-v2-
+
+      - name: Clean stale Lake cache on fallback restore
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: rm -rf .lake bench/.lake
+
+      - name: Build the bench exe
+        run: cd bench && lake -R build bench
+
+      - name: Fetch Silesia corpus
+        run: bash bench/fetch_corpora.sh silesia
+
+      - name: Assemble silesia.tar
+        # Concatenate the 12 Silesia files (fixed, sorted order) into one tar so
+        # the gate compresses a ~202 MB whole-tar payload, matching the
+        # `hyperfine zip silesia.tar` benchmark the gate defends.
+        run: |
+          tar --sort=name --owner=0 --group=0 --numeric-owner \
+              --mtime='2020-01-01 00:00:00' \
+              -cf silesia.tar -C bench/corpora/silesia \
+              dickens mozilla mr nci ooffice osdb reymont samba sao webster x-ray xml
+          ls -l silesia.tar
+
+      - name: Run the cold L6 whole-tar gate
+        # Pin to the idlest core so the cold ratio is not corrupted by scheduler
+        # migration / SMT contention with concurrent runner work.
+        run: bash bench/pin_core.sh bash bench/l6_tar_gate.sh silesia.tar 9
+
   animation-sync:
     # The committed compress-Pareto animation must match what
     # bench/pareto_history.py renders from the current latest.json git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,11 @@ jobs:
 
       - name: Run the cold L6 whole-tar gate
         # Pin to the idlest core so the cold ratio is not corrupted by scheduler
-        # migration / SMT contention with concurrent runner work.
-        run: bash bench/pin_core.sh bash bench/l6_tar_gate.sh silesia.tar 9
+        # migration / SMT contention with concurrent runner work. N=15 (not 9):
+        # the median-of-N absorbs the noisier single-shot jitter of a 2-core
+        # GitHub runner, keeping the ~1.8% cold margin's median stable well below
+        # the 1.0 threshold. ~72s extra over N=9 — cheap insurance.
+        run: bash bench/pin_core.sh bash bench/l6_tar_gate.sh silesia.tar 15
 
   animation-sync:
     # The committed compress-Pareto animation must match what

--- a/bench/ZipBench.lean
+++ b/bench/ZipBench.lean
@@ -224,8 +224,14 @@ where
       let _ ← RawDeflate.compress data level.toUInt8
       pure ()
     | "compress-miniz" =>
-      let _ ← MinizOxide.compress data level.toUInt8
-      pure ()
+      -- Print the compressed size (mirrors the `csize` one-line format) so the
+      -- cold L6 whole-tar gate (bench/l6_tar_gate.sh) can read miniz's output
+      -- size while still timing this as a fresh single-shot process. The extra
+      -- print is negligible next to compressing a 200 MB tar, so it does not
+      -- perturb the cold timing the gate measures.
+      let out ← MinizOxide.compress data level.toUInt8
+      let ratio : Float := 100.0 * out.size.toFloat / data.size.toFloat
+      IO.println s!"size={data.size} lvl={level}: out={out.size} ratio={ratio.toString.take 5}%"
     | "compress-libdeflate" =>
       let _ ← Libdeflate.compress data level.toUInt8
       pure ()

--- a/bench/graphs/silesia_compress_pareto_history.svg
+++ b/bench/graphs/silesia_compress_pareto_history.svg
@@ -348,7 +348,7 @@
 <text x="62" y="46" opacity="0">2026-07-19 · fbc02fc2 · 41/44 — perf: rolling lazy2 deferral at L7, fused into the merged loop hot pa…<animate attributeName="opacity" values="0;1;0" keyTimes="0;0.82126;0.84058" calcMode="discrete" dur="20.7s" repeatCount="indefinite"/></text>
 <text x="62" y="46" opacity="0">2026-07-20 · 3d940c5d · 42/44 — perf: content-gate the L6-8 hash3 length-3 probe, completing strict m…<animate attributeName="opacity" values="0;1;0" keyTimes="0;0.84058;0.85990" calcMode="discrete" dur="20.7s" repeatCount="indefinite"/></text>
 <text x="62" y="46" opacity="0">2026-07-21 · 74eda5e2 · 43/44 — perf(tune): anchor L6 at ld8/no-roll for strict whole-tar miniz domin…<animate attributeName="opacity" values="0;1;0" keyTimes="0;0.85990;0.87923" calcMode="discrete" dur="20.7s" repeatCount="indefinite"/></text>
-<text x="62" y="46" opacity="0">2026-07-21 · 9c6d3b82 · 44/44 — bench: refresh dashboard for the fault-reserve output-capacity change<animate attributeName="opacity" values="0;1" keyTimes="0;0.87923" calcMode="discrete" dur="20.7s" repeatCount="indefinite"/></text>
+<text x="62" y="46" opacity="0">2026-07-21 · 16eb4b4d · 44/44 — perf(deflate): reserve exact output capacity in the sized-prep emitte…<animate attributeName="opacity" values="0;1" keyTimes="0;0.87923" calcMode="discrete" dur="20.7s" repeatCount="indefinite"/></text>
 </g>
 <rect x="586" y="496" width="330" height="90" fill="#ffffff" opacity="0.85" stroke="#cccccc"/>
 <g font-size="10.5" fill="#333333">

--- a/bench/l6_tar_gate.sh
+++ b/bench/l6_tar_gate.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Cold single-shot L6 whole-tar dominance gate.
+#
+#   bench/l6_tar_gate.sh <tarPath> [N]        # N reps, default 9
+#
+# WHY COLD: the gate must FAIL if lean native DEFLATE L6 stops strictly
+# dominating miniz_oxide L6 on the whole silesia.tar in BOTH size and time,
+# matching Kim's `hyperfine zip silesia.tar` benchmark. That benchmark is COLD:
+# a fresh process each run, so native pays its full page-fault / CAF-build tax
+# every time (~0.24 s). An in-process warm loop amortizes that tax after the
+# first rep and inflates native's apparent time margin from ~2% (cold) to
+# ~4.5% (warm) — enough to green-light a config that is actually ~2.8% SLOWER
+# cold. So every timed rep here spawns FRESH `bench` subprocesses.
+#
+# Native side  : `bench csize 0 @<tar> 6`          — prints native L6 out-size
+# miniz side   : `bench compress-miniz 0 @<tar> 6` — prints miniz L6 out-size
+# Both are single-shot: one compress of the whole tar, then exit.
+#
+# Method (paired ratio, cold):
+#   (a) one run of each -> native_size, miniz_size; assert native_size < miniz_size.
+#   (b) N interleaved cold reps: each rep spawns native and miniz as fresh
+#       processes, wall-times each, ALTERNATING which runs first to cancel
+#       ordering bias; per-rep ratio = native_wall / miniz_wall.
+#   (c) median ratio across reps; assert median < 1.0.
+#
+# Pinning: keep this script simple; the CI step (or a manual invocation) wraps
+# it in bench/pin_core.sh so the whole process tree inherits one idle core.
+set -euo pipefail
+
+TAR="${1:-}"
+N="${2:-9}"
+
+if [ -z "$TAR" ]; then
+  echo "usage: bench/l6_tar_gate.sh <tarPath> [N]" >&2
+  exit 2
+fi
+if [ ! -f "$TAR" ]; then
+  echo "FAIL: tar not found: $TAR" >&2
+  exit 2
+fi
+
+# Vacuity guard: the gate is meaningless on a tiny input (native's fixed page
+# tax dominates and the ratio is noise). Require > 1 MiB.
+TAR_BYTES="$(wc -c < "$TAR")"
+if [ "$TAR_BYTES" -le 1048576 ]; then
+  echo "FAIL: tar too small (${TAR_BYTES} B <= 1 MiB); gate needs a large corpus" >&2
+  exit 2
+fi
+
+# Locate the built bench exe. Resolve relative to this script so it works from
+# any CWD, and fall back to the current dir's build tree.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BENCH=""
+for cand in \
+  "$SCRIPT_DIR/.lake/build/bin/bench" \
+  "$SCRIPT_DIR/../bench/.lake/build/bin/bench" \
+  ".lake/build/bin/bench" \
+  "bench/.lake/build/bin/bench"; do
+  if [ -x "$cand" ]; then BENCH="$cand"; break; fi
+done
+if [ -z "$BENCH" ]; then
+  echo "FAIL: could not find the built 'bench' exe (looked under $SCRIPT_DIR/.lake/build/bin)" >&2
+  exit 2
+fi
+
+echo "== L6 cold whole-tar gate =="
+echo "tar     : $TAR (${TAR_BYTES} B)"
+echo "bench   : $BENCH"
+echo "reps    : $N"
+echo
+
+# Parse `out=<n>` from a `size=... lvl=6: out=<n> ratio=...%` line.
+parse_out() { awk 'match($0, /out=[0-9]+/) { print substr($0, RSTART+4, RLENGTH-4); exit }'; }
+
+# --- (a) size dominance: one run of each, capture out-sizes ---
+NATIVE_LINE="$("$BENCH" csize 0 "@$TAR" 6)"
+MINIZ_LINE="$("$BENCH" compress-miniz 0 "@$TAR" 6)"
+NATIVE_SIZE="$(printf '%s\n' "$NATIVE_LINE" | parse_out)"
+MINIZ_SIZE="$(printf '%s\n' "$MINIZ_LINE"  | parse_out)"
+
+if ! [[ "$NATIVE_SIZE" =~ ^[0-9]+$ ]] || ! [[ "$MINIZ_SIZE" =~ ^[0-9]+$ ]]; then
+  echo "FAIL: could not parse out-sizes" >&2
+  echo "  native line: $NATIVE_LINE" >&2
+  echo "  miniz  line: $MINIZ_LINE" >&2
+  exit 1
+fi
+
+echo "size: native L6 out=$NATIVE_SIZE  miniz L6 out=$MINIZ_SIZE"
+if [ "$NATIVE_SIZE" -ge "$MINIZ_SIZE" ]; then
+  echo "FAIL: native L6 does not strictly beat miniz L6 on size"
+  echo "  native=$NATIVE_SIZE  miniz=$MINIZ_SIZE  (need native < miniz)"
+  exit 1
+fi
+SIZE_MARGIN="$(awk -v a="$NATIVE_SIZE" -v b="$MINIZ_SIZE" 'BEGIN{printf "%.3f", 100.0*(b-a)/b}')"
+echo "  -> native is ${SIZE_MARGIN}% smaller. size dominance OK."
+echo
+
+# nanosecond wall clock around a fresh subprocess.
+run_native() { "$BENCH" csize 0 "@$TAR" 6 >/dev/null; }
+run_miniz()  { "$BENCH" compress-miniz 0 "@$TAR" 6 >/dev/null; }
+
+now() { date +%s.%N; }
+
+echo "cold reps (native_wall / miniz_wall):"
+printf "  %-4s %-12s %-12s %-8s %-6s\n" "rep" "native(s)" "miniz(s)" "ratio" "first"
+
+RATIOS=()
+for ((i=1; i<=N; i++)); do
+  # alternate ordering to cancel any first-mover cache/turbo bias.
+  if (( i % 2 == 1 )); then
+    t0="$(now)"; run_native; t1="$(now)"; run_miniz; t2="$(now)"
+    nat="$(awk -v a="$t0" -v b="$t1" 'BEGIN{printf "%.6f", b-a}')"
+    miz="$(awk -v a="$t1" -v b="$t2" 'BEGIN{printf "%.6f", b-a}')"
+    first="nat"
+  else
+    t0="$(now)"; run_miniz; t1="$(now)"; run_native; t2="$(now)"
+    miz="$(awk -v a="$t0" -v b="$t1" 'BEGIN{printf "%.6f", b-a}')"
+    nat="$(awk -v a="$t1" -v b="$t2" 'BEGIN{printf "%.6f", b-a}')"
+    first="miz"
+  fi
+  r="$(awk -v n="$nat" -v m="$miz" 'BEGIN{printf "%.4f", n/m}')"
+  RATIOS+=("$r")
+  printf "  %-4s %-12s %-12s %-8s %-6s\n" "$i" "$nat" "$miz" "$r" "$first"
+done
+echo
+
+# --- (c) median ratio + stats ---
+STATS="$(printf '%s\n' "${RATIOS[@]}" | sort -n | awk '
+  { v[NR]=$1; s+=$1; if(NR==1||$1<mn)mn=$1; if(NR==1||$1>mx)mx=$1 }
+  END {
+    n=NR
+    if (n % 2 == 1) med = v[(n+1)/2]
+    else            med = (v[n/2] + v[n/2+1]) / 2.0
+    mean = s/n
+    ss=0; for (i=1;i<=n;i++){ d=v[i]-mean; ss+=d*d }
+    sd = (n>1) ? sqrt(ss/(n-1)) : 0
+    printf "%.4f %.4f %.4f %.4f %.4f", med, mean, mn, mx, sd
+  }')"
+read -r MED MEAN MIN MAX SD <<<"$STATS"
+
+echo "ratio distribution (native_wall / miniz_wall):"
+echo "  median=$MED  mean=$MEAN  min=$MIN  max=$MAX  stdev=$SD"
+echo
+
+# Median < 1.0 means native is cold-faster on the median rep.
+if awk -v m="$MED" 'BEGIN{exit !(m < 1.0)}'; then
+  echo "PASS: median ratio $MED < 1.0 — native L6 strictly dominates miniz L6 (size + cold time)."
+  exit 0
+else
+  echo "FAIL: median ratio $MED >= 1.0 — native L6 is NOT cold-faster than miniz L6."
+  exit 1
+fi


### PR DESCRIPTION
This PR adds a CI job that pins the invariant this campaign established: lean's native DEFLATE L6 must strictly dominate miniz_oxide L6 on the whole `silesia.tar` — SMALLER output AND FASTER — matching the `hyperfine zip silesia.tar` benchmark. It exists so a future ratio-tuning change cannot silently trade the whole-tar speed win back for per-file ratio (as ld18/#2842 and the ld10+roll tier each did before the ld8 anchor in #2861).

The gate (`bench/l6_tar_gate.sh`) measures COLD single-shot timing, because that is what the real benchmark does: a fresh process each run, so native pays its full ~0.24s page-fault tax every time. An in-process warm loop amortizes that tax after the first rep and inflates native's apparent margin from ~2% (cold) to ~4.5% (warm) — enough to green-light a config that is actually slower cold. Each timed rep spawns fresh `bench csize` (native L6) and `bench compress-miniz` (miniz L6) subprocesses, alternating order, and the gate requires native strictly smaller output AND a median per-rep `native_wall / miniz_wall` < 1.0 over N=15 reps. The paired ratio cancels GitHub-runner variance (both codecs see the same CPU); median-of-N absorbs single-shot jitter; `pin_core.sh` pins the tree to one idle core. `compress-miniz` now prints its output size (mirroring `csize`) so the size half is checkable.

Local validation on the real 211 MB silesia.tar (pinned, this is not a GitHub runner): ld8 (current master) 10/10 PASS, median 0.9818 [0.979, 0.985], cross-run stdev 0.17%. Negative control ld10+roll (the reverted regression: smaller output but ~1.5% slower cold) 6/6 FAIL, median 1.015 [1.009, 1.037]. The 1.0 threshold sits in a clean ~2.4% gap between the two.

Honest caveat: the cold margin is genuinely thin (~1.8%), so the gate is reliable-but-borderline. The residual risk is ubuntu-latest CPU heterogeneity shifting native's relative cold cost across runs. If it ever false-fails, the cheap mitigations are raising N further and logging the runner CPU; the threshold should NOT be loosened past 1.0 by more than ~0.005 since the reverted regression sits at only ~1.01. Making this a *required* status check is a repo-settings decision — see the PR discussion.

🤖 Prepared with Claude Code