### PR TITLE
bench: track peak RSS in the whole-tar reporting (#2837)

### DIFF
--- a/.claude/skills/perf-pr-graphs/SKILL.md
+++ b/.claude/skills/perf-pr-graphs/SKILL.md
@@ -122,6 +122,19 @@ PR that improves the codec while `wall_ratio_median` stays > 1.0 has NOT closed
 the end-to-end gap — say so plainly; closing it means shrinking the lean CLI I/O
 path, not the codec.
 
+Also read **peak RSS** here: `end_to_end.lean.maxrss_kb` /
+`end_to_end.rust.maxrss_kb` and `end_to_end.rss_ratio` (lean/rust), captured with
+GNU `time -v` (Maximum resident set size, deterministic — one run per side). This
+is the whole-tar **memory footprint**, a distinct axis from wall/ratio: lean's
+DEFLATE holds its entire token stream in memory while rust's miniz keeps only a
+bounded window, so `rss_ratio` is the cost of the token pipeline. A **compress**
+PR — especially any token-representation / parse-buffering change — must be read
+on this axis too, not just speed and ratio: check `lean.maxrss_kb` and
+`rss_ratio` before vs after. A codec change that trims memory (the token-unboxing
+refactor cut `lean.maxrss_kb` ~33% while leaving output byte-identical and the
+wall flat) is a real win even when speed and ratio do not move; conversely a
+speed win that inflates `rss_ratio` is a trade to call out, not a free lunch.
+
 Both are recorded measurements, not pass/fail gates. `bench/run.sh` refreshes
 this file in-PR (both the full and `--native-only` paths, guarded on the silesia
 corpus) exactly like `latest.json` — building the lean `compress-file` exe and

--- a/bench/results/whole_tar_l6.json
+++ b/bench/results/whole_tar_l6.json
@@ -1,42 +1,46 @@
 {
  "meta": {
-  "date": "2026-07-22T13:33:08Z",
+  "date": "2026-07-22T20:15:26Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "502832f7",
+  "git_commit": "67fc3081",
   "tar_bytes": 211957760,
-  "reps": 9
+  "reps": 9,
+  "note": "Whole-tar L6 comparison: codec-CPU (native vs miniz through the bench harness) plus end-to-end wall of the real lean/rust CLIs. Peak RSS (end_to_end.{lean,rust}.maxrss_kb + rss_ratio) is now tracked too — the whole-tar memory footprint, so a compress PR can be reviewed on memory as well as speed/ratio."
  },
  "codec": {
   "note": "CODEC comparison, measured THROUGH the lean bench harness so both sides pay the same readBinFile + 202 MB ByteArray-alloc I/O and it CANCELS: native (bench csize) vs miniz_oxide (bench compress-miniz) on the whole silesia.tar (211957760 B), cold best-of-9. ms are wall-clock of fresh bench subprocesses; time_ratio_median is median per-rep native_ms/miniz_ms (<1.0 = native codec-CPU faster). This guards a ratio-tuning codec regression; it is NOT the end-to-end zip wall (see end_to_end).",
   "native": {
    "size": 67943851,
-   "ms_best": 5714.395,
-   "ms_median": 5763.210
+   "ms_best": 5741.887,
+   "ms_median": 5840.687
   },
   "miniz": {
    "size": 68112144,
-   "ms_best": 5850.334,
-   "ms_median": 5876.288
+   "ms_best": 5851.261,
+   "ms_median": 5955.201
   },
   "size_margin_pct": 0.2471,
-  "time_ratio_median": 0.9768
+  "time_ratio_median": 0.9847
  },
  "end_to_end": {
-  "note": "END-TO-END comparison of two REAL CLI tools as fresh processes: lean compress-file (readBinFile -> deflateRaw -> print size) vs rust miniz-compress-file (std::fs::read -> compress_to_vec -> print len), cold best-of-9, alternating order. This IS the zip silesia.tar wall Kim benchmarks with hyperfine; each side pays its OWN file-read/alloc path (which the codec section cancels). wall_ratio_median is median per-rep lean_wall/rust_wall (>1.0 = rust wall-ahead). Rust is currently marginally wall-ahead: lean's compression CPU is faster (lower user_ms) but its file-read/alloc system time (sys_ms) is higher, so the gap is entirely the lean CLI I/O path. wall/user/sys captured via the bash time builtin.",
+  "note": "END-TO-END comparison of two REAL CLI tools as fresh processes: lean compress-file (readBinFile -> deflateRaw -> print size) vs rust miniz-compress-file (std::fs::read -> compress_to_vec -> print len), cold best-of-9, alternating order. This IS the zip silesia.tar wall Kim benchmarks with hyperfine; each side pays its OWN file-read/alloc path (which the codec section cancels). wall_ratio_median is median per-rep lean_wall/rust_wall (>1.0 = rust wall-ahead). Rust is currently marginally wall-ahead: lean's compression CPU is faster (lower user_ms) but its file-read/alloc system time (sys_ms) is higher, so the gap is entirely the lean CLI I/O path. wall/user/sys captured via the bash time builtin. PEAK RSS (maxrss_kb) is the whole-tar memory footprint of each CLI, captured with GNU time -v (Maximum resident set size); it is deterministic so one measured run per side suffices. rss_ratio is lean_maxrss_kb/rust_maxrss_kb: lean holds its whole DEFLATE token stream in memory while rust's miniz keeps only a bounded window, so this ratio is the memory cost of the token pipeline (the target of the token-unboxing work).",
   "lean": {
    "size": 67943851,
-   "wall_ms_best": 5766.000,
-   "wall_ms_median": 5812.000,
-   "user_ms": 5577.000,
-   "sys_ms": 212.000
+   "wall_ms_best": 5817.000,
+   "wall_ms_median": 5834.000,
+   "user_ms": 5593.000,
+   "sys_ms": 208.000,
+   "maxrss_kb": 664048
   },
   "rust": {
    "size": 68112144,
-   "wall_ms_best": 5768.000,
-   "wall_ms_median": 5782.000,
-   "user_ms": 5682.000,
-   "sys_ms": 83.000
+   "wall_ms_best": 5770.000,
+   "wall_ms_median": 5796.000,
+   "user_ms": 5676.000,
+   "sys_ms": 83.000,
+   "maxrss_kb": 276116
   },
-  "wall_ratio_median": 1.0045
+  "wall_ratio_median": 1.0097,
+  "rss_ratio": 2.4050
  }
 }

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -36,7 +36,9 @@ in_project_shell() {
 #   end_to_end: the real lean `compress-file` CLI vs the real rust
 #               `miniz-compress-file` CLI as fresh processes, the honest
 #               `zip silesia.tar` wall (currently rust marginally ahead on the
-#               lean CLI's file-read/alloc path).
+#               lean CLI's file-read/alloc path), plus each CLI's peak RSS
+#               (maxrss_kb + rss_ratio, via GNU time -v) — the whole-tar
+#               memory footprint.
 # The per-file dashboard ($OUT) tracks WARM per-file throughput and misses the
 # `zip silesia.tar` cold-stream workload, where a deeper L6 probe / rolling can
 # regress invisibly (three PRs did). This is a MEASUREMENT that records — not a
@@ -77,7 +79,7 @@ if [ "${1:-}" = "--native-only" ]; then
   refresh_whole_tar
   echo "Native-only dashboard refresh done:"
   echo "  data   → $OUT (native rows refreshed; reference rows reused)"
-  echo "  data   → $WTAR (whole-tar L6: codec native-vs-miniz + end-to-end lean-CLI-vs-rust-CLI, cold)"
+  echo "  data   → $WTAR (whole-tar L6: codec native-vs-miniz + end-to-end lean-CLI-vs-rust-CLI wall + peak RSS, cold)"
   echo "  graphs → bench/graphs/*.svg"
   exit 0
 fi

--- a/bench/whole_tar_l6.sh
+++ b/bench/whole_tar_l6.sh
@@ -121,6 +121,17 @@ if [ -z "$RUST_CLI" ]; then
   exit 2
 fi
 
+# Locate a GNU-time binary for PEAK-RSS capture: `time -v` reports "Maximum
+# resident set size (kbytes)". Prefer /usr/bin/time; else the first `time` on
+# PATH that is a real binary supporting -v (the nix project shell provides GNU
+# time there, NOT the shell builtin). Empty ⇒ fall back to /proc VmHWM polling.
+TIME_BIN=""
+for cand in /usr/bin/time "$(command -v time 2>/dev/null || true)"; do
+  if [ -n "$cand" ] && [ -x "$cand" ] && "$cand" -v true >/dev/null 2>&1; then
+    TIME_BIN="$cand"; break
+  fi
+done
+
 # Assemble a DETERMINISTIC silesia.tar in a temp dir (cleaned on exit). Same
 # command the removed l6_tar_gate used — reuse it exactly for reproducibility.
 TMPDIR_TAR="$(mktemp -d)"
@@ -264,6 +275,27 @@ timed() {
   awk -v r="$r" -v u="$u" -v s="$s" 'BEGIN{printf "%.3f %.3f %.3f", r*1000, u*1000, s*1000}'
 }
 
+# Peak RSS (kB) of a fresh run of CMD. Peak RSS is deterministic run-to-run
+# (allocation shape, not timing), so one measured run per side suffices. Primary
+# path: GNU `time -v` → "Maximum resident set size (kbytes)". Fallback: poll
+# VmHWM (a monotone high-water mark) from /proc/<pid>/status while it runs.
+maxrss_kb() {
+  if [ -n "$TIME_BIN" ]; then
+    local rpt="$TMPDIR_TAR/rss.txt"
+    "$TIME_BIN" -v "$@" >/dev/null 2>"$rpt" || true
+    awk -F': ' '/Maximum resident set size/ { gsub(/[^0-9]/,"",$2); print $2; exit }' "$rpt"
+  else
+    "$@" >/dev/null 2>/dev/null &
+    local pid=$! hwm=0 cur
+    while kill -0 "$pid" 2>/dev/null; do
+      cur="$(awk '/VmHWM/{print $2; exit}' "/proc/$pid/status" 2>/dev/null || echo 0)"
+      if [ -n "$cur" ] && [ "$cur" -gt "$hwm" ] 2>/dev/null; then hwm="$cur"; fi
+    done
+    wait "$pid" 2>/dev/null || true
+    echo "$hwm"
+  fi
+}
+
 echo "cold reps (lean_wall_ms / rust_wall_ms):"
 printf "  %-4s %-12s %-12s %-8s %-6s\n" "rep" "lean(ms)" "rust(ms)" "ratio" "first"
 
@@ -308,12 +340,29 @@ echo "e2e rust : size=$RUST_SIZE  wall_best=$RUST_WALL_BEST  wall_med=$RUST_WALL
 echo "e2e wall_ratio_median=$E2E_RATIO_MED  (lean/rust; >1.0 = rust wall-ahead)"
 echo
 
+# --- peak RSS: the whole-tar memory footprint of each real CLI ---------------
+# Lean's DEFLATE holds its whole token stream in memory (the footprint the
+# unboxing work targets); rust's miniz keeps only a bounded window. Peak RSS is
+# deterministic, so one measured run per side (GNU time -v) is enough.
+echo "--- end-to-end: peak resident set size (fresh process, GNU time -v) ---"
+if [ -n "$TIME_BIN" ]; then echo "rss via: $TIME_BIN -v"; else echo "rss via: /proc VmHWM polling (no GNU time found)"; fi
+LEAN_MAXRSS="$(maxrss_kb "$LEAN_CLI" "$TAR" 6)"
+RUST_MAXRSS="$(maxrss_kb "$RUST_CLI" "$TAR" 6)"
+if ! [[ "$LEAN_MAXRSS" =~ ^[0-9]+$ ]] || ! [[ "$RUST_MAXRSS" =~ ^[0-9]+$ ]] || [ "$RUST_MAXRSS" -eq 0 ]; then
+  echo "ERROR: could not capture peak RSS (lean='$LEAN_MAXRSS' rust='$RUST_MAXRSS')" >&2
+  exit 1
+fi
+RSS_RATIO="$(awk -v l="$LEAN_MAXRSS" -v r="$RUST_MAXRSS" 'BEGIN{printf "%.4f", l/r}')"
+echo "e2e peak RSS: lean_maxrss_kb=$LEAN_MAXRSS  rust_maxrss_kb=$RUST_MAXRSS  rss_ratio=$RSS_RATIO  (lean/rust)"
+echo
+
 # --- write JSON (meta style mirrors bench/results/latest.json) ---
 DATE_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 MACHINE="$(uname -mns)"
 GIT_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 CODEC_NOTE="CODEC comparison, measured THROUGH the lean bench harness so both sides pay the same readBinFile + 202 MB ByteArray-alloc I/O and it CANCELS: native (bench csize) vs miniz_oxide (bench compress-miniz) on the whole silesia.tar (${TAR_BYTES} B), cold best-of-${N}. ms are wall-clock of fresh bench subprocesses; time_ratio_median is median per-rep native_ms/miniz_ms (<1.0 = native codec-CPU faster). This guards a ratio-tuning codec regression; it is NOT the end-to-end zip wall (see end_to_end)."
-E2E_NOTE="END-TO-END comparison of two REAL CLI tools as fresh processes: lean compress-file (readBinFile -> deflateRaw -> print size) vs rust miniz-compress-file (std::fs::read -> compress_to_vec -> print len), cold best-of-${N}, alternating order. This IS the zip silesia.tar wall Kim benchmarks with hyperfine; each side pays its OWN file-read/alloc path (which the codec section cancels). wall_ratio_median is median per-rep lean_wall/rust_wall (>1.0 = rust wall-ahead). Rust is currently marginally wall-ahead: lean's compression CPU is faster (lower user_ms) but its file-read/alloc system time (sys_ms) is higher, so the gap is entirely the lean CLI I/O path. wall/user/sys captured via the bash time builtin."
+E2E_NOTE="END-TO-END comparison of two REAL CLI tools as fresh processes: lean compress-file (readBinFile -> deflateRaw -> print size) vs rust miniz-compress-file (std::fs::read -> compress_to_vec -> print len), cold best-of-${N}, alternating order. This IS the zip silesia.tar wall Kim benchmarks with hyperfine; each side pays its OWN file-read/alloc path (which the codec section cancels). wall_ratio_median is median per-rep lean_wall/rust_wall (>1.0 = rust wall-ahead). Rust is currently marginally wall-ahead: lean's compression CPU is faster (lower user_ms) but its file-read/alloc system time (sys_ms) is higher, so the gap is entirely the lean CLI I/O path. wall/user/sys captured via the bash time builtin. PEAK RSS (maxrss_kb) is the whole-tar memory footprint of each CLI, captured with GNU time -v (Maximum resident set size); it is deterministic so one measured run per side suffices. rss_ratio is lean_maxrss_kb/rust_maxrss_kb: lean holds its whole DEFLATE token stream in memory while rust's miniz keeps only a bounded window, so this ratio is the memory cost of the token pipeline (the target of the token-unboxing work)."
+META_NOTE="Whole-tar L6 comparison: codec-CPU (native vs miniz through the bench harness) plus end-to-end wall of the real lean/rust CLIs. Peak RSS (end_to_end.{lean,rust}.maxrss_kb + rss_ratio) is now tracked too — the whole-tar memory footprint, so a compress PR can be reviewed on memory as well as speed/ratio."
 
 mkdir -p "$(dirname "$OUT")"
 cat > "$OUT" <<EOF
@@ -323,7 +372,8 @@ cat > "$OUT" <<EOF
   "machine": "$MACHINE",
   "git_commit": "$GIT_COMMIT",
   "tar_bytes": $TAR_BYTES,
-  "reps": $N
+  "reps": $N,
+  "note": "$META_NOTE"
  },
  "codec": {
   "note": "$CODEC_NOTE",
@@ -347,16 +397,19 @@ cat > "$OUT" <<EOF
    "wall_ms_best": $LEAN_WALL_BEST,
    "wall_ms_median": $LEAN_WALL_MED,
    "user_ms": $LEAN_USER_MED,
-   "sys_ms": $LEAN_SYS_MED
+   "sys_ms": $LEAN_SYS_MED,
+   "maxrss_kb": $LEAN_MAXRSS
   },
   "rust": {
    "size": $RUST_SIZE,
    "wall_ms_best": $RUST_WALL_BEST,
    "wall_ms_median": $RUST_WALL_MED,
    "user_ms": $RUST_USER_MED,
-   "sys_ms": $RUST_SYS_MED
+   "sys_ms": $RUST_SYS_MED,
+   "maxrss_kb": $RUST_MAXRSS
   },
-  "wall_ratio_median": $E2E_RATIO_MED
+  "wall_ratio_median": $E2E_RATIO_MED,
+  "rss_ratio": $RSS_RATIO
  }
 }
 EOF


### PR DESCRIPTION
Salvage the peak-RSS tracking from the reverted #2866 — it is bench-only and correct independent of that refactor. `whole_tar_l6.json`'s `end_to_end` section now records each CLI's peak RSS (`lean.maxrss_kb`, `rust.maxrss_kb`, `rss_ratio`) via GNU `time -v` with a `/proc` VmHWM fallback; `run.sh` refreshes it; the perf-graphs skill directs reviewers of a compress PR to check the footprint.

The JSON is regenerated on the true (post-revert) baseline: lean 664 MB vs rust 276 MB, `rss_ratio 2.40`. That is the ~2.4× memory gap the token-stream unboxing (retry tracked in #2868, with the mandatory sandwich-measurement protocol) aims to close — now visible in regular reporting so any future attempt is measured honestly against it.

🤖 Prepared with Claude Code