### PR TITLE
proof: polish DEFLATE validity API

### DIFF
--- a/.claude/skills/lean-roundtrip-proofs/SKILL.md
+++ b/.claude/skills/lean-roundtrip-proofs/SKILL.md
@@ -156,9 +156,9 @@ The top-level roundtrip composes per-level proofs: unfold the encoder, `split` o
 level/strategy, `exact` to each per-level theorem (passing size bounds via `by omega`).
 
 ```lean
-theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
+theorem inflateReference_deflateRaw (data : ByteArray) (level : UInt8)
     (hsize : data.size < maxSize) :
-    inflate (deflateRaw data level) = .ok data := by
+    inflateReference (deflateRaw data level) = .ok data := by
   unfold deflateRaw
   split
   · exact inflate_deflateStoredPure data (by omega)
@@ -168,6 +168,9 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
       · exact inflate_deflateLazy data hsize
       · exact inflate_deflateDynamic data (by omega)
 ```
+
+Transfer this reference-decoder theorem to the production decoder with
+`Inflate.inflate_ok_iff_reference`.
 
 ### Per-Level Roundtrip Structure
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -121,7 +121,7 @@ for the core DEFLATE roundtrip.
 - `inflate_deflateLazy` — Levels 2–4 (lazy LZ77)
 - `inflate_deflateDynamic` — Level 5+ (dynamic Huffman)
 
