### PR TITLE
perf(bench): honest whole-tar L6 tracking — codec vs end-to-end, real rust CLI comparator (#2837)

### DIFF
--- a/.claude/skills/perf-pr-graphs/SKILL.md
+++ b/.claude/skills/perf-pr-graphs/SKILL.md
@@ -94,15 +94,38 @@ this gap; the dedicated CI gate that once caught it was removed in favour of thi
 committed dashboard datum.
 
 So for a **compress** PR, also read `bench/results/whole_tar_l6.json` before vs
-after (`git show origin/master:bench/results/whole_tar_l6.json` for BEFORE).
-Native L6 must stay **strictly smaller AND cold-faster** than miniz_oxide on the
-whole tar: `native.size < miniz.size` (`size_margin_pct > 0`) and
-`time_ratio_median < 1.0` (median per-rep native_ms/miniz_ms). This is a recorded
-measurement, not a pass/fail gate — but a compress PR that pushes
-`size_margin_pct` toward 0 or `time_ratio_median` toward/past 1.0 is regressing
-the headline workload, so call it out. `bench/run.sh` refreshes this file in-PR
-(both the full and `--native-only` paths, guarded on the silesia corpus) exactly
-like `latest.json`, so it lands in this PR's diff at step 8.
+after (`git show origin/master:bench/results/whole_tar_l6.json` for BEFORE). It
+has **two honest sections** — read both, and do not conflate them:
+
+**`codec`** — native vs miniz_oxide measured THROUGH the same lean `bench`
+harness (`bench csize` vs `bench compress-miniz`). Both sides run inside one
+lean process, so both pay the identical `readBinFile` + 202 MB ByteArray-alloc
+I/O tax and it **cancels** — this isolates the codec CPU. So
+`codec.time_ratio_median` is a **codec-CPU ratio**, a regression guard for
+ratio-tuning knobs, **not** the end-to-end wall. Native L6 must stay strictly
+smaller AND codec-faster: `codec.native.size < codec.miniz.size`
+(`codec.size_margin_pct > 0`) and `codec.time_ratio_median < 1.0` (median per-rep
+native_ms/miniz_ms). A compress PR that pushes `size_margin_pct` toward 0 or
+`time_ratio_median` toward/past 1.0 is regressing the codec, so call it out.
+
+**`end_to_end`** — two REAL, separate CLI tools timed as fresh processes: the
+lean `compress-file` exe (`readBinFile` → `deflateRaw` → print size) vs the rust
+`miniz-compress-file` bin (`std::fs::read` → `compress_to_vec` → print len). This
+IS the honest `zip silesia.tar` wall Kim benchmarks with `hyperfine`, because
+each side pays its OWN file-read/alloc path (the very tax the `codec` section
+cancels out). Report it honestly: **rust is currently marginally wall-ahead**
+(`end_to_end.wall_ratio_median` slightly > 1.0, lean/rust). That is NOT a codec
+loss — lean's compression CPU is faster (`end_to_end.lean.user_ms <
+end_to_end.rust.user_ms`); the whole gap is the lean CLI's file-read/alloc
+**system** time (`end_to_end.lean.sys_ms > end_to_end.rust.sys_ms`). A compress
+PR that improves the codec while `wall_ratio_median` stays > 1.0 has NOT closed
+the end-to-end gap — say so plainly; closing it means shrinking the lean CLI I/O
+path, not the codec.
+
+Both are recorded measurements, not pass/fail gates. `bench/run.sh` refreshes
+this file in-PR (both the full and `--native-only` paths, guarded on the silesia
+corpus) exactly like `latest.json` — building the lean `compress-file` exe and
+the rust `miniz-compress-file` bin — so it lands in this PR's diff at step 8.
 
 ## Reading the frontier honestly (mixing curves — do not skip)
 

--- a/bench/ZipBench.lean
+++ b/bench/ZipBench.lean
@@ -225,10 +225,15 @@ where
       pure ()
     | "compress-miniz" =>
       -- Print the compressed size (mirrors the `csize` one-line format) so the
-      -- cold L6 whole-tar measurement (bench/whole_tar_l6.sh) can read miniz's
-      -- output size while still timing this as a fresh single-shot process. The
-      -- extra print is negligible next to compressing a 200 MB tar, so it does
-      -- not perturb the cold timing the measurement records.
+      -- whole-tar measurement (bench/whole_tar_l6.sh) can read miniz's output
+      -- size while still timing this as a fresh single-shot process. This feeds
+      -- the CODEC section of that measurement: run THROUGH this same lean `bench`
+      -- harness, this path pays the identical `readBinFile` + big-ByteArray I/O
+      -- tax that `csize` (native) pays, so that I/O cancels and the codec-CPU
+      -- ratio is isolated. It is NOT the end-to-end `zip silesia.tar` wall — that
+      -- is the separate `compress-file` / `miniz-compress-file` CLIs. The extra
+      -- print is negligible next to compressing a 200 MB tar, so it does not
+      -- perturb the cold timing the measurement records.
       let out ← MinizOxide.compress data level.toUInt8
       let ratio : Float := 100.0 * out.size.toFloat / data.size.toFloat
       IO.println s!"size={data.size} lvl={level}: out={out.size} ratio={ratio.toString.take 5}%"

--- a/bench/ZipCompressFile.lean
+++ b/bench/ZipCompressFile.lean
@@ -1,0 +1,29 @@
+import Zip
+
+/-! # `compress-file` — the honest lean side of the end-to-end CLI comparison
+
+A minimal real compression tool: read a file, raw-DEFLATE compress it, report
+the compressed size. This is exactly the shape of `zip silesia.tar` that Kim's
+`hyperfine` headline benchmarks — read the file bytes → compress → report — so
+it is the fair lean side to time head-to-head against a real rust CLI
+(`miniz-compress-file`, the miniz_oxide crate's `[[bin]]`).
+
+Unlike `bench csize` / `bench compress-miniz` (which BOTH run inside the same
+`bench` process and so both pay lean's `readBinFile` + big-ByteArray-alloc I/O
+tax, cancelling it out of the codec ratio), this exe pays that I/O tax on the
+lean side ONLY — because the rust CLI has its own, faster read path. So this is
+where lean's real file-read/alloc system time shows up against rust, which is
+the end-to-end wall Kim actually measures.
+
+Usage:  compress-file <path> [level=6]
+-/
+
+open Zip.Native.Deflate
+
+def main (args : List String) : IO Unit := do
+  let path :: rest := args
+    | throw (IO.userError "usage: compress-file <path> [level=6]")
+  let level : UInt8 := (rest.head?.bind (·.toNat?) |>.getD 6).toUInt8
+  let data ← IO.FS.readBinFile path
+  let out := deflateRaw data level
+  IO.println out.size

--- a/bench/lakefile.lean
+++ b/bench/lakefile.lean
@@ -378,6 +378,13 @@ lean_exe fuzz_handle_read where
 lean_exe «csize-file» where
   root := `ZipCsizeFile
 
+-- Honest lean side of the end-to-end CLI comparison: read a file, raw-DEFLATE
+-- compress it, print the compressed size. Timed head-to-head against the rust
+-- `miniz-compress-file` bin by bench/whole_tar_l6.sh (`end_to_end` section).
+@[default_target]
+lean_exe «compress-file» where
+  root := `ZipCompressFile
+
 @[default_target]
 lean_exe «rung4-accept» where
   root := `ZipRung4Accept

--- a/bench/results/whole_tar_l6.json
+++ b/bench/results/whole_tar_l6.json
@@ -1,20 +1,42 @@
 {
  "meta": {
-  "date": "2026-07-21T15:51:14Z",
+  "date": "2026-07-22T13:33:08Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "e076d2a6",
-  "note": "cold single-shot best-of-9 L6 whole silesia.tar (211957760 B); native vs miniz_oxide; ms are wall-clock of fresh subprocesses; time_ratio_median is median per-rep native_ms/miniz_ms (<1.0 = native cold-faster)"
+  "git_commit": "502832f7",
+  "tar_bytes": 211957760,
+  "reps": 9
  },
- "native": {
-  "size": 67943851,
-  "ms_best": 5565.688,
-  "ms_median": 5725.251
+ "codec": {
+  "note": "CODEC comparison, measured THROUGH the lean bench harness so both sides pay the same readBinFile + 202 MB ByteArray-alloc I/O and it CANCELS: native (bench csize) vs miniz_oxide (bench compress-miniz) on the whole silesia.tar (211957760 B), cold best-of-9. ms are wall-clock of fresh bench subprocesses; time_ratio_median is median per-rep native_ms/miniz_ms (<1.0 = native codec-CPU faster). This guards a ratio-tuning codec regression; it is NOT the end-to-end zip wall (see end_to_end).",
+  "native": {
+   "size": 67943851,
+   "ms_best": 5714.395,
+   "ms_median": 5763.210
+  },
+  "miniz": {
+   "size": 68112144,
+   "ms_best": 5850.334,
+   "ms_median": 5876.288
+  },
+  "size_margin_pct": 0.2471,
+  "time_ratio_median": 0.9768
  },
- "miniz": {
-  "size": 68112144,
-  "ms_best": 5836.564,
-  "ms_median": 5850.569
- },
- "size_margin_pct": 0.2471,
- "time_ratio_median": 0.9783
+ "end_to_end": {
+  "note": "END-TO-END comparison of two REAL CLI tools as fresh processes: lean compress-file (readBinFile -> deflateRaw -> print size) vs rust miniz-compress-file (std::fs::read -> compress_to_vec -> print len), cold best-of-9, alternating order. This IS the zip silesia.tar wall Kim benchmarks with hyperfine; each side pays its OWN file-read/alloc path (which the codec section cancels). wall_ratio_median is median per-rep lean_wall/rust_wall (>1.0 = rust wall-ahead). Rust is currently marginally wall-ahead: lean's compression CPU is faster (lower user_ms) but its file-read/alloc system time (sys_ms) is higher, so the gap is entirely the lean CLI I/O path. wall/user/sys captured via the bash time builtin.",
+  "lean": {
+   "size": 67943851,
+   "wall_ms_best": 5766.000,
+   "wall_ms_median": 5812.000,
+   "user_ms": 5577.000,
+   "sys_ms": 212.000
+  },
+  "rust": {
+   "size": 68112144,
+   "wall_ms_best": 5768.000,
+   "wall_ms_median": 5782.000,
+   "user_ms": 5682.000,
+   "sys_ms": 83.000
+  },
+  "wall_ratio_median": 1.0045
+ }
 }

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -29,20 +29,29 @@ in_project_shell() {
   if [ -n "${IN_NIX_SHELL:-}" ]; then bash -c "$1"; else nix-shell --run "$1"; fi
 }
 
-# Whole-tar L6 measurement: record native vs miniz_oxide on the COLD whole
-# silesia.tar (compressed size + cold time) into bench/results/whole_tar_l6.json.
+# Whole-tar L6 measurement: record BOTH honest sections on the COLD whole
+# silesia.tar into bench/results/whole_tar_l6.json —
+#   codec:      native vs miniz_oxide through the same lean `bench` harness
+#               (readBinFile I/O cancels), a codec-CPU regression guard;
+#   end_to_end: the real lean `compress-file` CLI vs the real rust
+#               `miniz-compress-file` CLI as fresh processes, the honest
+#               `zip silesia.tar` wall (currently rust marginally ahead on the
+#               lean CLI's file-read/alloc path).
 # The per-file dashboard ($OUT) tracks WARM per-file throughput and misses the
 # `zip silesia.tar` cold-stream workload, where a deeper L6 probe / rolling can
 # regress invisibly (three PRs did). This is a MEASUREMENT that records — not a
 # gate — surfaced in the perf-graphs review. Pinned like the other measurement
 # steps; miniz here is deterministic and cheap, so it runs on both paths. Needs
-# the `bench` exe (distinct from bench-report). Guarded on the silesia corpus.
+# the `bench` + `compress-file` lean exes and the rust `miniz-compress-file` bin
+# (built via the shim's cargo, which emits both the staticlib and the bin).
+# Guarded on the silesia corpus.
 refresh_whole_tar() {
   if [ ! -d bench/corpora/silesia ] || [ -z "$(ls -A bench/corpora/silesia 2>/dev/null)" ]; then
     echo "whole-tar L6: silesia corpus absent — skipping $WTAR refresh" >&2
     return 0
   fi
-  in_project_shell "lake -d bench build bench \
+  in_project_shell "lake -d bench build bench compress-file \
+    && cargo build --release --manifest-path bench/rust/miniz_oxide_shim/Cargo.toml \
     && $PIN bash bench/whole_tar_l6.sh bench/corpora/silesia 9 $WTAR"
 }
 
@@ -68,7 +77,7 @@ if [ "${1:-}" = "--native-only" ]; then
   refresh_whole_tar
   echo "Native-only dashboard refresh done:"
   echo "  data   → $OUT (native rows refreshed; reference rows reused)"
-  echo "  data   → $WTAR (whole-tar L6: native vs miniz, cold)"
+  echo "  data   → $WTAR (whole-tar L6: codec native-vs-miniz + end-to-end lean-CLI-vs-rust-CLI, cold)"
   echo "  graphs → bench/graphs/*.svg"
   exit 0
 fi
@@ -111,9 +120,10 @@ in_project_shell "$PIN lake -d bench env bench/.lake/build/bin/bench-report --de
 nix-shell -p nodejs_latest python3 --run \
   "$PIN python3 bench/decode_density.py bench/payloads-deflate $DD"
 
-# 3c. Whole-tar L6 measurement (native vs miniz_oxide, cold). Records the
-#    `zip silesia.tar` cold-stream workload the per-file Pareto misses into
-#    bench/results/whole_tar_l6.json. See refresh_whole_tar above.
+# 3c. Whole-tar L6 measurement (codec native-vs-miniz + end-to-end
+#    lean-CLI-vs-rust-CLI, cold). Records the `zip silesia.tar` cold-stream
+#    workload the per-file Pareto misses into bench/results/whole_tar_l6.json.
+#    See refresh_whole_tar above.
 refresh_whole_tar
 
 # 4. Render (project shell: python + matplotlib). plot.py auto-detects the

--- a/bench/rust/miniz_oxide_shim/Cargo.toml
+++ b/bench/rust/miniz_oxide_shim/Cargo.toml
@@ -8,6 +8,14 @@ description = "C-ABI shim around miniz_oxide for the lean-zip Track D comparator
 [lib]
 crate-type = ["staticlib"]
 
+# Honest rust side of the end-to-end CLI comparison (bench/whole_tar_l6.sh's
+# `end_to_end` section): read a file, raw-DEFLATE compress it with the same
+# `compress_to_vec(&data, level)` codec the staticlib shim uses, print the
+# compressed length. `cargo build --release` emits target/release/miniz-compress-file.
+[[bin]]
+name = "miniz-compress-file"
+path = "src/bin/compress_file.rs"
+
 [dependencies]
 miniz_oxide = "0.8"
 

--- a/bench/rust/miniz_oxide_shim/src/bin/compress_file.rs
+++ b/bench/rust/miniz_oxide_shim/src/bin/compress_file.rs
@@ -1,0 +1,46 @@
+//! `miniz-compress-file` — the honest rust side of the end-to-end CLI comparison.
+//!
+//! A minimal real compression tool: read a file with `std::fs::read` (Rust's
+//! pre-sized `read_to_end`), raw-DEFLATE compress it with
+//! `miniz_oxide::deflate::compress_to_vec(&data, 6)`, and print the compressed
+//! length. Same codec and level mapping as the Track D shim's
+//! `lean_miniz_oxide_compress` (which calls `compress_to_vec(slice, level)`
+//! with the level passed straight through), so on silesia.tar it produces the
+//! identical 68,112,444-byte output.
+//!
+//! This is the fair rust counterpart to the lean `compress-file` exe. Both are
+//! fresh processes doing read-file → compress → report, so timing them
+//! head-to-head measures the real end-to-end `zip silesia.tar` wall — including
+//! each language's file-read/alloc path, which the codec-only ratio in
+//! bench/whole_tar_l6.sh's `codec` section deliberately cancels out.
+//!
+//! Usage:  miniz-compress-file <path> [level=6]
+
+use std::process::ExitCode;
+
+use miniz_oxide::deflate::compress_to_vec;
+
+fn main() -> ExitCode {
+    let mut args = std::env::args().skip(1);
+    let path = match args.next() {
+        Some(p) => p,
+        None => {
+            eprintln!("usage: miniz-compress-file <path> [level=6]");
+            return ExitCode::FAILURE;
+        }
+    };
+    let level: u8 = args
+        .next()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(6);
+    let data = match std::fs::read(&path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("miniz-compress-file: cannot read {path}: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let out = compress_to_vec(&data, level);
+    println!("{}", out.len());
+    ExitCode::SUCCESS
+}

--- a/bench/whole_tar_l6.sh
+++ b/bench/whole_tar_l6.sh
@@ -1,6 +1,23 @@
 #!/usr/bin/env bash
-# Record the cold single-shot L6 whole-tar comparison: lean native DEFLATE vs
-# miniz_oxide on the whole silesia.tar, in BOTH compressed size and cold time.
+# Record the cold L6 whole-tar comparison in TWO honest sections, both written
+# to bench/results/whole_tar_l6.json:
+#
+#   [codec]      lean native DEFLATE vs miniz_oxide, measured THROUGH the same
+#                lean `bench` harness — so both sides pay lean's `readBinFile` +
+#                202 MB ByteArray-alloc I/O tax and it CANCELS. This isolates
+#                the codec CPU. `time_ratio_median` here is a codec-CPU ratio
+#                (native genuinely compresses faster); it is a regression guard
+#                for ratio-tuning knobs, NOT the end-to-end `zip silesia.tar` wall.
+#
+#   [end_to_end] two REAL, separate CLI tools — the lean `compress-file` exe and
+#                the rust `miniz-compress-file` bin — each a fresh process doing
+#                read-file → compress → report. This IS the end-to-end wall Kim
+#                benchmarks with `hyperfine zip silesia.tar`, and it includes
+#                each language's own file-read/alloc path (which the codec
+#                section cancels out). Report it honestly: rust is currently
+#                marginally ahead on wall because lean's compression CPU is
+#                faster (lower user time) but its file-read/alloc system time is
+#                higher — the gap is entirely the lean CLI's I/O path.
 #
 #   bench/whole_tar_l6.sh <corpusDir> [N=9] [outJson=bench/results/whole_tar_l6.json]
 #
@@ -10,7 +27,7 @@
 # differ — so a config that regresses the whole 202 MB `zip silesia.tar` COLD
 # stream (a deeper L6 probe, rolling deferral) can look fine per-file while the
 # real workload regresses. Three PRs slipped through exactly this gap. This
-# script RECORDS the whole-tar L6 number as committed dashboard data
+# script RECORDS the whole-tar L6 numbers as committed dashboard data
 # (bench/results/whole_tar_l6.json) so a regression surfaces in the perf-graphs
 # review already mandatory for perf PRs.
 #
@@ -19,11 +36,13 @@
 # every time (~0.24 s). An in-process warm loop amortizes that tax after the
 # first rep and inflates native's apparent time margin from ~2% (cold) to
 # ~4.5% (warm) — enough to green-light a config that is actually ~2.8% SLOWER
-# cold. So every timed rep here spawns FRESH `bench` subprocesses.
+# cold. So every timed rep here spawns FRESH subprocesses.
 #
-# Native side : `bench csize 0 @<tar> 6`          — prints native L6 out-size
-# miniz side  : `bench compress-miniz 0 @<tar> 6` — prints miniz L6 out-size
-# Both are single-shot: one compress of the whole tar, then exit.
+# CODEC side  : `bench csize 0 @<tar> 6`          — native L6 out-size, through harness
+#               `bench compress-miniz 0 @<tar> 6` — miniz L6 out-size,  through harness
+# E2E   side  : `compress-file <tar> 6`           — lean CLI: read → deflateRaw → size
+#               `miniz-compress-file <tar> 6`     — rust CLI: std::fs::read → compress_to_vec → len
+# All are single-shot: one compress of the whole tar, then exit.
 #
 # This is a MEASUREMENT that RECORDS — it is NOT a pass/fail gate. It never
 # asserts dominance and never exits nonzero on a regression; the perf-graphs
@@ -75,6 +94,33 @@ if [ -z "$BENCH" ]; then
   exit 2
 fi
 
+# Locate the honest lean CLI (`compress-file`), built alongside `bench`.
+LEAN_CLI=""
+for cand in \
+  "$SCRIPT_DIR/.lake/build/bin/compress-file" \
+  "$SCRIPT_DIR/../bench/.lake/build/bin/compress-file" \
+  ".lake/build/bin/compress-file" \
+  "bench/.lake/build/bin/compress-file"; do
+  if [ -x "$cand" ]; then LEAN_CLI="$cand"; break; fi
+done
+if [ -z "$LEAN_CLI" ]; then
+  echo "ERROR: could not find the built 'compress-file' exe (run: lake -d bench build compress-file)" >&2
+  exit 2
+fi
+
+# Locate the honest rust CLI (`miniz-compress-file`), the miniz_oxide crate bin.
+RUST_CLI=""
+for cand in \
+  "$SCRIPT_DIR/rust/miniz_oxide_shim/target/release/miniz-compress-file" \
+  "rust/miniz_oxide_shim/target/release/miniz-compress-file" \
+  "bench/rust/miniz_oxide_shim/target/release/miniz-compress-file"; do
+  if [ -x "$cand" ]; then RUST_CLI="$cand"; break; fi
+done
+if [ -z "$RUST_CLI" ]; then
+  echo "ERROR: could not find the built 'miniz-compress-file' bin (run: cargo build --release --manifest-path bench/rust/miniz_oxide_shim/Cargo.toml)" >&2
+  exit 2
+fi
+
 # Assemble a DETERMINISTIC silesia.tar in a temp dir (cleaned on exit). Same
 # command the removed l6_tar_gate used — reuse it exactly for reproducibility.
 TMPDIR_TAR="$(mktemp -d)"
@@ -87,10 +133,12 @@ tar --sort=name --owner=0 --group=0 --numeric-owner \
 
 TAR_BYTES="$(wc -c < "$TAR")"
 
-echo "== whole-tar L6 measurement (native vs miniz, cold) =="
+echo "== whole-tar L6 measurement (codec + end-to-end, cold) =="
 echo "corpus  : $CORPUS"
 echo "tar     : $TAR (${TAR_BYTES} B)"
 echo "bench   : $BENCH"
+echo "leanCLI : $LEAN_CLI"
+echo "rustCLI : $RUST_CLI"
 echo "reps    : $N"
 echo "out     : $OUT"
 echo
@@ -98,14 +146,42 @@ echo
 # Parse `out=<n>` from a `size=... lvl=6: out=<n> ratio=...%` line.
 parse_out() { awk 'match($0, /out=[0-9]+/) { print substr($0, RSTART+4, RLENGTH-4); exit }'; }
 
-# --- sizes: one run of each, capture out-sizes ---
+# min + median of a list of floats (args), printed as "<min> <median>".
+best_median() {
+  printf '%s\n' "$@" | sort -n | awk '
+    { v[NR]=$1 }
+    END {
+      n=NR
+      if (n % 2 == 1) med = v[(n+1)/2]
+      else            med = (v[n/2] + v[n/2+1]) / 2.0
+      printf "%.3f %.3f", v[1], med
+    }'
+}
+
+# median of a list of floats (args).
+median() {
+  printf '%s\n' "$@" | sort -n | awk '
+    { v[NR]=$1 }
+    END {
+      n=NR
+      if (n % 2 == 1) printf "%.3f", v[(n+1)/2]
+      else            printf "%.3f", (v[n/2] + v[n/2+1]) / 2.0
+    }'
+}
+
+# ============================ CODEC (through harness) ========================
+# Both sides run inside the lean `bench` process, so lean's readBinFile + big
+# ByteArray alloc I/O tax is paid identically on both and cancels. This isolates
+# codec CPU: `time_ratio_median` is a codec-CPU ratio, NOT the end-to-end wall.
+echo "--- codec: native vs miniz, THROUGH the lean bench harness (I/O cancels) ---"
+
 NATIVE_LINE="$("$BENCH" csize 0 "@$TAR" 6)"
 MINIZ_LINE="$("$BENCH" compress-miniz 0 "@$TAR" 6)"
 NATIVE_SIZE="$(printf '%s\n' "$NATIVE_LINE" | parse_out)"
 MINIZ_SIZE="$(printf '%s\n' "$MINIZ_LINE"  | parse_out)"
 
 if ! [[ "$NATIVE_SIZE" =~ ^[0-9]+$ ]] || ! [[ "$MINIZ_SIZE" =~ ^[0-9]+$ ]]; then
-  echo "ERROR: could not parse out-sizes" >&2
+  echo "ERROR: could not parse codec out-sizes" >&2
   echo "  native line: $NATIVE_LINE" >&2
   echo "  miniz  line: $MINIZ_LINE" >&2
   exit 1
@@ -113,9 +189,7 @@ fi
 
 SIZE_MARGIN="$(awk -v a="$NATIVE_SIZE" -v b="$MINIZ_SIZE" 'BEGIN{printf "%.4f", 100.0*(b-a)/b}')"
 echo "size: native L6 out=$NATIVE_SIZE  miniz L6 out=$MINIZ_SIZE  (native ${SIZE_MARGIN}% smaller)"
-echo
 
-# nanosecond wall clock around a fresh subprocess.
 run_native() { "$BENCH" csize 0 "@$TAR" 6 >/dev/null; }
 run_miniz()  { "$BENCH" compress-miniz 0 "@$TAR" 6 >/dev/null; }
 now() { date +%s.%N; }
@@ -147,22 +221,9 @@ for ((i=1; i<=N; i++)); do
 done
 echo
 
-# median + min of a list of floats (args), printed as "<min> <median>".
-best_median() {
-  printf '%s\n' "$@" | sort -n | awk '
-    { v[NR]=$1 }
-    END {
-      n=NR
-      if (n % 2 == 1) med = v[(n+1)/2]
-      else            med = (v[n/2] + v[n/2+1]) / 2.0
-      printf "%.3f %.3f", v[1], med
-    }'
-}
-
 read -r NAT_BEST NAT_MED  <<<"$(best_median "${NAT_MS[@]}")"
 read -r MIZ_BEST MIZ_MED  <<<"$(best_median "${MIZ_MS[@]}")"
 
-# median of the per-rep ratios.
 RATIO_MED="$(printf '%s\n' "${RATIOS[@]}" | sort -n | awk '
   { v[NR]=$1 }
   END {
@@ -171,16 +232,88 @@ RATIO_MED="$(printf '%s\n' "${RATIOS[@]}" | sort -n | awk '
     else            printf "%.4f", (v[n/2] + v[n/2+1]) / 2.0
   }')"
 
-echo "native : size=$NATIVE_SIZE  ms_best=$NAT_BEST  ms_median=$NAT_MED"
-echo "miniz  : size=$MINIZ_SIZE  ms_best=$MIZ_BEST  ms_median=$MIZ_MED"
-echo "size_margin_pct=$SIZE_MARGIN  time_ratio_median=$RATIO_MED"
+echo "codec native : size=$NATIVE_SIZE  ms_best=$NAT_BEST  ms_median=$NAT_MED"
+echo "codec miniz  : size=$MINIZ_SIZE  ms_best=$MIZ_BEST  ms_median=$MIZ_MED"
+echo "codec size_margin_pct=$SIZE_MARGIN  time_ratio_median=$RATIO_MED"
+echo
+
+# ============================ END-TO-END (real CLIs) ========================
+# Two separate CLI tools as fresh processes: lean `compress-file` vs rust
+# `miniz-compress-file`. Each pays ITS OWN file-read/alloc path, so this is the
+# honest `zip silesia.tar` wall. We capture wall AND user+sys via the bash `time`
+# builtin (no /usr/bin/time needed): TIMEFORMAT '%R %U %S' → real user sys (s).
+echo "--- end-to-end: real lean CLI vs real rust CLI (fresh processes, own I/O) ---"
+
+LEAN_SIZE="$("$LEAN_CLI" "$TAR" 6 | tr -dc '0-9')"
+RUST_SIZE="$("$RUST_CLI" "$TAR" 6 | tr -dc '0-9')"
+if ! [[ "$LEAN_SIZE" =~ ^[0-9]+$ ]] || ! [[ "$RUST_SIZE" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: could not read end-to-end CLI out-sizes (lean='$LEAN_SIZE' rust='$RUST_SIZE')" >&2
+  exit 1
+fi
+echo "size: lean CLI out=$LEAN_SIZE  rust CLI out=$RUST_SIZE"
+
+# Run CMD as a fresh process; echo "<wall_ms> <user_ms> <sys_ms>" via bash time.
+TIMING="$TMPDIR_TAR/timing.txt"
+timed() {
+  # `time` report → group stderr → $TIMING; the command's own stdout/stderr are
+  # discarded inside the group so only the three timing floats land in $TIMING.
+  TIMEFORMAT='%R %U %S'
+  { time "$@" >/dev/null 2>/dev/null; } 2>"$TIMING"
+  local r u s
+  read -r r u s < "$TIMING"
+  awk -v r="$r" -v u="$u" -v s="$s" 'BEGIN{printf "%.3f %.3f %.3f", r*1000, u*1000, s*1000}'
+}
+
+echo "cold reps (lean_wall_ms / rust_wall_ms):"
+printf "  %-4s %-12s %-12s %-8s %-6s\n" "rep" "lean(ms)" "rust(ms)" "ratio" "first"
+
+LEAN_WALL=(); LEAN_USER=(); LEAN_SYS=()
+RUST_WALL=(); RUST_USER=(); RUST_SYS=()
+E2E_RATIOS=()
+for ((i=1; i<=N; i++)); do
+  if (( i % 2 == 1 )); then
+    read -r lw lu ls <<<"$(timed "$LEAN_CLI" "$TAR" 6)"
+    read -r rw ru rs <<<"$(timed "$RUST_CLI" "$TAR" 6)"
+    first="lean"
+  else
+    read -r rw ru rs <<<"$(timed "$RUST_CLI" "$TAR" 6)"
+    read -r lw lu ls <<<"$(timed "$LEAN_CLI" "$TAR" 6)"
+    first="rust"
+  fi
+  r="$(awk -v l="$lw" -v x="$rw" 'BEGIN{printf "%.4f", l/x}')"
+  LEAN_WALL+=("$lw"); LEAN_USER+=("$lu"); LEAN_SYS+=("$ls")
+  RUST_WALL+=("$rw"); RUST_USER+=("$ru"); RUST_SYS+=("$rs")
+  E2E_RATIOS+=("$r")
+  printf "  %-4s %-12s %-12s %-8s %-6s\n" "$i" "$lw" "$rw" "$r" "$first"
+done
+echo
+
+read -r LEAN_WALL_BEST LEAN_WALL_MED <<<"$(best_median "${LEAN_WALL[@]}")"
+read -r RUST_WALL_BEST RUST_WALL_MED <<<"$(best_median "${RUST_WALL[@]}")"
+LEAN_USER_MED="$(median "${LEAN_USER[@]}")"
+LEAN_SYS_MED="$(median "${LEAN_SYS[@]}")"
+RUST_USER_MED="$(median "${RUST_USER[@]}")"
+RUST_SYS_MED="$(median "${RUST_SYS[@]}")"
+
+E2E_RATIO_MED="$(printf '%s\n' "${E2E_RATIOS[@]}" | sort -n | awk '
+  { v[NR]=$1 }
+  END {
+    n=NR
+    if (n % 2 == 1) print v[(n+1)/2]
+    else            printf "%.4f", (v[n/2] + v[n/2+1]) / 2.0
+  }')"
+
+echo "e2e lean : size=$LEAN_SIZE  wall_best=$LEAN_WALL_BEST  wall_med=$LEAN_WALL_MED  user_med=$LEAN_USER_MED  sys_med=$LEAN_SYS_MED"
+echo "e2e rust : size=$RUST_SIZE  wall_best=$RUST_WALL_BEST  wall_med=$RUST_WALL_MED  user_med=$RUST_USER_MED  sys_med=$RUST_SYS_MED"
+echo "e2e wall_ratio_median=$E2E_RATIO_MED  (lean/rust; >1.0 = rust wall-ahead)"
 echo
 
 # --- write JSON (meta style mirrors bench/results/latest.json) ---
 DATE_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 MACHINE="$(uname -mns)"
 GIT_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
-NOTE="cold single-shot best-of-${N} L6 whole silesia.tar (${TAR_BYTES} B); native vs miniz_oxide; ms are wall-clock of fresh subprocesses; time_ratio_median is median per-rep native_ms/miniz_ms (<1.0 = native cold-faster)"
+CODEC_NOTE="CODEC comparison, measured THROUGH the lean bench harness so both sides pay the same readBinFile + 202 MB ByteArray-alloc I/O and it CANCELS: native (bench csize) vs miniz_oxide (bench compress-miniz) on the whole silesia.tar (${TAR_BYTES} B), cold best-of-${N}. ms are wall-clock of fresh bench subprocesses; time_ratio_median is median per-rep native_ms/miniz_ms (<1.0 = native codec-CPU faster). This guards a ratio-tuning codec regression; it is NOT the end-to-end zip wall (see end_to_end)."
+E2E_NOTE="END-TO-END comparison of two REAL CLI tools as fresh processes: lean compress-file (readBinFile -> deflateRaw -> print size) vs rust miniz-compress-file (std::fs::read -> compress_to_vec -> print len), cold best-of-${N}, alternating order. This IS the zip silesia.tar wall Kim benchmarks with hyperfine; each side pays its OWN file-read/alloc path (which the codec section cancels). wall_ratio_median is median per-rep lean_wall/rust_wall (>1.0 = rust wall-ahead). Rust is currently marginally wall-ahead: lean's compression CPU is faster (lower user_ms) but its file-read/alloc system time (sys_ms) is higher, so the gap is entirely the lean CLI I/O path. wall/user/sys captured via the bash time builtin."
 
 mkdir -p "$(dirname "$OUT")"
 cat > "$OUT" <<EOF
@@ -189,20 +322,42 @@ cat > "$OUT" <<EOF
   "date": "$DATE_UTC",
   "machine": "$MACHINE",
   "git_commit": "$GIT_COMMIT",
-  "note": "$NOTE"
+  "tar_bytes": $TAR_BYTES,
+  "reps": $N
  },
- "native": {
-  "size": $NATIVE_SIZE,
-  "ms_best": $NAT_BEST,
-  "ms_median": $NAT_MED
+ "codec": {
+  "note": "$CODEC_NOTE",
+  "native": {
+   "size": $NATIVE_SIZE,
+   "ms_best": $NAT_BEST,
+   "ms_median": $NAT_MED
+  },
+  "miniz": {
+   "size": $MINIZ_SIZE,
+   "ms_best": $MIZ_BEST,
+   "ms_median": $MIZ_MED
+  },
+  "size_margin_pct": $SIZE_MARGIN,
+  "time_ratio_median": $RATIO_MED
  },
- "miniz": {
-  "size": $MINIZ_SIZE,
-  "ms_best": $MIZ_BEST,
-  "ms_median": $MIZ_MED
- },
- "size_margin_pct": $SIZE_MARGIN,
- "time_ratio_median": $RATIO_MED
+ "end_to_end": {
+  "note": "$E2E_NOTE",
+  "lean": {
+   "size": $LEAN_SIZE,
+   "wall_ms_best": $LEAN_WALL_BEST,
+   "wall_ms_median": $LEAN_WALL_MED,
+   "user_ms": $LEAN_USER_MED,
+   "sys_ms": $LEAN_SYS_MED
+  },
+  "rust": {
+   "size": $RUST_SIZE,
+   "wall_ms_best": $RUST_WALL_BEST,
+   "wall_ms_median": $RUST_WALL_MED,
+   "user_ms": $RUST_USER_MED,
+   "sys_ms": $RUST_SYS_MED
+  },
+  "wall_ratio_median": $E2E_RATIO_MED
+ }
 }
 EOF
 


### PR DESCRIPTION
This PR makes the whole-tar L6 dashboard tracking honest. The `whole_tar_l6.json` added in #2864 compared native vs miniz_oxide L6 through the same lean `bench` harness — so both sides paid identical `readBinFile` + 202 MB ByteArray-alloc I/O, which cancels. Its `time_ratio_median` was therefore a CODEC-CPU comparison (native genuinely faster), not the end-to-end `zip silesia.tar` wall it implied.

Two changes. First, the codec numbers are relabelled honestly: they nest under a `codec` key, and the script, JSON note, and perf-graphs skill state plainly that this is the codec comparison (I/O cancels) — a ratio-tuning regression guard, not the CLI wall. Second, a real apples-to-apples end-to-end comparison is added: a committed lean CLI (`compress-file`: `readBinFile` + `deflateRaw` L6) and a committed real rust CLI (`miniz-compress-file`: `std::fs::read` + `miniz_oxide::compress_to_vec` L6, a new `[[bin]]` on the vendored shim crate, verified byte-identical output to the shim), timed head-to-head as fresh cold processes with the wall/user/sys split recorded under a new `end_to_end` key. run.sh refreshes both.

The honest split, measured (chungus2, 9 cold reps pinned): native output 67,943,851 B is 0.25% smaller than miniz's 68,112,144, and lean's compression **user CPU is faster** (5577 vs 5682 ms) — but end-to-end **wall is rust ~0.45% ahead** (5782 vs 5812 ms median) entirely on **system time** (lean 212 vs rust 83 ms), i.e. the lean CLI's file-read/alloc path, not the codec. So: codec = lean wins, whole-tar wall = rust marginally wins on I/O. Closing that I/O gap is the follow-up.

No library code changes (`deflateRaw` untouched); build + tests green.

🤖 Prepared with Claude Code