-**Capstone theorem** (DeflateRoundtrip.lean):
+**Capstone theorem** (DeflateRoundtripProduction.lean):
 ```lean
 theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     (hsize : data.size < 1024 * 1024 * 1024) :

--- a/Zip.lean
+++ b/Zip.lean
@@ -62,6 +62,7 @@ import Zip.Spec.DeflateDynamicHeader
 import Zip.Spec.DeflateDynamicFreqs
 import Zip.Spec.DeflateDynamicCorrect
 import Zip.Spec.DeflateRoundtrip
+import Zip.Spec.InflateProductionCorrect
 import Zip.Spec.DeflateRoundtripProduction
 import Zip.Spec.LZ77PackedCorrect
 import Zip.Spec.BitReaderInvariant

--- a/Zip/Spec/Deflate.lean
+++ b/Zip/Spec/Deflate.lean
@@ -458,12 +458,28 @@ termination_by bits.length
 def DecodesTo (compressed output : ByteArray) : Prop :=
   decode (bytesToBits compressed) = some output.data.toList
 
+/-- Unfolding characterization of `DecodesTo`. -/
+theorem decodesTo_iff (compressed output : ByteArray) :
+    DecodesTo compressed output ↔
+      decode (bytesToBits compressed) = some output.data.toList :=
+  Iff.rfl
+
 /-- `compressed` is exactly one valid raw-DEFLATE stream for `output`, apart
-    from the fewer-than-eight unused padding bits allowed in its final byte. -/
+    from the fewer-than-eight unused padding bits allowed in its final byte.
+    The padding bits need not be zero. The `DeflateSuffix` module proves that
+    exact validity implies ordinary decoder acceptance. -/
 def IsValidStreamFor (compressed output : ByteArray) : Prop :=
   ∃ remaining,
     decode.goR (bytesToBits compressed) [] = some (output.data.toList, remaining) ∧
     remaining.length < 8
+
+/-- Unfolding characterization of `IsValidStreamFor`. -/
+theorem isValidStreamFor_iff (compressed output : ByteArray) :
+    IsValidStreamFor compressed output ↔
+      ∃ remaining,
+        decode.goR (bytesToBits compressed) [] = some (output.data.toList, remaining) ∧
+        remaining.length < 8 :=
+  Iff.rfl
 
 /-- `compressed` is exactly one valid raw-DEFLATE stream for some output. -/
 def IsValidStream (compressed : ByteArray) : Prop :=

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -602,13 +602,13 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
 
 /-- The encoder always produces exactly one valid raw-DEFLATE stream for its
     input, as judged by the independent formal bitstream specification. -/
-theorem deflateRaw_isValidStreamFor (data : ByteArray) (level : UInt8) :
+theorem isValidStreamFor_deflateRaw (data : ByteArray) (level : UInt8) :
     Deflate.Spec.IsValidStreamFor (deflateRaw data level) data :=
   deflateRaw_goR_pad data level
 
 /-- The encoder always produces a valid raw-DEFLATE stream. -/
-theorem deflateRaw_isValidStream (data : ByteArray) (level : UInt8) :
+theorem isValidStream_deflateRaw (data : ByteArray) (level : UInt8) :
     Deflate.Spec.IsValidStream (deflateRaw data level) :=
-  ⟨data, deflateRaw_isValidStreamFor data level⟩
+  ⟨data, isValidStreamFor_deflateRaw data level⟩
 
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateRoundtripProduction.lean
+++ b/Zip/Spec/DeflateRoundtripProduction.lean
@@ -1,6 +1,5 @@
 import Zip.Spec.DeflateRoundtrip
-import Zip.Spec.DeflateSuffix
-import Zip.Spec.InflateLoopBounds
+import Zip.Spec.InflateProductionCorrect
 import Zip.Spec.InflateTreeFreeCorrect
 
 /-!
@@ -33,46 +32,3 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     (inflateReference_deflateRaw data level maxOutputSize hsize)
 
 end Zip.Native.Deflate
-
-namespace Zip.Native.Inflate
-
-/-- The production inflater succeeds with `output` exactly when the independent
-    formal DEFLATE specification decodes the input to `output`, provided that
-    `output` fits under the inflater's zip-bomb limit.
-
-    `Deflate.Spec.DecodesTo` deliberately permits trailing data after the final
-    DEFLATE block, matching `inflate`. For a predicate asserting that the input
-    contains exactly one stream up to final-byte padding, use
-    `Deflate.Spec.IsValidStreamFor`. -/
-theorem inflate_ok_iff_decodesTo (compressed : ByteArray) (maxOutputSize : Nat)
-    (output : ByteArray) (hsize : output.size ≤ maxOutputSize) :
-    inflate compressed maxOutputSize = .ok output ↔
-      Deflate.Spec.DecodesTo compressed output := by
-  constructor
-  · intro hinflate
-    have href : inflateReference compressed maxOutputSize = .ok output :=
-      (inflate_ok_iff_reference compressed maxOutputSize output).mp hinflate
-    exact Deflate.Correctness.inflate_correct' compressed maxOutputSize output href
-  · intro hspec
-    have hlen : output.data.toList.length ≤ maxOutputSize := by
-      simpa only [Array.length_toList, ByteArray.size_data] using hsize
-    have hgo : Deflate.Spec.decode.go (Deflate.Spec.bytesToBits compressed) [] =
-        some output.data.toList := by
-      exact hspec
-    obtain ⟨endPos, hraw⟩ :=
-      Zip.Native.inflateRaw_complete compressed 0 maxOutputSize output.data.toList hlen
-        (by simpa only [Nat.zero_mul, List.drop_zero] using hgo)
-    have href : inflateReference compressed maxOutputSize = .ok output := by
-      simp only [inflateReference, hraw, bind, Except.bind, pure, Except.pure,
-        Array.toArray_toList]
-    exact (inflate_ok_iff_reference compressed maxOutputSize output).mpr href
-
-/-- Every exact valid stream is accepted by the production inflater when its
-    specified output fits under the zip-bomb limit. -/
-theorem inflate_of_isValidStreamFor (compressed output : ByteArray)
-    (maxOutputSize : Nat) (hvalid : Deflate.Spec.IsValidStreamFor compressed output)
-    (hsize : output.size ≤ maxOutputSize) :
-    inflate compressed maxOutputSize = .ok output :=
-  (inflate_ok_iff_decodesTo compressed maxOutputSize output hsize).mpr hvalid.decodesTo
-
-end Zip.Native.Inflate

--- a/Zip/Spec/InflateProductionCorrect.lean
+++ b/Zip/Spec/InflateProductionCorrect.lean
@@ -1,0 +1,66 @@
+import Zip.Spec.DeflateSuffix
+import Zip.Spec.InflateCorrect
+import Zip.Spec.InflateLoopBounds
+import Zip.Spec.InflateTreeFreeCorrect
+
+/-!
+# Production inflater correctness against the formal DEFLATE specification
+
+The production tree-free inflater has the same accept set as the verified
+reference inflater. This module packages that result against the public
+`Deflate.Spec.DecodesTo` and `Deflate.Spec.IsValidStreamFor` predicates.
+-/
+
+namespace Zip.Native.Inflate
+
+/-- Successful production inflation implies decoding by the independent formal
+    DEFLATE specification. This direction does not require the caller to recover
+    the inflater's output-size invariant. -/
+theorem decodesTo_of_inflate_eq_ok (compressed : ByteArray) (maxOutputSize : Nat)
+    (output : ByteArray) (hinflate : inflate compressed maxOutputSize = .ok output) :
+    Deflate.Spec.DecodesTo compressed output := by
+  have href : inflateReference compressed maxOutputSize = .ok output :=
+    (inflate_ok_iff_reference compressed maxOutputSize output).mp hinflate
+  exact (Deflate.Spec.decodesTo_iff compressed output).mpr
+    (Deflate.Correctness.inflate_correct' compressed maxOutputSize output href)
+
+/-- The production inflater succeeds with `output` exactly when the independent
+    formal DEFLATE specification decodes the input to `output`, provided that
+    `output` fits under the inflater's zip-bomb limit. The size hypothesis is
+    needed only for the spec-to-inflater direction; use
+    `decodesTo_of_inflate_eq_ok` for the unconditional inflater-to-spec direction.
+
+    `Deflate.Spec.DecodesTo` deliberately permits trailing data after the final
+    DEFLATE block, matching `inflate`. For a predicate asserting that the input
+    contains exactly one stream up to final-byte padding, use
+    `Deflate.Spec.IsValidStreamFor`. -/
+theorem inflate_ok_iff_decodesTo (compressed : ByteArray) (maxOutputSize : Nat)
+    (output : ByteArray) (hsize : output.size ≤ maxOutputSize) :
+    inflate compressed maxOutputSize = .ok output ↔
+      Deflate.Spec.DecodesTo compressed output := by
+  constructor
+  · exact decodesTo_of_inflate_eq_ok compressed maxOutputSize output
+  · intro hspec
+    have hlen : output.data.toList.length ≤ maxOutputSize := by
+      simpa only [Array.length_toList, ByteArray.size_data] using hsize
+    have hdecode := (Deflate.Spec.decodesTo_iff compressed output).mp hspec
+    have hgo : Deflate.Spec.decode.go (Deflate.Spec.bytesToBits compressed) [] =
+        some output.data.toList := by
+      simpa only [Deflate.Spec.decode] using hdecode
+    obtain ⟨endPos, hraw⟩ :=
+      Zip.Native.inflateRaw_complete compressed 0 maxOutputSize output.data.toList hlen
+        (by simpa only [Nat.zero_mul, List.drop_zero] using hgo)
+    have href : inflateReference compressed maxOutputSize = .ok output := by
+      simp only [inflateReference, hraw, bind, Except.bind, pure, Except.pure,
+        Array.toArray_toList]
+    exact (inflate_ok_iff_reference compressed maxOutputSize output).mpr href
+
+/-- Every exact valid stream is accepted by the production inflater when its
+    specified output fits under the zip-bomb limit. -/
+theorem inflate_of_isValidStreamFor (compressed output : ByteArray)
+    (maxOutputSize : Nat) (hvalid : Deflate.Spec.IsValidStreamFor compressed output)
+    (hsize : output.size ≤ maxOutputSize) :
+    inflate compressed maxOutputSize = .ok output :=
+  (inflate_ok_iff_decodesTo compressed maxOutputSize output hsize).mpr hvalid.decodesTo
+
+end Zip.Native.Inflate

--- a/bench/BenchTests/FuzzCompress.lean
+++ b/bench/BenchTests/FuzzCompress.lean
@@ -10,14 +10,13 @@ across the whole level ladder × a diverse input-shape generator?
 ### What this is *not* for
 
 Native encode → native decode being the identity is already a **theorem**:
-`Deflate.inflate_deflateRaw` (`Zip/Spec/DeflateRoundtrip.lean`) proves
+`Deflate.inflate_deflateRaw` (`Zip/Spec/DeflateRoundtripProduction.lean`) proves
 `inflate (deflateRaw data level) = .ok data`, sorry-free, for *every*
 input and *every* level (its proof branches through level-0 stored, the
-L1/respread band, the #2638 L9-fast parse, and the level-10 crown), and it
-transfers to the production `inflate` via the `inflate ↔ inflateReference`
-equivalence. Totality likewise makes "native encode/decode never panics" a
-proof obligation, not a test one. So this driver does **not** exist to
-re-check the self-roundtrip — over the Lean model that is redundant.
+L1/respread band, the #2638 L9-fast parse, and the level-10 crown). Totality
+likewise makes "native encode/decode never panics" a proof obligation, not a
+test one. So this driver does **not** exist to re-check the self-roundtrip —
+over the Lean model that is redundant.
 
 ### What this *is* for
 


### PR DESCRIPTION
## Summary

- expose unconditional production-inflater soundness as `decodesTo_of_inflate_eq_ok`
- move decoder-versus-spec theorems into a discoverable `InflateProductionCorrect` module
- add public unfolding lemmas for the DEFLATE validity predicates
- align validity theorem names and repair stale documentation references

## Why

The initial validity packaging established the encoder theorem and production-decoder iff, but the soundness direction of the iff was unnecessarily hidden behind an output-size hypothesis. This follow-up exposes that direction directly and makes the public API easier to find and use.

## Validation

- `lake -R build Zip` (98 jobs)
- theorem axiom audit with `#print axioms`
- independent second-opinion review completed; naming and definitional-unfolding findings addressed before opening this PR
