### PR TITLE
perf(decode): refill input a word at a time

### DIFF
--- a/Zip.lean
+++ b/Zip.lean
@@ -55,6 +55,7 @@ import Zip.Spec.EmitPackedCorrect
 import Zip.Spec.DeflateFixedCorrect
 import Zip.Spec.InflateBufCorrect
 import Zip.Spec.InflateTreeFreeCorrect
+import Zip.Spec.InflateFastCorrect
 import Zip.Spec.InflateBufRoundtrip
 import Zip.Spec.DeflateStoredCorrect
 import Zip.Spec.DeflateDynamicEmit

--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -307,6 +307,29 @@ theorem and_0x7FF_toUSize_toNat_eq (bitBuf : UInt64) :
   have h2 : (2047 : Nat) < USize.size := Nat.lt_of_lt_of_le (by decide) USize.le_size
   omega
 
+/-- The native-word spelling of the 11-bit fast-table window is in bounds. -/
+theorem toUSize_and_0x7FF_toNat_lt (bitBuf : UInt64) :
+    (bitBuf.toUSize &&& 0x7FF).toNat < 2 ^ fastBits := by
+  rw [USize.toNat_and]
+  apply Nat.and_lt_two_pow
+  rw [USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)]
+  decide
+
+theorem and_0x7FF_toUSize_eq_toUSize_and (bitBuf : UInt64) :
+    (bitBuf &&& 0x7FF).toUSize = bitBuf.toUSize &&& 0x7FF := by
+  apply USize.toNat_inj.mp
+  rw [and_0x7FF_toUSize_toNat_eq, USize.toNat_and,
+    USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)]
+  rw [UInt64.toNat_and]
+  have hm64 : (0x7FF : UInt64).toNat = 2047 := rfl
+  rw [hm64]
+  have hm : (2047 : Nat) = 2 ^ 11 - 1 := by decide
+  rw [hm, Nat.and_two_pow_sub_one_eq_mod]
+  rw [UInt64.toNat_toUSize]
+  change bitBuf.toNat % 2 ^ 11 = (bitBuf.toNat % USize.size) &&& (2 ^ 11 - 1)
+  rw [Nat.and_two_pow_sub_one_eq_mod, USize.size_eq_two_pow, Nat.mod_mod_of_dvd]
+  exact Nat.pow_dvd_pow 2 (Nat.le_trans (by omega) System.Platform.le_numBits)
+
 /-- Reading the `fastBits`-bit window slot by `uget` on the `USize` index equals the
     guarded `entryAt` read on the `Nat` index — the bridge that carries the tree-free
     loop's `uget` optimization back to the boxed reference's `entryAt`/`lenAt`. -/
@@ -314,6 +337,14 @@ theorem and_0x7FF_toUSize_toNat_eq (bitBuf : UInt64) :
     (h : ((bitBuf &&& 0x7FF).toUSize).toNat < t.packed.size) :
     t.entryAtU (bitBuf &&& 0x7FF).toUSize h = t.entryAt (bitBuf &&& 0x7FF).toNat := by
   rw [entryAtU_eq_entryAt, and_0x7FF_toUSize_toNat_eq]
+
+theorem DecodeTable.entryAtU_native_window_eq (t : DecodeTable) (bitBuf : UInt64)
+    (h : (bitBuf.toUSize &&& 0x7FF).toNat < t.packed.size) :
+    t.entryAtU (bitBuf.toUSize &&& 0x7FF) h = t.entryAt (bitBuf &&& 0x7FF).toNat := by
+  rw [entryAtU_eq_entryAt]
+  congr 1
+  exact (congrArg USize.toNat (and_0x7FF_toUSize_eq_toUSize_and bitBuf).symm).trans
+    (and_0x7FF_toUSize_toNat_eq bitBuf)
 
 /-- Build the `2^fastBits`-entry decode table for `tree`: slot `i` holds
     `packEntry sym codeLen` for the `(sym, codeLen)` reached by walking `tree` on
@@ -1019,6 +1050,60 @@ theorem refillGuard_usize (data : ByteArray) (pos cnt : USize) (hsz : data.size 
       ↔ (cnt.toNat ≤ 56 ∧ pos.toNat < data.size) := by
   rw [USize.le_iff_toNat_le, USize.lt_iff_toNat_lt, toUSize_toNat_of_lt hsz,
       USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)]
+
+/-- The input-margin guard in `USize`, written with guarded subtraction so the
+    addition cannot wrap at the top of the address space. -/
+theorem refillGuardWide_usize (data : ByteArray) (pos cnt : USize) (hsz : data.size < USize.size) :
+    (cnt ≤ (56 : USize) ∧ (8 : USize) ≤ data.size.toUSize ∧ pos ≤ data.size.toUSize - 8)
+      ↔ (cnt.toNat ≤ 56 ∧ pos.toNat + 8 ≤ data.size) := by
+  have h56 : (56 : USize).toNat = 56 :=
+    USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+  have h8 : (8 : USize).toNat = 8 :=
+    USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+  have hsize : data.size.toUSize.toNat = data.size := toUSize_toNat_of_lt hsz
+  rw [USize.le_iff_toNat_le, USize.le_iff_toNat_le, USize.le_iff_toNat_le, h56, h8, hsize]
+  constructor
+  · rintro ⟨hc, h8le, hp⟩
+    rw [USize.toNat_sub_of_le _ _ (USize.le_iff_toNat_le.mpr (by rw [h8, hsize]; omega)),
+        h8, hsize] at hp
+    exact ⟨hc, by omega⟩
+  · rintro ⟨hc, hp⟩
+    refine ⟨hc, by omega, ?_⟩
+    rw [USize.toNat_sub_of_le _ _ (USize.le_iff_toNat_le.mpr (by rw [h8, hsize]; omega)),
+        h8, hsize]
+    omega
+
+/-- The wide refill's byte advance, expressed in `USize`, round-trips to the
+    corresponding natural-number division while a top-up is required. -/
+theorem wideRefillK_toNat (cnt : USize) (hcnt : cnt.toNat ≤ 56) :
+    (((64 - cnt) >>> 3 : USize).toNat) = (64 - cnt.toNat) / 8 := by
+  have h64 : (64 : USize).toNat = 64 :=
+    USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+  have h3 : (3 : USize).toNat = 3 :=
+    USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+  rw [USize.toNat_shiftRight, USize.toNat_sub_of_le _ _
+    (USize.le_iff_toNat_le.mpr (by rw [h64]; omega)), h64, h3]
+  simp only [Nat.shiftRight_eq_div_pow]
+  rcases System.Platform.numBits_eq with h | h <;> simp [h]
+
+/-- The exact counted-bit update adds eight bits per advanced byte. -/
+theorem wideRefillCnt_toNat (cnt : USize) (hcnt : cnt.toNat ≤ 56) :
+    (64 - ((64 - cnt) &&& 7) : USize).toNat =
+      cnt.toNat + 8 * ((64 - cnt.toNat) / 8) := by
+  have h64 : (64 : USize).toNat = 64 :=
+    USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+  have h7 : (7 : USize).toNat = 7 :=
+    USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+  have hsub : (64 - cnt : USize).toNat = 64 - cnt.toNat := by
+    rw [USize.toNat_sub_of_le _ _ (USize.le_iff_toNat_le.mpr (by rw [h64]; omega)), h64]
+  have hand : ((64 - cnt) &&& 7 : USize).toNat = (64 - cnt.toNat) % 8 := by
+    rw [USize.toNat_and, hsub, h7, show 7 = 2 ^ 3 - 1 by decide,
+      Nat.and_two_pow_sub_one_eq_mod]
+  rw [USize.toNat_sub_of_le _ _ (USize.le_iff_toNat_le.mpr (by
+    rw [h64, hand]
+    have := Nat.mod_lt (64 - cnt.toNat) (by decide : 0 < 8)
+    omega)), h64, hand]
+  omega
 
 /-- The inline-literal guard reads the packed entry **once** (`entryAt`) and tests
     `len`/`sym` in their native `UInt8`/`UInt16` widths; this matches the boxed

--- a/Zip/Native/InflateFast.lean
+++ b/Zip/Native/InflateFast.lean
@@ -232,7 +232,9 @@ def goCur (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
       rw [hb]; omega
 
 set_option maxRecDepth 4096 in
-/-- Branch-free fastloop variant of `goCur` (the actual #2799 shape). A single
+/-- Branch-free fastloop variant of `goCur` (the actual #2799 shape), retained
+    as the byte-refill reference twin used by the correctness proof for `goCurUW`.
+    A single
     per-symbol margin guard `outPos + 299 ≤ output.size` gates the hot body, in
     which literal writes are proven-bounds `uset` (bound discharged from the
     margin, no per-literal bounds check) and the per-literal max-size check is
@@ -351,6 +353,197 @@ def goCurU (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
       have hb : cnt4.toUSize.toNat = cnt4 := toUSize_toNat_of_lt (by omega)
       rw [hb]; omega
 
+/-- Unboxed state produced by one input-margin refill probe. -/
+structure WideRefillState where
+  pos : USize
+  bitBuf : UInt64
+  cnt : USize
+  didWide : Bool
+
+/-- One libdeflate-style refill when eight bytes remain. The load deliberately
+    remains unmasked: bits above `cnt` are genuine look-ahead bits and overlapping
+    future loads OR the same stream bits back into the same positions. -/
+@[inline] def wideRefillU (data : ByteArray) (pos : USize) (bitBuf : UInt64) (cnt : USize)
+    (hsz : data.size < USize.size) : WideRefillState :=
+  if hrcw : cnt ≤ 56 ∧ (8 : USize) ≤ data.size.toUSize ∧ pos ≤ data.size.toUSize - 8 then
+    let k := (64 - cnt) >>> 3
+    { pos := pos + k
+      bitBuf := bitBuf ||| (data.ugetUInt64LE pos
+        ((refillGuardWide_usize data pos cnt hsz).mp hrcw).2 <<< cnt.toUInt64)
+      cnt := 64 - ((64 - cnt) &&& 7)
+      didWide := true }
+  else
+    { pos := pos, bitBuf := bitBuf, cnt := cnt, didWide := false }
+
+/-- A wide refill does not increase `goCurUW`'s termination measure. It advances
+    `k` bytes and adds exactly `8k` counted bits, changing the measure by `-k`. -/
+theorem wideRefillU_measure_le (data : ByteArray) (pos : USize) (bitBuf : UInt64) (cnt : USize)
+    (hsz : data.size < USize.size) :
+    let r := wideRefillU data pos bitBuf cnt hsz
+    (data.size - r.pos.toNat) * 9 + r.cnt.toNat ≤
+      (data.size - pos.toNat) * 9 + cnt.toNat := by
+  simp only [wideRefillU]
+  split
+  · rename_i hrcw
+    have hg := (refillGuardWide_usize data pos cnt hsz).mp hrcw
+    have hcnt : cnt.toNat ≤ 56 := hg.1
+    have hpos : pos.toNat + 8 ≤ data.size := hg.2
+    have hk := wideRefillK_toNat cnt hcnt
+    have hc := wideRefillCnt_toNat cnt hcnt
+    have hpa : (pos + ((64 - cnt) >>> 3)).toNat = pos.toNat + (64 - cnt.toNat) / 8 := by
+      rw [USize.toNat_add, hk]
+      apply Nat.mod_eq_of_lt
+      rw [← USize.size_eq_two_pow]
+      omega
+    simp only [hpa, hc]
+    omega
+  · simp
+
+/-- Drop speculative look-ahead bits before handing the cold output-margin tail
+    to the byte-at-a-time loop. The hot wide loop deliberately retains them. -/
+@[inline] def trimBitBufU (bitBuf : UInt64) (cnt : USize) : UInt64 :=
+  if cnt == 64 then bitBuf else bitBuf &&& ((1 <<< cnt.toUInt64) - 1)
+
+set_option maxRecDepth 4096 in
+/-- Word-at-a-time input-refill twin of `goCurU`. -/
+def goCurUW (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
+    (maxBits : Nat) (data : ByteArray) (maxOut : Nat)
+    (pos : USize) (bitBuf : UInt64) (cnt : USize)
+    (hsz : data.size < USize.size)
+    (hlp : litTable.packed.size = 2 ^ HuffTree.fastBits)
+    (output : ByteArray) (outPos : USize) :
+    Except String (ByteArray × USize × USize × UInt64 × USize) := do
+  if hmt : outPos.toNat + 299 ≤ output.size then
+  let r := wideRefillU data pos bitBuf cnt hsz
+  have hwm := wideRefillU_measure_le data pos bitBuf cnt hsz
+  let pos := r.pos
+  let bitBuf := r.bitBuf
+  let cnt := r.cnt
+  let didWide := r.didWide
+  if hrc : didWide = false ∧ cnt ≤ 56 ∧ pos < data.size.toUSize then
+    goCurUW litTable distTable litLD distLD maxBits data maxOut
+      (pos + 1)
+      (bitBuf ||| ((data.uget pos (by
+          have h := USize.lt_iff_toNat_lt.mp hrc.2.2
+          rwa [toUSize_toNat_of_lt hsz] at h)).toUInt64 <<< cnt.toUInt64))
+      (cnt + 8) hsz hlp output outPos
+  else
+    let e := litTable.entryAtU (bitBuf.toUSize &&& 0x7FF)
+      (by rw [hlp]; exact HuffTree.toUSize_and_0x7FF_toNat_lt bitBuf)
+    if hlit : HuffTree.unpackLen e ≠ 0
+        ∧ (HuffTree.unpackLen e).toUSize ≤ cnt
+        ∧ HuffTree.unpackSym e < 256 then
+      goCurUW litTable distTable litLD distLD maxBits data maxOut pos
+        (bitBuf >>> (HuffTree.unpackLen e).toUInt64)
+        (cnt - (HuffTree.unpackLen e).toUSize)
+        hsz hlp
+        (output.uset outPos (HuffTree.unpackSym e).toUInt8 (by omega)) (outPos + 1)
+    else
+    let cnt0 := cnt.toNat
+    match decodeSymCanon litLD litTable maxBits bitBuf cnt.toNat with
+    | .error e => .error e
+    | .ok (sym, bitBuf, cnt', _used) =>
+      if sym < 256 then
+        if hnp : cnt0 ≤ cnt' then throw "Inflate: no progress in Huffman decode"
+        else
+          goCurUW litTable distTable litLD distLD maxBits data maxOut pos bitBuf
+            cnt'.toUSize hsz hlp
+            (output.uset outPos sym.toUInt8 (by omega)) (outPos + 1)
+      else if sym == 256 then
+        .ok (output, outPos, pos, trimBitBufU bitBuf cnt'.toUSize, cnt'.toUSize)
+      else
+        let idx := sym.toNat - 257
+        if h : idx ≥ Inflate.lengthBase.size then throw s!"Inflate: invalid length code {sym}"
+        else
+          let base := Inflate.lengthBase[idx]
+          let extra := Inflate.lengthExtra[idx]'(by simp [Inflate.lengthExtra_size, Inflate.lengthBase_size] at h ⊢; omega)
+          let (extraBits, bitBuf, cnt'') ← takeBits bitBuf cnt' extra.toNat
+          let length := base.toNat + extraBits
+          match decodeSymCanon distLD distTable maxBits bitBuf cnt'' with
+          | .error e => .error e
+          | .ok (distSym, bitBuf, cnt3, _dused) =>
+            let dIdx := distSym.toNat
+            if h : dIdx ≥ Inflate.distBase.size then throw s!"Inflate: invalid distance code {distSym}"
+            else
+              let dBase := Inflate.distBase[dIdx]
+              let dExtra := Inflate.distExtra[dIdx]'(by simp [Inflate.distExtra_size, Inflate.distBase_size] at h ⊢; omega)
+              let (dExtraBits, bitBuf, cnt4) ← takeBits bitBuf cnt3 dExtra.toNat
+              let distance := dBase.toNat + dExtraBits
+              if hz : distance = 0 then throw s!"Inflate: zero back-reference distance"
+              else if hds : distance > outPos.toNat then
+                throw s!"Inflate: distance {distance} exceeds output size {outPos.toNat}"
+              else if hlen : length > 258 then throw "Inflate: length exceeds 258"
+              else if hnp : cnt0 ≤ cnt4 then throw "Inflate: no progress in Huffman decode"
+              else
+                let out := if hshort : 8 ≤ distance ∧ length ≤ 8 then
+                  output.copyWithinAtShort outPos distance length hshort.1
+                    (by exact Nat.lt_of_lt_of_le (lengthBase_pos idx (by omega)) (Nat.le_add_right ..)) hshort.2
+                    (by omega) (by omega)
+                else
+                  output.copyWithinAt outPos.toNat distance length
+                goCurUW litTable distTable litLD distLD maxBits data maxOut pos bitBuf
+                  cnt4.toUSize hsz hlp out (outPos + length.toUSize)
+  else
+    goCur litTable distTable litLD distLD maxBits data maxOut pos (trimBitBufU bitBuf cnt) cnt
+      hsz hlp output outPos
+  termination_by (data.size - pos.toNat) * 9 + cnt.toNat
+  decreasing_by
+    all_goals
+      simp_wf
+      subst r
+      subst pos
+      subst cnt
+      try subst bitBuf
+      try subst didWide
+      dsimp only at hwm
+    · obtain ⟨_, hc, hp⟩ := hrc
+      have hbig : (64 : Nat) < 2 ^ System.Platform.numBits :=
+        USize.size_eq_two_pow ▸ Nat.lt_of_lt_of_le (by decide) USize.le_size
+      have hpn : (wideRefillU data pos bitBuf cnt hsz).pos.toNat < data.size := by
+        have h := USize.lt_iff_toNat_lt.mp hp; rwa [toUSize_toNat_of_lt hsz] at h
+      have hcn : (wideRefillU data pos bitBuf cnt hsz).cnt.toNat ≤ 56 := by
+        have h := USize.le_iff_toNat_le.mp hc
+        rwa [USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)] at h
+      have hpa : ((wideRefillU data pos bitBuf cnt hsz).pos.toNat + 1) %
+          2 ^ System.Platform.numBits =
+          (wideRefillU data pos bitBuf cnt hsz).pos.toNat + 1 := by
+        apply Nat.mod_eq_of_lt
+        rw [← USize.size_eq_two_pow]
+        omega
+      have hca : ((wideRefillU data pos bitBuf cnt hsz).cnt.toNat + 8) %
+          2 ^ System.Platform.numBits =
+          (wideRefillU data pos bitBuf cnt hsz).cnt.toNat + 8 := by
+        apply Nat.mod_eq_of_lt
+        rw [← USize.size_eq_two_pow]
+        have hbig' : (64 : Nat) < USize.size := USize.size_eq_two_pow ▸ hbig
+        omega
+      rw [hpa, hca]; omega
+    · obtain ⟨hne, hle, _⟩ := hlit
+      have hne' : (HuffTree.unpackLen e).toNat ≠ 0 := (uint8_ne_zero_iff_toNat _).mp hne
+      have hlen : ((HuffTree.unpackLen e).toUSize).toNat = (HuffTree.unpackLen e).toNat :=
+        UInt8.toNat_toUSize _
+      have hsub : ((wideRefillU data pos bitBuf cnt hsz).cnt -
+          (HuffTree.unpackLen e).toUSize).toNat =
+          (wideRefillU data pos bitBuf cnt hsz).cnt.toNat -
+            (HuffTree.unpackLen e).toNat := by
+        rw [USize.toNat_sub_of_le _ _ hle, hlen]
+      have hlecnt : (HuffTree.unpackLen e).toNat ≤
+          (wideRefillU data pos bitBuf cnt hsz).cnt.toNat :=
+        hlen ▸ USize.le_iff_toNat_le.mp hle
+      rw [hsub]; omega
+    · have hcsz : cnt0 < USize.size := by
+        dsimp only [cnt0]
+        exact USize.toNat_lt_two_pow_numBits _
+      have hb : cnt'.toUSize.toNat = cnt' := toUSize_toNat_of_lt (by omega)
+      rw [Nat.mod_eq_of_lt (by rw [← USize.size_eq_two_pow]; omega)]
+      omega
+    · have hcsz : cnt0 < USize.size := by
+        dsimp only [cnt0]
+        exact USize.toNat_lt_two_pow_numBits _
+      have hb : cnt4.toUSize.toNat = cnt4 := toUSize_toNat_of_lt (by omega)
+      rw [Nat.mod_eq_of_lt (by rw [← USize.size_eq_two_pow]; omega)]
+      omega
+
 /-- Write `bytes[i]` at `output[outPos + i]` for `i ∈ [start, len)` via `set!`,
     by well-founded recursion. A `for i in [:len]` loop would compile to an opaque
     `forIn` that cannot be unfolded in proofs; this WF form lets the stored-block
@@ -400,7 +593,8 @@ def decodeHuffmanCurTables (br : BitReader) (output : ByteArray) (outPos : Nat)
   else
     throw "Inflate: input too large for cursor decode"
 
-/-- `decodeHuffmanCurTables` through the branch-free `uset` fastloop `goCurU`. -/
+/-- `decodeHuffmanCurTables` through the branch-free `uset` fastloop `goCurUW`,
+    with word-at-a-time input refill behind an eight-byte margin. -/
 def decodeHuffmanCurTablesU (br : BitReader) (output : ByteArray) (outPos : Nat)
     (litTable distTable : DecodeTable) (litLD distLD : LongDecode) (maxOut : Nat)
     (hlp : litTable.packed.size = 2 ^ HuffTree.fastBits) :
@@ -411,7 +605,7 @@ def decodeHuffmanCurTablesU (br : BitReader) (output : ByteArray) (outPos : Nat)
   if hsz : br.data.size.toUSize.toNat = br.data.size then
     let hlt : br.data.size < USize.size := by rw [← hsz]; exact USize.toNat_lt_two_pow_numBits _
     let (out, outPos', pos', bitBuf', cnt') ←
-      goCurU litTable distTable litLD distLD 15 br.data maxOut
+      goCurUW litTable distTable litLD distLD 15 br.data maxOut
         pos.toUSize bitBuf cnt.toUSize hlt hlp output outPos.toUSize
     let _ := bitBuf'
     let endbit := pos'.toNat * 8 - cnt'.toNat
@@ -458,7 +652,7 @@ def inflateLoopCur (br : BitReader) (output : ByteArray) (outPos : Nat)
 
 set_option maxRecDepth 100000 in
 set_option maxHeartbeats 2000000 in
-/-- `inflateLoopCur` through the branch-free `uset` fastloop `goCurU`. -/
+/-- `inflateLoopCur` through the branch-free `uset` fastloop `goCurUW`. -/
 def inflateLoopCurU (br : BitReader) (output : ByteArray) (outPos : Nat)
     (maxOut dataSize : Nat) : Except String (ByteArray × Nat × Nat) := do
   let (bfinal, br₁) ← br.readBits 1

--- a/Zip/Spec/InflateFastCorrect.lean
+++ b/Zip/Spec/InflateFastCorrect.lean
@@ -1,5 +1,6 @@
 import Zip.Native.InflateFast
 import Zip.Spec.InflateTreeFreeCorrect
+import Zip.Spec.InflateWideRefillCorrect
 import Zip.Spec.DecodeCorrect
 import Zip.Spec.BitstreamCorrect
 
@@ -92,8 +93,8 @@ everywhere in this library, this is verified against the Lean reference bodies
 of the `@[extern]` primitives (`presize`, `copyWithinAt`), which the C
 implementations are trusted (and conformance-tested) to refine.
 
-This file is standalone — not imported by `Zip` — so `Inflate.inflate` and CI
-stay `sorry`-free regardless.
+This file is imported by `Zip`, so the complete fastloop equivalence and
+soundness chain is checked by the default library build and CI.
 -/
 
 namespace Zip.Native
@@ -2486,6 +2487,53 @@ theorem lengthExtra_lt_64 (idx : Nat) (h : idx < Inflate.lengthExtra.size) :
   have hk := hkey ⟨idx, h⟩
   rwa [getElem!_pos Inflate.lengthExtra idx h] at hk
 
+theorem lengthExtra_le_5 (idx : Nat) (h : idx < Inflate.lengthExtra.size) :
+    (Inflate.lengthExtra[idx]).toNat ≤ 5 := by
+  have hkey : ∀ k : Fin Inflate.lengthExtra.size,
+      Inflate.lengthExtra[k.val]!.toNat ≤ 5 := by decide
+  have hk := hkey ⟨idx, h⟩
+  rwa [getElem!_pos Inflate.lengthExtra idx h] at hk
+
+theorem distExtra_lt_64 (idx : Nat) (h : idx < Inflate.distExtra.size) :
+    (Inflate.distExtra[idx]).toNat < 64 := by
+  have hkey : ∀ k : Fin Inflate.distExtra.size,
+      Inflate.distExtra[k.val]!.toNat < 64 := by decide
+  have hk := hkey ⟨idx, h⟩
+  rwa [getElem!_pos Inflate.distExtra idx h] at hk
+
+theorem decodeSym_used_le (tree : HuffTree) (table : HuffTree.DecodeTable)
+    (hdep : InflateBuf.treeDepthLE tree 15)
+    (hlen : ∀ b : UInt64, (table.lenAt (b &&& 0x7FF).toNat).toNat ≤ 11)
+    {b : UInt64} {n : Nat} {s : UInt16} {bb : UInt64} {c used : Nat}
+    (h : InflateBuf.decodeSym tree table b n = .ok (s, bb, c, used)) : used ≤ 15 := by
+  simp only [InflateBuf.decodeSym] at h
+  split at h
+  · exact InflateBuf.walkTree_used_le tree h hdep
+  · simp only [Except.ok.injEq, Prod.mk.injEq] at h
+    obtain ⟨_, _, _, rfl⟩ := h
+    exact Nat.le_trans (hlen b) (by omega)
+
+theorem treeFree_len_le (lengths : Array UInt8)
+    (hv : Huffman.Spec.ValidLengths (lengths.toList.map UInt8.toNat) 15)
+    (hbound : lengths.size ≤ UInt16.size) (b : UInt64) :
+    ((HuffTree.buildTreeFreeWithCount lengths (HuffTree.countLengthsFast lengths 15) 15).1.lenAt
+      (b &&& 0x7FF).toNat).toNat ≤ 11 := by
+  rw [HuffTree.treeFree_lenAt_eq lengths 15 (by omega) hv hbound _ (InflateBuf.buf_idx_lt b)]
+  exact InflateBuf.buildTable_codeLen_le _ _ (InflateBuf.buf_idx_lt b)
+
+theorem treeFree_decode_used_le (lengths : Array UInt8)
+    (hv : Huffman.Spec.ValidLengths (lengths.toList.map UInt8.toNat) 15)
+    (hbound : lengths.size ≤ UInt16.size)
+    {b : UInt64} {n : Nat} {s : UInt16} {bb : UInt64} {c used : Nat}
+    (h : HuffTree.decodeSymCanon
+      (HuffTree.buildTreeFreeWithCount lengths (HuffTree.countLengthsFast lengths 15) 15).2
+      (HuffTree.buildTreeFreeWithCount lengths (HuffTree.countLengthsFast lengths 15) 15).1
+      15 b n = .ok (s, bb, c, used)) : used ≤ 15 := by
+  apply decodeSym_used_le (HuffTree.fromLengthsTree lengths 15) _
+    (InflateBuf.fromLengths_depthLE (HuffTree.fromLengths_ok_of_valid lengths 15 hv))
+    (treeFree_len_le lengths hv hbound)
+  exact (HuffTree.decodeSymCanon_treeFree_ok_iff lengths hv hbound b n _).mp h
+
 -- Force generation of the `goCurU` functional-induction principle.
 private def goCurU_induct_force := @Zip.Native.InflateBuf.goCurU.induct
 
@@ -2628,15 +2676,681 @@ theorem goCurU_eq (litTable distTable : HuffTree.DecodeTable) (litLD distLD : Hu
     intro hsize
     rw [InflateBuf.goCurU, dif_neg hrc, dif_neg hm]
 
+/-- `goCurU` may be entered either before or after its byte refill: running the
+    whole canonical refill up front does not change the result. -/
+theorem goCurU_absorb_refill (litTable distTable : HuffTree.DecodeTable)
+    (litLD distLD : HuffTree.LongDecode) (maxBits : Nat) (data : ByteArray)
+    (maxOut : Nat) (hsz : data.size < USize.size)
+    (hlp : litTable.packed.size = 2 ^ HuffTree.fastBits)
+    (pos : USize) (bitBuf : UInt64) (cnt : USize) (output : ByteArray) (outPos : USize)
+    (hpos : pos.toNat ≤ data.size) (hcnt : cnt.toNat ≤ 64) :
+    let r := InflateBuf.refill data pos.toNat bitBuf cnt.toNat
+    InflateBuf.goCurU litTable distTable litLD distLD maxBits data maxOut
+        pos bitBuf cnt hsz hlp output outPos =
+      InflateBuf.goCurU litTable distTable litLD distLD maxBits data maxOut
+        r.1.toUSize r.2.1 r.2.2.toUSize hsz hlp output outPos := by
+  rw [InflateBuf.refill]
+  split
+  · rename_i hrc
+    have hpU : pos.toNat.toUSize = pos := by
+      apply USize.toNat_inj.mp
+      rw [InflateBuf.toUSize_toNat_of_lt (Nat.lt_of_le_of_lt hpos hsz)]
+    have hcU : cnt.toNat.toUSize = cnt := by
+      apply USize.toNat_inj.mp
+      rw [InflateBuf.toUSize_toNat_of_lt (Nat.lt_of_le_of_lt hcnt
+        (Nat.lt_of_lt_of_le (by decide) USize.le_size))]
+    have hguard : cnt ≤ 56 ∧ pos < data.size.toUSize := by
+      rw [← hpU, ← hcU,
+        InflateBuf.refillGuard_usize data pos.toNat.toUSize cnt.toNat.toUSize hsz]
+      simpa using hrc
+    rw [InflateBuf.goCurU, dif_pos hguard,
+      InflateBuf.uget_eq_getElem! data pos hrc.2]
+    have hp1 : (pos + 1).toNat = pos.toNat + 1 := by
+      rw [USize.toNat_add]
+      have h1 : (1 : USize).toNat = 1 :=
+        USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+      rw [h1]
+      apply Nat.mod_eq_of_lt
+      rw [← USize.size_eq_two_pow]
+      omega
+    have hc1 : (cnt + 8).toNat = cnt.toNat + 8 := by
+      rw [USize.toNat_add]
+      have h8 : (8 : USize).toNat = 8 :=
+        USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+      rw [h8]
+      apply Nat.mod_eq_of_lt
+      rw [← USize.size_eq_two_pow]
+      have : (64 : Nat) < USize.size := USize.size_eq_two_pow ▸
+        Nat.lt_of_lt_of_le (by decide) USize.le_size
+      omega
+    have hstep := goCurU_absorb_refill litTable distTable litLD distLD maxBits data maxOut hsz hlp
+      (pos + 1) (bitBuf ||| data[pos.toNat]!.toUInt64 <<< cnt.toUInt64) (cnt + 8)
+      output outPos (by rw [hp1]; omega) (by rw [hc1]; omega)
+    rw [InflateBuf.usize_toUInt64_toNat cnt] at hstep
+    rw [← getElem!_pos data pos.toNat hrc.2]
+    rw [InflateBuf.usize_toUInt64_toNat cnt]
+    simpa only [hp1, hc1] using hstep
+  · rename_i hrc
+    have hpU : pos.toNat.toUSize = pos := by
+      apply USize.toNat_inj.mp
+      rw [InflateBuf.toUSize_toNat_of_lt (Nat.lt_of_le_of_lt hpos hsz)]
+    have hcU : cnt.toNat.toUSize = cnt := by
+      apply USize.toNat_inj.mp
+      rw [InflateBuf.toUSize_toNat_of_lt (Nat.lt_of_le_of_lt hcnt
+        (Nat.lt_of_lt_of_le (by decide) USize.le_size))]
+    have hguard : ¬(cnt ≤ 56 ∧ pos < data.size.toUSize) := by
+      intro h
+      apply hrc
+      exact (InflateBuf.refillGuard_usize data pos cnt hsz).mp h
+    rw [InflateBuf.goCurU, dif_neg hguard]
+    simp only
+    rw [hpU, hcU]
+    rw [InflateBuf.goCurU, dif_neg hguard]
+termination_by data.size - pos.toNat
+decreasing_by
+  simp_wf
+  have hlt : pos.toNat < data.size := by omega
+  have hp : pos.toNat + 1 < 2 ^ System.Platform.numBits := by
+    rw [← USize.size_eq_two_pow]
+    exact Nat.lt_of_le_of_lt (Nat.succ_le_of_lt hlt) hsz
+  rw [Nat.mod_eq_of_lt hp]
+  omega
+
+theorem goCurU_absorb_wide (litTable distTable : HuffTree.DecodeTable)
+    (litLD distLD : HuffTree.LongDecode) (data : ByteArray) (maxOut : Nat)
+    (hsz : data.size < USize.size)
+    (hlp : litTable.packed.size = 2 ^ HuffTree.fastBits)
+    {bitpos p0 p1 : Nat} {b0 b1 : UInt64} {c0 c1 a0 a1 : Nat}
+    (h0 : InflateBuf.WideBufCorr data bitpos p0 b0 c0 a0)
+    (h1 : InflateBuf.WideBufCorr data bitpos p1 b1 c1 a1)
+    (hfull : 56 < c1 ∨ p1 = data.size)
+    (output : ByteArray) (outPos : USize) :
+    InflateBuf.goCurU litTable distTable litLD distLD 15 data maxOut
+        p0.toUSize (InflateBuf.trimBits b0 c0) c0.toUSize hsz hlp output outPos =
+      InflateBuf.goCurU litTable distTable litLD distLD 15 data maxOut
+        p1.toUSize (InflateBuf.trimBits b1 c1) c1.toUSize hsz hlp output outPos := by
+  have hp0 : p0.toUSize.toNat = p0 :=
+    InflateBuf.toUSize_toNat_of_lt (Nat.lt_of_le_of_lt h0.posLe hsz)
+  have hc0 : c0.toUSize.toNat = c0 :=
+    InflateBuf.toUSize_toNat_of_lt (Nat.lt_of_le_of_lt
+      (Nat.le_trans h0.cntLe h0.availLe)
+      (Nat.lt_of_lt_of_le (by decide) USize.le_size))
+  have h := goCurU_absorb_refill litTable distTable litLD distLD 15 data maxOut hsz hlp
+    p0.toUSize (InflateBuf.trimBits b0 c0) c0.toUSize output outPos
+    (by rw [hp0]; exact h0.posLe) (by rw [hc0]; exact Nat.le_trans h0.cntLe h0.availLe)
+  rw [hp0, hc0, InflateBuf.refill_eq_trimmed_full h0 h1 hfull] at h
+  have hp1 : p1.toUSize = p1.toUSize := rfl
+  simpa only using h
+
+theorem goCurU_absorb_wideU (litTable distTable : HuffTree.DecodeTable)
+    (litLD distLD : HuffTree.LongDecode) (data : ByteArray) (maxOut : Nat)
+    (hsz : data.size < USize.size)
+    (hlp : litTable.packed.size = 2 ^ HuffTree.fastBits)
+    {bitpos : Nat} {p0 p1 : USize} {b0 b1 : UInt64} {c0 c1 : USize} {a0 a1 : Nat}
+    (h0 : InflateBuf.WideBufCorr data bitpos p0.toNat b0 c0.toNat a0)
+    (h1 : InflateBuf.WideBufCorr data bitpos p1.toNat b1 c1.toNat a1)
+    (hfull : 56 < c1.toNat ∨ p1.toNat = data.size)
+    (output : ByteArray) (outPos : USize) :
+    InflateBuf.goCurU litTable distTable litLD distLD 15 data maxOut
+        p0 (InflateBuf.trimBits b0 c0.toNat) c0 hsz hlp output outPos =
+      InflateBuf.goCurU litTable distTable litLD distLD 15 data maxOut
+        p1 (InflateBuf.trimBits b1 c1.toNat) c1 hsz hlp output outPos := by
+  have hp0 : p0.toNat.toUSize = p0 := by
+    apply USize.toNat_inj.mp
+    rw [InflateBuf.toUSize_toNat_of_lt (Nat.lt_of_le_of_lt h0.posLe hsz)]
+  have hp1 : p1.toNat.toUSize = p1 := by
+    apply USize.toNat_inj.mp
+    rw [InflateBuf.toUSize_toNat_of_lt (Nat.lt_of_le_of_lt h1.posLe hsz)]
+  have hc0 : c0.toNat.toUSize = c0 := by
+    apply USize.toNat_inj.mp
+    rw [InflateBuf.toUSize_toNat_of_lt (Nat.lt_of_le_of_lt
+      (Nat.le_trans h0.cntLe h0.availLe)
+      (Nat.lt_of_lt_of_le (by decide) USize.le_size))]
+  have hc1 : c1.toNat.toUSize = c1 := by
+    apply USize.toNat_inj.mp
+    rw [InflateBuf.toUSize_toNat_of_lt (Nat.lt_of_le_of_lt
+      (Nat.le_trans h1.cntLe h1.availLe)
+      (Nat.lt_of_lt_of_le (by decide) USize.le_size))]
+  simpa only [hp0, hp1, hc0, hc1] using
+    goCurU_absorb_wide litTable distTable litLD distLD data maxOut hsz hlp
+      h0 h1 hfull output outPos
+
+set_option maxRecDepth 100000 in
+set_option maxHeartbeats 4000000 in
+/-- The word-refill loop observes only counted stream bits. With production
+    (15-bit) tables it therefore agrees with `goCurU` on the trimmed buffer. -/
+theorem goCurUW_eq (litTable distTable : HuffTree.DecodeTable)
+    (litLD distLD : HuffTree.LongDecode) (data : ByteArray) (maxOut : Nat)
+    (hsz : data.size < USize.size)
+    (hlp : litTable.packed.size = 2 ^ HuffTree.fastBits)
+    (hlitFast : ∀ b : UInt64,
+      (litTable.lenAt (b &&& 0x7FF).toNat).toNat ≤ HuffTree.fastBits)
+    (hlitUsed : ∀ b n s bb c used,
+      HuffTree.decodeSymCanon litLD litTable 15 b n = .ok (s, bb, c, used) → used ≤ 15)
+    (hdistUsed : ∀ b n s bb c used,
+      HuffTree.decodeSymCanon distLD distTable 15 b n = .ok (s, bb, c, used) → used ≤ 15) :
+    ∀ (pos : USize) (bitBuf : UInt64) (cnt : USize)
+      (output : ByteArray) (outPos : USize) (bitpos avail : Nat),
+    InflateBuf.WideBufCorr data bitpos pos.toNat bitBuf cnt.toNat avail →
+    output.size ≤ maxOut →
+    InflateBuf.goCurUW litTable distTable litLD distLD 15 data maxOut
+        pos bitBuf cnt hsz hlp output outPos =
+      InflateBuf.goCurU litTable distTable litLD distLD 15 data maxOut
+        pos (InflateBuf.trimBits bitBuf cnt.toNat) cnt hsz hlp output outPos := by
+  intro pos bitBuf cnt output outPos
+  induction pos, bitBuf, cnt, output, outPos using InflateBuf.goCurUW.induct
+      (litTable := litTable) (litLD := litLD) (maxBits := 15)
+      (data := data) (hsz := hsz) (hlp := hlp) with
+  | case1 pos bitBuf cnt output outPos hmt r hwm pos1 bitBuf1 cnt1 didWide hrc ih =>
+    intro bitpos avail hw hsize
+    have hfalse : (InflateBuf.wideRefillU data pos bitBuf cnt hsz).didWide = false := by
+      simpa only [r, didWide] using hrc.1
+    have hrid : InflateBuf.wideRefillU data pos bitBuf cnt hsz =
+        { pos := pos, bitBuf := bitBuf, cnt := cnt, didWide := false } := by
+      simp only [InflateBuf.wideRefillU] at hfalse
+      split at hfalse
+      · contradiction
+      · rename_i hn
+        simp only [InflateBuf.wideRefillU, dif_neg hn]
+    have hrc' : cnt ≤ 56 ∧ pos < data.size.toUSize := by
+      simpa only [r, pos1, cnt1, hrid] using hrc.2
+    obtain ⟨avail1, hwr⟩ := InflateBuf.wideRefillU_corr pos cnt hsz hw
+    have hrcN : r.cnt.toNat ≤ 56 ∧ r.pos.toNat < data.size := by
+      exact (InflateBuf.refillGuard_usize data r.pos r.cnt hsz).mp
+        (by simpa only [pos1, cnt1] using hrc.2)
+    have hp : (r.pos + 1).toNat = r.pos.toNat + 1 := by
+      rw [USize.toNat_add, USize.toNat_one]
+      apply Nat.mod_eq_of_lt
+      rw [← USize.size_eq_two_pow]
+      have hplt : r.pos.toNat < USize.size := Nat.lt_trans hrcN.2 hsz
+      omega
+    have h8 : (8 : USize).toNat = 8 :=
+      USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+    have hc : (r.cnt + 8).toNat = r.cnt.toNat + 8 := by
+      rw [USize.toNat_add, h8]
+      apply Nat.mod_eq_of_lt
+      rw [← USize.size_eq_two_pow]
+      have hc64 := Nat.le_trans hwr.cntLe hwr.availLe
+      have h64sz : (64 : Nat) < USize.size :=
+        Nat.lt_of_lt_of_le (by decide) USize.le_size
+      omega
+    have hbyte := hwr.refillByte hrcN.1 hrcN.2
+    have hread : data.uget r.pos (by
+        have h := USize.lt_iff_toNat_lt.mp (show r.pos < data.size.toUSize by
+          simpa only [pos1] using hrc.2.2)
+        rwa [InflateBuf.toUSize_toNat_of_lt hsz] at h) = data[pos.toNat]! :=
+      (InflateBuf.uget_eq_getElem! data r.pos hrcN.2).trans (by simp only [r, hrid])
+    have hI := ih bitpos (r.cnt.toNat + 8) (by
+      rw [hp, hc, InflateBuf.usize_toUInt64_toNat,
+        InflateBuf.uget_eq_getElem! data r.pos hrcN.2]
+      exact hbyte.toWide) hsize
+    have hp0 : (pos + 1).toNat = pos.toNat + 1 := by
+      simpa only [r, hrid] using hp
+    have hc0 : (cnt + 8).toNat = cnt.toNat + 8 := by
+      simpa only [r, hrid] using hc
+    have hrcN0 := (InflateBuf.refillGuard_usize data pos cnt hsz).mp hrc'
+    have hget0 := InflateBuf.uget_eq_getElem! data pos hrcN0.2
+    have hI0 :
+        InflateBuf.goCurUW litTable distTable litLD distLD 15 data maxOut
+            (pos + 1) (bitBuf ||| data[pos.toNat]!.toUInt64 <<< cnt.toNat.toUInt64)
+            (cnt + 8) hsz hlp output outPos =
+          InflateBuf.goCurU litTable distTable litLD distLD 15 data maxOut
+            (pos + 1) (InflateBuf.trimBits
+              (bitBuf ||| data[pos.toNat]!.toUInt64 <<< cnt.toNat.toUInt64)
+              (cnt.toNat + 8)) (cnt + 8) hsz hlp output outPos := by
+      simpa only [r, pos1, bitBuf1, cnt1, hrid, hp0, hc0,
+        InflateBuf.usize_toUInt64_toNat, hget0] using hI
+    have hbyte0 := hw.refillByte hrcN0.1 hrcN0.2
+    have heq : InflateBuf.trimBits
+        (bitBuf ||| data[pos.toNat]!.toUInt64 <<< cnt.toNat.toUInt64) (cnt.toNat + 8) =
+        InflateBuf.trimBits bitBuf cnt.toNat |||
+          data[pos.toNat]!.toUInt64 <<< cnt.toNat.toUInt64 := by
+      rw [InflateBuf.trimBits_eq_self hbyte0.cntLe hbyte0.high]
+      exact (InflateBuf.BufCorr.bitBuf_eq hbyte0
+        (InflateBuf.refill_step hw.trim hrcN0.1 hrcN0.2))
+    rw [heq] at hI0
+    rw [InflateBuf.goCurUW, dif_pos hmt]
+    rw [dif_pos (by simpa only [r, pos1, bitBuf1, cnt1, didWide] using hrc)]
+    simp only [hrid]
+    rw [InflateBuf.goCurU, dif_pos hrc']
+    rw [hget0, InflateBuf.usize_toUInt64_toNat]
+    exact hI0
+  | case2 pos bitBuf cnt output outPos hmt r hwm pos1 bitBuf1 cnt1 didWide hrc ent hlit ih =>
+    intro bitpos avail hw hsize
+    obtain ⟨avail1, hwr, hfull⟩ := InflateBuf.wideRefillU_full_of_no_tail
+      pos cnt hsz hw (by simpa only [r, pos1, bitBuf1, cnt1, didWide] using hrc)
+    have halign := goCurU_absorb_wideU litTable distTable litLD distLD data maxOut
+      hsz hlp hw hwr hfull output outPos
+    have hroot := hwr.trim_and_0x7FF hfull
+    have hent : litTable.entryAtU
+        (InflateBuf.trimBits r.bitBuf r.cnt.toNat &&& 0x7FF).toUSize
+          (by rw [hlp]; exact HuffTree.and_0x7FF_toUSize_toNat_lt _) = ent := by
+      dsimp only [ent, r, bitBuf1]
+      congr 2
+      exact (congrArg UInt64.toUSize hroot).trans
+        (HuffTree.and_0x7FF_toUSize_eq_toUSize_and r.bitBuf)
+    obtain ⟨hne, hle, hs⟩ := hlit
+    have hk : (HuffTree.unpackLen ent).toNat ≤ r.cnt.toNat := by
+      have := USize.le_iff_toNat_le.mp hle
+      rwa [UInt8.toNat_toUSize] at this
+    have hue : ent = litTable.entryAt (r.bitBuf &&& 0x7FF).toNat := by
+      dsimp only [ent, r, bitBuf1]
+      exact litTable.entryAtU_native_window_eq _ _
+    have hk11 : (HuffTree.unpackLen ent).toNat ≤ 11 := by
+      have ht := hlitFast r.bitBuf
+      rw [litTable.lenAt_eq_unpackLen_entryAt, ← hue] at ht
+      simpa only [HuffTree.fastBits] using ht
+    have hcons := hwr.consume hk (by omega : (HuffTree.unpackLen ent).toNat < 64)
+    have hsub : (r.cnt - (HuffTree.unpackLen ent).toUSize).toNat =
+        r.cnt.toNat - (HuffTree.unpackLen ent).toNat := by
+      rw [USize.toNat_sub_of_le _ _ hle, UInt8.toNat_toUSize]
+    have hI := ih (bitpos + (HuffTree.unpackLen ent).toNat)
+      (avail1 - (HuffTree.unpackLen ent).toNat) (by
+        simpa only [r, pos1, bitBuf1, cnt1, hsub, InflateBuf.uint8_toUInt64_toNat] using hcons)
+      (by rw [ByteArray.uset_eq_set!, ByteArray.size_set!]; exact hsize)
+    rw [InflateBuf.goCurUW, dif_pos hmt]
+    rw [dif_neg (by simpa only [r, pos1, bitBuf1, cnt1, didWide] using hrc),
+      dif_pos ⟨hne, hle, hs⟩]
+    rw [halign, InflateBuf.goCurU, dif_pos hmt,
+      dif_neg (InflateBuf.refillGuard_usize_false_of_full data r.pos r.cnt hsz hfull)]
+    rw [hent, dif_pos ⟨hne, hle, hs⟩]
+    have hshift := InflateBuf.trimBits_shiftRight r.bitBuf
+      (Nat.le_trans hwr.cntLe hwr.availLe) hk (by omega : (HuffTree.unpackLen ent).toNat < 64)
+    simpa only [r, pos1, bitBuf1, cnt1, ent, hsub, hshift,
+      InflateBuf.uint8_toUInt64_toNat,
+      ByteArray.uset_eq_set!] using hI
+  | case3 pos bitBuf cnt output outPos hmt r hwm pos1 bitBuf1 cnt1 didWide hrc ent hlit estr hde =>
+    intro bitpos avail hw hsize
+    dsimp only [bitBuf1, cnt1, r] at hde
+    obtain ⟨avail1, hwr, hfull⟩ := InflateBuf.wideRefillU_full_of_no_tail
+      pos cnt hsz hw (by simpa only [r, pos1, bitBuf1, cnt1, didWide] using hrc)
+    have halign := goCurU_absorb_wideU litTable distTable litLD distLD data maxOut
+      hsz hlp hw hwr hfull output outPos
+    have hroot := hwr.trim_and_0x7FF hfull
+    have hent : litTable.entryAtU
+        (InflateBuf.trimBits r.bitBuf r.cnt.toNat &&& 0x7FF).toUSize
+          (by rw [hlp]; exact HuffTree.and_0x7FF_toUSize_toNat_lt _) = ent := by
+      dsimp only [ent, r, bitBuf1]
+      congr 2
+      exact (congrArg UInt64.toUSize hroot).trans
+        (HuffTree.and_0x7FF_toUSize_eq_toUSize_and r.bitBuf)
+    have hmap := hwr.decodeSymCanon_map_trim (hfull.imp (by omega) id) litLD litTable
+    have hde' : HuffTree.decodeSymCanon litLD litTable 15
+        (InflateBuf.trimBits r.bitBuf r.cnt.toNat) r.cnt.toNat = .error estr := by
+      cases hx : HuffTree.decodeSymCanon litLD litTable 15
+          (InflateBuf.trimBits r.bitBuf r.cnt.toNat) r.cnt.toNat with
+      | error e =>
+        rw [hx, hde] at hmap
+        simp only [Except.map, Except.error.injEq] at hmap
+        subst e
+        simpa only using hx
+      | ok x =>
+        rw [hx, hde] at hmap
+        contradiction
+    dsimp only [r] at hde'
+    rw [InflateBuf.goCurUW, dif_pos hmt,
+      dif_neg (by simpa only [r, pos1, bitBuf1, cnt1, didWide] using hrc), dif_neg hlit]
+    simp only [hde]
+    rw [halign, InflateBuf.goCurU, dif_pos hmt,
+      dif_neg (InflateBuf.refillGuard_usize_false_of_full data r.pos r.cnt hsz hfull),
+      hent, dif_neg hlit]
+    simp only [hde']
+  | case4 pos bitBuf cnt output outPos hmt r hwm pos1 bitBuf1 cnt1 didWide hrc ent hlit
+      cnt0 sym bb c used hde hsym hnp =>
+    intro bitpos avail hw hsize
+    dsimp only [bitBuf1, cnt1, r] at hde
+    obtain ⟨avail1, hwr, hfull⟩ := InflateBuf.wideRefillU_full_of_no_tail
+      pos cnt hsz hw (by simpa only [r, pos1, bitBuf1, cnt1, didWide] using hrc)
+    have halign := goCurU_absorb_wideU litTable distTable litLD distLD data maxOut
+      hsz hlp hw hwr hfull output outPos
+    have hroot := hwr.trim_and_0x7FF hfull
+    have hent : litTable.entryAtU
+        (InflateBuf.trimBits r.bitBuf r.cnt.toNat &&& 0x7FF).toUSize
+          (by rw [hlp]; exact HuffTree.and_0x7FF_toUSize_toNat_lt _) = ent := by
+      dsimp only [ent, r, bitBuf1]
+      congr 2
+      exact (congrArg UInt64.toUSize hroot).trans
+        (HuffTree.and_0x7FF_toUSize_eq_toUSize_and r.bitBuf)
+    have hde' := hwr.decodeSymCanon_trim_ok (hfull.imp (by omega) id) litLD litTable
+      (by have := hlitUsed r.bitBuf r.cnt.toNat sym bb c used hde; omega) hde
+    rw [InflateBuf.goCurUW, dif_pos hmt,
+      dif_neg (by simpa only [r, pos1, bitBuf1, cnt1, didWide] using hrc), dif_neg hlit]
+    simp only [hde]
+    rw [if_pos hsym, dif_pos hnp]
+    rw [halign, InflateBuf.goCurU, dif_pos hmt,
+      dif_neg (InflateBuf.refillGuard_usize_false_of_full data r.pos r.cnt hsz hfull),
+      hent, dif_neg hlit]
+    simp only [hde']
+    rw [if_pos hsym, dif_pos hnp]
+  | case5 pos bitBuf cnt output outPos hmt r hwm pos1 bitBuf1 cnt1 didWide hrc ent hlit
+      cnt0 sym bb c used hde hsym hnp ih =>
+    intro bitpos avail hw hsize
+    dsimp only [bitBuf1, cnt1, r] at hde
+    obtain ⟨avail1, hwr, hfull⟩ := InflateBuf.wideRefillU_full_of_no_tail
+      pos cnt hsz hw (by simpa only [r, pos1, bitBuf1, cnt1, didWide] using hrc)
+    have halign := goCurU_absorb_wideU litTable distTable litLD distLD data maxOut
+      hsz hlp hw hwr hfull output outPos
+    have hroot := hwr.trim_and_0x7FF hfull
+    have hent : litTable.entryAtU
+        (InflateBuf.trimBits r.bitBuf r.cnt.toNat &&& 0x7FF).toUSize
+          (by rw [hlp]; exact HuffTree.and_0x7FF_toUSize_toNat_lt _) = ent := by
+      dsimp only [ent, r, bitBuf1]
+      congr 2
+      exact (congrArg UInt64.toUSize hroot).trans
+        (HuffTree.and_0x7FF_toUSize_eq_toUSize_and r.bitBuf)
+    have hde' := hwr.decodeSymCanon_trim_ok (hfull.imp (by omega) id) litLD litTable
+      (by have := hlitUsed r.bitBuf r.cnt.toNat sym bb c used hde; omega) hde
+    obtain ⟨hbb, hc, hu⟩ := InflateBuf.decodeSymCanon_ok_spec litLD litTable 15
+      r.bitBuf r.cnt.toNat hde
+    have hu15 := hlitUsed r.bitBuf r.cnt.toNat sym bb c used hde
+    have hcons := hwr.consume hu (by omega : used < 64)
+    rw [← hbb, ← hc] at hcons
+    have hcle := HuffTree.decodeSymCanon_cnt_le litLD litTable 15
+      r.bitBuf r.cnt.toNat hde
+    have hcrt : c.toUSize.toNat = c := InflateBuf.toUSize_toNat_of_lt
+      (Nat.lt_of_le_of_lt hcle (Nat.lt_of_le_of_lt
+        (Nat.le_trans hwr.cntLe hwr.availLe)
+        (Nat.lt_of_lt_of_le (by decide : 64 < 2 ^ 32) USize.le_size)))
+    have hI := ih (bitpos + used) (avail1 - used)
+      (by simpa only [r, pos1, hcrt] using hcons)
+      (by rw [ByteArray.uset_eq_set!, ByteArray.size_set!]; exact hsize)
+    rw [InflateBuf.goCurUW, dif_pos hmt,
+      dif_neg (by simpa only [r, pos1, bitBuf1, cnt1, didWide] using hrc), dif_neg hlit]
+    simp only [hde]
+    rw [if_pos hsym, dif_neg hnp]
+    rw [halign, InflateBuf.goCurU, dif_pos hmt,
+      dif_neg (InflateBuf.refillGuard_usize_false_of_full data r.pos r.cnt hsz hfull),
+      hent, dif_neg hlit]
+    simp only [hde']
+    rw [if_pos hsym, dif_neg hnp]
+    simpa only [r, pos1, bitBuf1, cnt1, hcrt, ByteArray.uset_eq_set!] using hI
+  | case6 pos bitBuf cnt output outPos hmt r hwm pos1 bitBuf1 cnt1 didWide hrc ent hlit
+      sym bb c used hde hsym heob =>
+    intro bitpos avail hw hsize
+    dsimp only [bitBuf1, cnt1, r] at hde
+    obtain ⟨avail1, hwr, hfull⟩ := InflateBuf.wideRefillU_full_of_no_tail
+      pos cnt hsz hw (by simpa only [r, pos1, bitBuf1, cnt1, didWide] using hrc)
+    have halign := goCurU_absorb_wideU litTable distTable litLD distLD data maxOut
+      hsz hlp hw hwr hfull output outPos
+    have hroot := hwr.trim_and_0x7FF hfull
+    have hent : litTable.entryAtU
+        (InflateBuf.trimBits r.bitBuf r.cnt.toNat &&& 0x7FF).toUSize
+          (by rw [hlp]; exact HuffTree.and_0x7FF_toUSize_toNat_lt _) = ent := by
+      dsimp only [ent, r, bitBuf1]
+      congr 2
+      exact (congrArg UInt64.toUSize hroot).trans
+        (HuffTree.and_0x7FF_toUSize_eq_toUSize_and r.bitBuf)
+    have hde' := hwr.decodeSymCanon_trim_ok (hfull.imp (by omega) id) litLD litTable
+      (by have := hlitUsed r.bitBuf r.cnt.toNat sym bb c used hde; omega) hde
+    have hcle := HuffTree.decodeSymCanon_cnt_le litLD litTable 15 r.bitBuf r.cnt.toNat hde
+    have hcrt : c.toUSize.toNat = c := InflateBuf.toUSize_toNat_of_lt
+      (Nat.lt_of_le_of_lt hcle (Nat.lt_of_le_of_lt
+        (Nat.le_trans hwr.cntLe hwr.availLe)
+        (Nat.lt_of_lt_of_le (by decide : 64 < 2 ^ 32) USize.le_size)))
+    rw [InflateBuf.goCurUW, dif_pos hmt,
+      dif_neg (by simpa only [r, pos1, bitBuf1, cnt1, didWide] using hrc), dif_neg hlit]
+    simp only [hde]
+    rw [if_neg hsym, if_pos heob,
+      InflateBuf.trimBitBufU_eq_trimBits bb c.toUSize (by
+        rw [hcrt]
+        exact Nat.le_trans hcle (Nat.le_trans hwr.cntLe hwr.availLe)), hcrt]
+    rw [halign, InflateBuf.goCurU, dif_pos hmt,
+      dif_neg (InflateBuf.refillGuard_usize_false_of_full data r.pos r.cnt hsz hfull),
+      hent, dif_neg hlit]
+    simp only [hde']
+    rw [if_neg hsym, if_pos heob]
+  | case7 pos bitBuf cnt output outPos hmt r hwm pos1 bitBuf1 cnt1 didWide hrc ent hlit
+      sym bb c used hde hsym hneob idx hidx =>
+    intro bitpos avail hw hsize
+    dsimp only [bitBuf1, cnt1, r] at hde
+    obtain ⟨avail1, hwr, hfull⟩ := InflateBuf.wideRefillU_full_of_no_tail
+      pos cnt hsz hw (by simpa only [r, pos1, bitBuf1, cnt1, didWide] using hrc)
+    have halign := goCurU_absorb_wideU litTable distTable litLD distLD data maxOut
+      hsz hlp hw hwr hfull output outPos
+    have hroot := hwr.trim_and_0x7FF hfull
+    have hent : litTable.entryAtU
+        (InflateBuf.trimBits r.bitBuf r.cnt.toNat &&& 0x7FF).toUSize
+          (by rw [hlp]; exact HuffTree.and_0x7FF_toUSize_toNat_lt _) = ent := by
+      dsimp only [ent, r, bitBuf1]
+      congr 2
+      exact (congrArg UInt64.toUSize hroot).trans
+        (HuffTree.and_0x7FF_toUSize_eq_toUSize_and r.bitBuf)
+    have hde' := hwr.decodeSymCanon_trim_ok (hfull.imp (by omega) id) litLD litTable
+      (by have := hlitUsed r.bitBuf r.cnt.toNat sym bb c used hde; omega) hde
+    rw [InflateBuf.goCurUW, dif_pos hmt,
+      dif_neg (by simpa only [r, pos1, bitBuf1, cnt1, didWide] using hrc), dif_neg hlit]
+    simp only [hde]
+    rw [if_neg hsym, if_neg hneob, dif_pos hidx]
+    rw [halign, InflateBuf.goCurU, dif_pos hmt,
+      dif_neg (InflateBuf.refillGuard_usize_false_of_full data r.pos r.cnt hsz hfull),
+      hent, dif_neg hlit]
+    simp only [hde']
+    rw [if_neg hsym, if_neg hneob, dif_pos hidx]
+  | case8 pos bitBuf cnt output outPos hmt r hwm pos1 bitBuf1 cnt1 didWide hrc ent hlit
+      cnt0 sym bb c used hde hsym hneob idx hh base ih =>
+    intro bitpos avail hw hsize
+    dsimp only [bitBuf1, cnt1, r] at hde
+    obtain ⟨avail1, hwr, hfull⟩ := InflateBuf.wideRefillU_full_of_no_tail
+      pos cnt hsz hw (by simpa only [r, pos1, bitBuf1, cnt1, didWide] using hrc)
+    have halign := goCurU_absorb_wideU litTable distTable litLD distLD data maxOut
+      hsz hlp hw hwr hfull output outPos
+    have hroot := hwr.trim_and_0x7FF hfull
+    have hent : litTable.entryAtU
+        (InflateBuf.trimBits r.bitBuf r.cnt.toNat &&& 0x7FF).toUSize
+          (by rw [hlp]; exact HuffTree.and_0x7FF_toUSize_toNat_lt _) = ent := by
+      dsimp only [ent, r, bitBuf1]
+      congr 2
+      exact (congrArg UInt64.toUSize hroot).trans
+        (HuffTree.and_0x7FF_toUSize_eq_toUSize_and r.bitBuf)
+    have hde' := hwr.decodeSymCanon_trim_ok (hfull.imp (by omega) id) litLD litTable
+      (by have := hlitUsed r.bitBuf r.cnt.toNat sym bb c used hde; omega) hde
+    obtain ⟨hbb, hc, hu⟩ := InflateBuf.decodeSymCanon_ok_spec litLD litTable 15
+      r.bitBuf r.cnt.toNat hde
+    have hu15 := hlitUsed r.bitBuf r.cnt.toNat sym bb c used hde
+    have hw1 := hwr.consume hu (by omega : used < 64)
+    rw [← hbb, ← hc] at hw1
+    have hidxLen : sym.toNat - 257 < Inflate.lengthBase.size := by omega
+    have hidxExtra : sym.toNat - 257 < Inflate.lengthExtra.size := by
+      rw [Inflate.lengthExtra_size, ← Inflate.lengthBase_size]
+      exact hidxLen
+    have hhc : ¬ sym.toNat - 257 ≥ Inflate.lengthBase.size := by omega
+    rw [InflateBuf.goCurUW, dif_pos hmt,
+      dif_neg (by simpa only [r, pos1, bitBuf1, cnt1, didWide] using hrc), dif_neg hlit]
+    simp only [hde]
+    rw [if_neg hsym, if_neg hneob, dif_neg hhc]
+    rw [halign, InflateBuf.goCurU, dif_pos hmt,
+      dif_neg (InflateBuf.refillGuard_usize_false_of_full data r.pos r.cnt hsz hfull),
+      hent, dif_neg hlit]
+    simp only [hde']
+    rw [if_neg hsym, if_neg hneob, dif_neg hhc]
+    simp only [bind, Except.bind]
+    cases htb : InflateBuf.takeBits bb c
+        (Inflate.lengthExtra[sym.toNat - 257]'hidxExtra).toNat with
+    | error e =>
+      have htb' : InflateBuf.takeBits (InflateBuf.trimBits bb c) c
+          (Inflate.lengthExtra[sym.toNat - 257]'hidxExtra).toNat = .error e :=
+        InflateBuf.takeBits_trim_error bb c _ htb
+      simp only [htb, htb']
+    | ok pe =>
+      obtain ⟨eb, bb2, c2⟩ := pe
+      obtain ⟨hn, hbb2, hc2⟩ := InflateBuf.takeBits_ok_spec bb c
+        (Inflate.lengthExtra[sym.toNat - 257]'hidxExtra).toNat htb
+      have hn64 := lengthExtra_lt_64 (sym.toNat - 257)
+        hidxExtra
+      have htb' := InflateBuf.takeBits_trim_ok bb c
+        (Inflate.lengthExtra[sym.toNat - 257]'hidxExtra).toNat
+        hn hn64 (Nat.le_trans hw1.cntLe hw1.availLe) htb
+      have hw2 := hw1.consume hn hn64
+      rw [← hbb2, ← hc2] at hw2
+      have hposfull2 : 15 ≤ c2 ∨ r.pos.toNat = data.size := by
+        rcases hfull with hf | hp
+        · left
+          have hf' : 56 < r.cnt.toNat := by simpa only [r] using hf
+          have hn5 : (Inflate.lengthExtra[sym.toNat - 257]'hidxExtra).toNat ≤ 5 :=
+            lengthExtra_le_5 _ hidxExtra
+          have hc2eq : c2 = r.cnt.toNat -
+              (used + (Inflate.lengthExtra[sym.toNat - 257]'hidxExtra).toNat) := by
+            rw [hc2, hc, Nat.sub_sub]
+          rw [hc2eq]
+          apply Nat.le_sub_of_add_le
+          omega
+        · right; exact hp
+      simp only [htb, htb']
+      cases hdd : HuffTree.decodeSymCanon distLD distTable 15 bb2 c2 with
+      | error e =>
+        have hm := hw2.decodeSymCanon_map_trim hposfull2 distLD distTable
+        have hdd' : HuffTree.decodeSymCanon distLD distTable 15
+            (InflateBuf.trimBits bb2 c2) c2 = .error e := by
+          cases hx : HuffTree.decodeSymCanon distLD distTable 15
+              (InflateBuf.trimBits bb2 c2) c2 with
+          | error e' =>
+            rw [hx, hdd] at hm
+            simp only [Except.map, Except.error.injEq] at hm
+            subst e'
+            simpa only using hx
+          | ok x => rw [hx, hdd] at hm; contradiction
+        simp only [hdd, hdd']
+      | ok pd =>
+        obtain ⟨dsym, bb3, c3, dused⟩ := pd
+        have hdd' := hw2.decodeSymCanon_trim_ok hposfull2 distLD distTable
+          (by have := hdistUsed bb2 c2 dsym bb3 c3 dused hdd; omega) hdd
+        obtain ⟨hbb3, hc3, hdu⟩ := InflateBuf.decodeSymCanon_ok_spec
+          distLD distTable 15 bb2 c2 hdd
+        have hdu15 := hdistUsed bb2 c2 dsym bb3 c3 dused hdd
+        have hw3 := hw2.consume hdu (by omega : dused < 64)
+        rw [← hbb3, ← hc3] at hw3
+        simp only [hdd, hdd']
+        by_cases hdidx : dsym.toNat ≥ Inflate.distBase.size
+        · simp only [dif_pos hdidx]
+        · simp only [dif_neg hdidx]
+          have hdidxExtra : dsym.toNat < Inflate.distExtra.size := by
+            rw [Inflate.distExtra_size, ← Inflate.distBase_size]
+            omega
+          cases htb2 : InflateBuf.takeBits bb3 c3
+              (Inflate.distExtra[dsym.toNat]'hdidxExtra).toNat with
+          | error e =>
+            have htb2' : InflateBuf.takeBits (InflateBuf.trimBits bb3 c3) c3
+                (Inflate.distExtra[dsym.toNat]'hdidxExtra).toNat = .error e :=
+              InflateBuf.takeBits_trim_error bb3 c3 _ htb2
+            simp only [htb2, htb2']
+          | ok pd2 =>
+            obtain ⟨deb, bb4, c4⟩ := pd2
+            obtain ⟨hdn, hbb4, hc4⟩ := InflateBuf.takeBits_ok_spec bb3 c3
+              (Inflate.distExtra[dsym.toNat]'hdidxExtra).toNat htb2
+            have hdn64 := distExtra_lt_64 dsym.toNat
+              hdidxExtra
+            have htb2' := InflateBuf.takeBits_trim_ok bb3 c3
+              (Inflate.distExtra[dsym.toNat]'hdidxExtra).toNat
+              hdn hdn64 (Nat.le_trans hw3.cntLe hw3.availLe) htb2
+            have hw4 := hw3.consume hdn hdn64
+            rw [← hbb4, ← hc4] at hw4
+            simp only [htb2, htb2']
+            by_cases hz : Inflate.distBase[dsym.toNat].toNat + deb = 0
+            · split
+              · rfl
+              · rename_i hnzero
+                exact (hnzero hz).elim
+            · split
+              · rename_i hzero
+                exact (hz hzero).elim
+              · split
+                · rfl
+                · rename_i hds
+                  have heblt : eb < 2 ^ (Inflate.lengthExtra[sym.toNat - 257]'hidxExtra).toNat :=
+                    takeBits_lt bb c _ hn64 htb
+                  have hlen258 : Inflate.lengthBase[sym.toNat - 257].toNat + eb ≤ 258 :=
+                    length_le_258 (sym.toNat - 257)
+                      hidxLen heblt
+                  split
+                  · rfl
+                  · rename_i hlen
+                    split
+                    · rfl
+                    · rename_i hnp
+                      have hc4rt : c4.toUSize.toNat = c4 := InflateBuf.toUSize_toNat_of_lt
+                        (Nat.lt_of_le_of_lt (Nat.le_trans hw4.cntLe hw4.availLe)
+                          (Nat.lt_of_lt_of_le (by decide : 64 < 2 ^ 32) USize.le_size))
+                      simpa only [r, pos1, base, idx, hc4rt, Nat.add_assoc] using
+                        ih eb dsym hdidx deb bb4 c4 hds hnp
+                          (bitpos + used +
+                            (Inflate.lengthExtra[sym.toNat - 257]'hidxExtra).toNat +
+                            dused + (Inflate.distExtra[dsym.toNat]'hdidxExtra).toNat)
+                          (avail1 - used -
+                            (Inflate.lengthExtra[sym.toNat - 257]'hidxExtra).toNat -
+                            dused - (Inflate.distExtra[dsym.toNat]'hdidxExtra).toNat)
+                          (by simpa only [r, pos1, hc4rt, Nat.add_assoc] using hw4)
+                          (by
+                            rw [ByteArray.copyWithinAtShort_if_eq, copyWithinAt_size]
+                            exact hsize)
+  | case9 pos bitBuf cnt output outPos hmt =>
+    intro bitpos avail hw hsize
+    rw [InflateBuf.goCurUW, dif_neg hmt,
+      InflateBuf.trimBitBufU_eq_trimBits bitBuf cnt (Nat.le_trans hw.cntLe hw.availLe)]
+    exact (goCurU_eq litTable distTable litLD distLD 15 data maxOut hsz hlp
+      pos (InflateBuf.trimBits bitBuf cnt.toNat) cnt output outPos hsize).symm
+
 /-- The `uset` fastloop block decoder agrees with the `set!` one (lifts `goCurU_eq`
     through the shared `decodeHuffmanCurTables` scaffolding). -/
 theorem decodeHuffmanCurTablesU_eq (br : ZipCommon.BitReader) (output : ByteArray) (outPos : Nat)
     (litTable distTable : HuffTree.DecodeTable) (litLD distLD : HuffTree.LongDecode) (maxOut : Nat)
-    (hlp : litTable.packed.size = 2 ^ HuffTree.fastBits) (hsize : output.size ≤ maxOut) :
+    (hlp : litTable.packed.size = 2 ^ HuffTree.fastBits)
+    (hlitFast : ∀ b : UInt64,
+      (litTable.lenAt (b &&& 0x7FF).toNat).toNat ≤ HuffTree.fastBits)
+    (hlitUsed : ∀ b n s bb c used,
+      HuffTree.decodeSymCanon litLD litTable 15 b n = .ok (s, bb, c, used) → used ≤ 15)
+    (hdistUsed : ∀ b n s bb c used,
+      HuffTree.decodeSymCanon distLD distTable 15 b n = .ok (s, bb, c, used) → used ≤ 15)
+    (hwf : br.bitOff < 8) (hbp : br.bitPos ≤ br.data.size * 8)
+    (hsize : output.size ≤ maxOut) :
     InflateBuf.decodeHuffmanCurTablesU br output outPos litTable distTable litLD distLD maxOut hlp
       = InflateBuf.decodeHuffmanCurTables br output outPos litTable distTable litLD distLD maxOut hlp := by
   unfold InflateBuf.decodeHuffmanCurTablesU InflateBuf.decodeHuffmanCurTables
-  simp only [goCurU_eq _ _ _ _ _ _ _ _ _ _ _ _ _ _ hsize]
+  by_cases hszeq : br.data.size.toUSize.toNat = br.data.size
+  · simp only [hszeq, ↓reduceDIte]
+    have hsz : br.data.size < USize.size := by
+      rw [← hszeq]
+      exact USize.toNat_lt_two_pow_numBits _
+    have hposle : br.pos ≤ br.data.size := by
+      have hbpe : br.bitPos = br.pos * 8 + br.bitOff := rfl
+      omega
+    have hbc0 : InflateBuf.BufCorr br.data (br.pos * 8) br.pos 0 0 :=
+      ⟨by omega, hposle, by omega, by simp, fun j hj => absurd hj (Nat.not_lt_zero j)⟩
+    rcases hrf : InflateBuf.refill br.data br.pos 0 0 with ⟨p, b, c⟩
+    obtain ⟨hbc1, hfull⟩ := InflateBuf.refill_corr hbc0 hrf
+    have hboff : br.bitOff ≤ c := by
+      rcases hfull with hc | hp
+      · omega
+      · have hs := hbc1.span; rw [hp] at hs
+        have hbp' := hbp
+        simp only [ZipCommon.BitReader.bitPos] at hbp'
+        omega
+    have hbc2 := InflateBuf.consume_corr hbc1 hboff (by omega : br.bitOff < 64)
+    have hp : p.toUSize.toNat = p := InflateBuf.toUSize_toNat_of_lt
+      (Nat.lt_of_le_of_lt hbc2.posLe hsz)
+    have hc : (c - br.bitOff).toUSize.toNat = c - br.bitOff :=
+      InflateBuf.toUSize_toNat_of_lt (Nat.lt_of_le_of_lt hbc2.cntLe
+        (Nat.lt_of_lt_of_le (by decide) USize.le_size))
+    have hw : InflateBuf.WideBufCorr br.data br.bitPos p.toUSize.toNat
+        (b >>> br.bitOff.toUInt64) (c - br.bitOff).toUSize.toNat (c - br.bitOff) := by
+      simpa only [ZipCommon.BitReader.bitPos, hp, hc] using hbc2.toWide
+    have hwEq := goCurUW_eq litTable distTable litLD distLD br.data maxOut hsz hlp
+      hlitFast hlitUsed hdistUsed p.toUSize (b >>> br.bitOff.toUInt64)
+      (c - br.bitOff).toUSize output outPos.toUSize br.bitPos (c - br.bitOff) hw hsize
+    have htrim : InflateBuf.trimBits (b >>> br.bitOff.toUInt64) (c - br.bitOff) =
+        b >>> br.bitOff.toUInt64 :=
+      InflateBuf.trimBits_eq_self hbc2.cntLe hbc2.high
+    have hcurEq := goCurU_eq litTable distTable litLD distLD 15 br.data maxOut hsz hlp
+      p.toUSize (b >>> br.bitOff.toUInt64)
+      (c - br.bitOff).toUSize output outPos.toUSize hsize
+    have hwEq' : InflateBuf.goCurUW litTable distTable litLD distLD 15 br.data maxOut
+        p.toUSize (b >>> br.bitOff.toUInt64) (c - br.bitOff).toUSize hsz hlp output outPos.toUSize =
+      InflateBuf.goCurU litTable distTable litLD distLD 15 br.data maxOut p.toUSize
+        (b >>> br.bitOff.toUInt64)
+        (c - br.bitOff).toUSize hsz hlp output outPos.toUSize := by
+      simpa only [hc, htrim] using hwEq
+    simp only
+    rw [hwEq', hcurEq]
+  · simp only [hszeq, ↓reduceDIte]
 
 
 set_option maxRecDepth 100000 in
@@ -2664,6 +3378,34 @@ theorem inflateLoopCurU_eq (maxOut dataSize : Nat) :
       | error e => simp only [h1, h2, bind, Except.bind]
       | ok r2 =>
         obtain ⟨btype, br₂⟩ := r2
+        have hbo₂ : br₂.bitOff < 8 := InflateBuf.readBits_bitOff_lt_pos (by omega) h2
+        have hbp₂ : br₂.bitPos ≤ br₂.data.size * 8 := by
+          exact Deflate.Correctness.readBits_bitPos_le br₁ 2 btype br₂ (by omega) h2
+        have hflv : Huffman.Spec.ValidLengths
+            (Inflate.fixedLitLengths.toList.map UInt8.toNat) 15 := by
+          obtain ⟨fixedLit, hfl⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedLit_ok
+          exact Deflate.Correctness.fromLengths_valid Inflate.fixedLitLengths 15 fixedLit hfl
+        have hfdv : Huffman.Spec.ValidLengths
+            (Inflate.fixedDistLengths.toList.map UInt8.toNat) 15 := by
+          obtain ⟨fixedDist, hfd⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedDist_ok
+          exact Deflate.Correctness.fromLengths_valid Inflate.fixedDistLengths 15 fixedDist hfd
+        have hflFast : ∀ b : UInt64,
+            (Inflate.fixedLitTF.1.lenAt (b &&& 0x7FF).toNat).toNat ≤ HuffTree.fastBits := by
+          intro b
+          simpa only [Inflate.fixedLitTF, Inflate.fixedLitCount] using
+            treeFree_len_le Inflate.fixedLitLengths hflv (by decide) b
+        have hflUsed : ∀ b n s bb c used,
+            HuffTree.decodeSymCanon Inflate.fixedLitTF.2 Inflate.fixedLitTF.1 15 b n =
+              .ok (s, bb, c, used) → used ≤ 15 := by
+          intro b n s bb c used h
+          simpa only [Inflate.fixedLitTF, Inflate.fixedLitCount] using
+            treeFree_decode_used_le Inflate.fixedLitLengths hflv (by decide) h
+        have hfdUsed : ∀ b n s bb c used,
+            HuffTree.decodeSymCanon Inflate.fixedDistTF.2 Inflate.fixedDistTF.1 15 b n =
+              .ok (s, bb, c, used) → used ≤ 15 := by
+          intro b n s bb c used h
+          simpa only [Inflate.fixedDistTF, Inflate.fixedDistCount] using
+            treeFree_decode_used_le Inflate.fixedDistLengths hfdv (by decide) h
         have htail : ∀ (o' : ByteArray) (p' : Nat) (b' : ZipCommon.BitReader), o'.size ≤ maxOut →
             (if bfinal == 1 then (pure (o', p', b'.alignToByte.pos) : Except String (ByteArray × Nat × Nat))
              else if _h : b'.bitPos ≤ br.bitPos then throw "Inflate: no progress in inflate loop"
@@ -2699,7 +3441,8 @@ theorem inflateLoopCurU_eq (maxOut dataSize : Nat) :
             obtain ⟨o', p', b'⟩ := r
             simp only [hb, bind, Except.bind]
             exact htail o' p' b' (by rw [decodeStoredCur_size hb]; exact hsize)
-        · rw [decodeHuffmanCurTablesU_eq _ _ _ _ _ _ _ _ _ hsize]
+        · rw [decodeHuffmanCurTablesU_eq br₂ output outPos _ _ _ _ maxOut _
+              hflFast hflUsed hfdUsed hbo₂ hbp₂ hsize]
           cases hb : InflateBuf.decodeHuffmanCurTables br₂ output outPos
               Inflate.fixedLitTF.1 Inflate.fixedDistTF.1 Inflate.fixedLitTF.2 Inflate.fixedDistTF.2 maxOut
               (HuffTree.buildTreeFreeWithCount_size Inflate.fixedLitLengths Inflate.fixedLitCount 15) with
@@ -2713,7 +3456,25 @@ theorem inflateLoopCurU_eq (maxOut dataSize : Nat) :
           | ok rd =>
             obtain ⟨litLens, distLens, br₃⟩ := rd
             simp only [hd, bind, Except.bind]
-            rw [decodeHuffmanCurTablesU_eq _ _ _ _ _ _ _ _ _ hsize]
+            obtain ⟨hdyntrees, hlv, hdv, hlb, hdb⟩ := Inflate.decodeDynamicTrees_of_lengthsOnly hd
+            have hple₂ : br₂.pos ≤ br₂.data.size := by
+              have := hbp₂; simp only [ZipCommon.BitReader.bitPos] at this; omega
+            have hpos₂ : br₂.bitOff = 0 ∨ br₂.pos < br₂.data.size := by
+              have := hbp₂; simp only [ZipCommon.BitReader.bitPos] at this
+              rcases Nat.lt_or_ge br₂.pos br₂.data.size with h | h
+              · exact Or.inr h
+              · exact Or.inl (by omega)
+            obtain ⟨hd₃, hp₃, hl₃⟩ := Zip.Native.decodeDynamicTrees_inv
+              br₂ br₃ _ _ hdyntrees hpos₂ hple₂
+            have hbo₃ := InflateBuf.decodeDynamicTrees_bitOff_pres hbo₂ hdyntrees
+            have hbp₃ : br₃.bitPos ≤ br₃.data.size * 8 := by
+              simp only [ZipCommon.BitReader.bitPos]
+              rcases hp₃ with h' | h' <;> omega
+            rw [decodeHuffmanCurTablesU_eq br₃ output outPos _ _ _ _ maxOut _
+              (treeFree_len_le litLens hlv hlb)
+              (fun _ _ _ _ _ _ h => treeFree_decode_used_le litLens hlv hlb h)
+              (fun _ _ _ _ _ _ h => treeFree_decode_used_le distLens hdv hdb h)
+              hbo₃ hbp₃ hsize]
             cases hb : InflateBuf.decodeHuffmanCurTables br₃ output outPos
                 (HuffTree.buildTreeFreeWithCount litLens (HuffTree.countLengthsFast litLens 15) 15).1
                 (HuffTree.buildTreeFreeWithCount distLens (HuffTree.countLengthsFast distLens 15) 15).1

--- a/Zip/Spec/InflateWideRefillCorrect.lean
+++ b/Zip/Spec/InflateWideRefillCorrect.lean
@@ -1,0 +1,736 @@
+import Zip.Spec.InflateBufCorrect
+import Zip.Native.InflateFast
+
+/-!
+# Correctness infrastructure for the speculative wide decoder refill
+
+The libdeflate refill keeps real future stream bits above the logical bit count.
+`LowEq` records the observational fact used by the decoder: two words agree in
+their first `n` bits. `trimBits` is the proof-side canonical representative.
+-/
+
+namespace Zip.Native.InflateBuf
+
+private theorem byte_mul_lt_wide {b cnt : Nat} (h : b < 256) :
+    b * 2 ^ cnt < 2 ^ (cnt + 8) := by
+  calc
+    b * 2 ^ cnt < 256 * 2 ^ cnt := (Nat.mul_lt_mul_right (Nat.two_pow_pos cnt)).mpr h
+    _ = 2 ^ (cnt + 8) := by
+      rw [Nat.pow_add, show (2 : Nat) ^ 8 = 256 from by decide, Nat.mul_comm]
+
+private theorem byteShift_testBit (b : UInt8) (s j : Nat) (hs : s ≤ 56) :
+    (b.toUInt64 <<< s.toUInt64).toNat.testBit j =
+      if s ≤ j ∧ j < s + 8 then b.toNat.testBit (j - s) else false := by
+  have hb : b.toNat < 256 := UInt8.toNat_lt b
+  have hsmod : s.toUInt64.toNat % 64 = s := by simp [Nat.toUInt64]; omega
+  have hshift : (b.toUInt64 <<< s.toUInt64).toNat = b.toNat * 2 ^ s := by
+    rw [UInt64.toNat_shiftLeft, UInt8.toNat_toUInt64, hsmod, Nat.shiftLeft_eq]
+    apply Nat.mod_eq_of_lt
+    exact Nat.lt_of_lt_of_le (byte_mul_lt_wide hb)
+      (Nat.pow_le_pow_right (by omega) (by omega))
+  rw [hshift, Nat.testBit_mul_two_pow]
+  by_cases hsj : s ≤ j
+  · simp only [hsj, decide_true, Bool.true_and]
+    by_cases hj : j < s + 8
+    · simp only [hj, and_self, if_true]
+    · simp only [hj, and_false, if_false]
+      apply Nat.testBit_lt_two_pow
+      exact Nat.lt_of_lt_of_le hb (show 2 ^ 8 ≤ 2 ^ (j - s) from
+        Nat.pow_le_pow_right (by omega) (by omega))
+  · simp [hsj]
+
+private theorem toU64_8 : Nat.toUInt64 8 = 8 := rfl
+private theorem toU64_16 : Nat.toUInt64 16 = 16 := rfl
+private theorem toU64_24 : Nat.toUInt64 24 = 24 := rfl
+private theorem toU64_32 : Nat.toUInt64 32 = 32 := rfl
+private theorem toU64_40 : Nat.toUInt64 40 = 40 := rfl
+private theorem toU64_48 : Nat.toUInt64 48 = 48 := rfl
+private theorem toU64_56 : Nat.toUInt64 56 = 56 := rfl
+
+private theorem byteShift8 (b : UInt8) (j : Nat) :
+    (b.toUInt64 <<< 8).toNat.testBit j =
+      if 8 ≤ j ∧ j < 16 then b.toNat.testBit (j - 8) else false := by
+  simpa only [toU64_8] using byteShift_testBit b 8 j (by omega)
+
+private theorem byteShift16 (b : UInt8) (j : Nat) :
+    (b.toUInt64 <<< 16).toNat.testBit j =
+      if 16 ≤ j ∧ j < 24 then b.toNat.testBit (j - 16) else false := by
+  simpa only [toU64_16] using byteShift_testBit b 16 j (by omega)
+
+private theorem byteShift24 (b : UInt8) (j : Nat) :
+    (b.toUInt64 <<< 24).toNat.testBit j =
+      if 24 ≤ j ∧ j < 32 then b.toNat.testBit (j - 24) else false := by
+  simpa only [toU64_24] using byteShift_testBit b 24 j (by omega)
+
+private theorem byteShift32 (b : UInt8) (j : Nat) :
+    (b.toUInt64 <<< 32).toNat.testBit j =
+      if 32 ≤ j ∧ j < 40 then b.toNat.testBit (j - 32) else false := by
+  simpa only [toU64_32] using byteShift_testBit b 32 j (by omega)
+
+private theorem byteShift40 (b : UInt8) (j : Nat) :
+    (b.toUInt64 <<< 40).toNat.testBit j =
+      if 40 ≤ j ∧ j < 48 then b.toNat.testBit (j - 40) else false := by
+  simpa only [toU64_40] using byteShift_testBit b 40 j (by omega)
+
+private theorem byteShift48 (b : UInt8) (j : Nat) :
+    (b.toUInt64 <<< 48).toNat.testBit j =
+      if 48 ≤ j ∧ j < 56 then b.toNat.testBit (j - 48) else false := by
+  simpa only [toU64_48] using byteShift_testBit b 48 j (by omega)
+
+private theorem byteShift56 (b : UInt8) (j : Nat) :
+    (b.toUInt64 <<< 56).toNat.testBit j =
+      if 56 ≤ j ∧ j < 64 then b.toNat.testBit (j - 56) else false := by
+  simpa only [toU64_56] using byteShift_testBit b 56 j (by omega)
+
+private theorem byte_testBit_high (b : UInt8) {j : Nat} (hj : 8 ≤ j) :
+    b.toNat.testBit j = false := by
+  apply Nat.testBit_lt_two_pow
+  exact Nat.lt_of_lt_of_le (UInt8.toNat_lt b)
+    (show 2 ^ 8 ≤ 2 ^ j from Nat.pow_le_pow_right (by omega) hj)
+
+private theorem byteInterval_iff (j k : Nat) :
+    k * 8 ≤ j ∧ j < (k + 1) * 8 ↔ j / 8 = k := by
+  constructor
+  · intro h
+    apply Nat.le_antisymm
+    · have := (Nat.div_lt_iff_lt_mul (k := 8) (x := j) (y := k + 1) (by omega)).mpr h.2
+      omega
+    · exact (Nat.le_div_iff_mul_le (k := 8) (x := k) (y := j) (by omega)).mpr h.1
+  · intro h
+    constructor
+    · apply (Nat.le_div_iff_mul_le (k := 8) (x := k) (y := j) (by omega)).mp
+      omega
+    · apply (Nat.div_lt_iff_lt_mul (k := 8) (x := j) (y := k + 1) (by omega)).mp
+      omega
+
+/-- Two words agree on every bit below `n`. -/
+def LowEq (a b : UInt64) (n : Nat) : Prop :=
+  ∀ j, j < n → a.toNat.testBit j = b.toNat.testBit j
+
+theorem LowEq.symm {a b : UInt64} {n : Nat} (h : LowEq a b n) : LowEq b a n := by
+  intro j hj
+  exact (h j hj).symm
+
+/-- Consuming `k` bits preserves equality on the remaining low window. -/
+theorem LowEq.shiftRight {a b : UInt64} {n k : Nat} (h : LowEq a b n)
+    (hk : k ≤ n) (hk64 : k < 64) :
+    LowEq (a >>> k.toUInt64) (b >>> k.toUInt64) (n - k) := by
+  intro j hj
+  have hkmod : k.toUInt64.toNat % 64 = k := by
+    simp [Nat.toUInt64]
+    omega
+  rw [UInt64.toNat_shiftRight, UInt64.toNat_shiftRight, hkmod, Nat.testBit_shiftRight,
+    Nat.testBit_shiftRight]
+  exact h (k + j) (by omega)
+
+/-- AND with a mask confined to the observed window turns low equality into
+    ordinary word equality. -/
+theorem LowEq.and_eq {a b mask : UInt64} {n : Nat} (h : LowEq a b n)
+    (hm : mask.toNat < 2 ^ n) : a &&& mask = b &&& mask := by
+  apply UInt64.toNat_inj.mp
+  apply Nat.eq_of_testBit_eq
+  intro j
+  rw [UInt64.toNat_and, UInt64.toNat_and, Nat.testBit_and, Nat.testBit_and]
+  by_cases hj : j < n
+  · rw [h j hj]
+  · have hz : mask.toNat.testBit j = false :=
+      Nat.testBit_lt_two_pow (Nat.lt_of_lt_of_le hm
+        (Nat.pow_le_pow_right (by omega) (by omega)))
+    rw [hz, Bool.and_false, Bool.and_false]
+
+/-- Proof-side canonical buffer: discard every bit at or above `n`. -/
+def trimBits (bitBuf : UInt64) (n : Nat) : UInt64 :=
+  (bitBuf.toNat % 2 ^ n).toUInt64
+
+theorem trimBits_toNat {bitBuf : UInt64} {n : Nat} (hn : n ≤ 64) :
+    (trimBits bitBuf n).toNat = bitBuf.toNat % 2 ^ n := by
+  simp only [trimBits, Nat.toUInt64, UInt64.toNat_ofNat']
+  apply Nat.mod_eq_of_lt
+  exact Nat.lt_of_lt_of_le (Nat.mod_lt _ (Nat.two_pow_pos n))
+    (Nat.pow_le_pow_right (by omega) hn)
+
+theorem lowEq_trimBits (bitBuf : UInt64) {n : Nat} (hn : n ≤ 64) :
+    LowEq bitBuf (trimBits bitBuf n) n := by
+  intro j hj
+  rw [trimBits_toNat hn, Nat.testBit_mod_two_pow]
+  simp only [decide_eq_true_eq.mpr hj, Bool.true_and]
+
+/-- Trimming commutes with consuming counted bits. -/
+theorem trimBits_shiftRight (bitBuf : UInt64) {n k : Nat} (hn : n ≤ 64)
+    (hk : k ≤ n) (hk64 : k < 64) :
+    trimBits bitBuf n >>> k.toUInt64 = trimBits (bitBuf >>> k.toUInt64) (n - k) := by
+  apply UInt64.toNat_inj.mp
+  apply Nat.eq_of_testBit_eq
+  intro j
+  have hkmod : k.toUInt64.toNat % 64 = k := by simp [Nat.toUInt64]; omega
+  rw [UInt64.toNat_shiftRight, hkmod, Nat.testBit_shiftRight]
+  by_cases hj : j < n - k
+  · rw [trimBits_toNat hn, Nat.testBit_mod_two_pow]
+    simp only [show k + j < n by omega, decide_true, Bool.true_and]
+    rw [trimBits_toNat (by omega), Nat.testBit_mod_two_pow]
+    simp only [hj, decide_true, Bool.true_and, UInt64.toNat_shiftRight, hkmod,
+      Nat.testBit_shiftRight]
+  · have hl : (trimBits bitBuf n).toNat.testBit (k + j) = false := by
+      apply Nat.testBit_lt_two_pow
+      exact Nat.lt_of_lt_of_le (by rw [trimBits_toNat hn]; exact Nat.mod_lt _ (Nat.two_pow_pos n))
+        (Nat.pow_le_pow_right (by omega) (by omega))
+    rw [hl]
+    apply Eq.symm
+    apply Nat.testBit_lt_two_pow
+    rw [trimBits_toNat (by omega)]
+    exact Nat.lt_of_lt_of_le (Nat.mod_lt _ (Nat.two_pow_pos (n - k)))
+      (Nat.pow_le_pow_right (by omega) (by omega))
+
+/-- Trimming an already exact buffer is a no-op. -/
+theorem trimBits_eq_self {bitBuf : UInt64} {n : Nat} (hn : n ≤ 64)
+    (hhigh : bitBuf.toNat < 2 ^ n) : trimBits bitBuf n = bitBuf := by
+  apply UInt64.toNat_inj.mp
+  rw [trimBits_toNat hn, Nat.mod_eq_of_lt hhigh]
+
+@[simp] theorem trimBits_idem (bitBuf : UInt64) {n : Nat} (hn : n ≤ 64) :
+    trimBits (trimBits bitBuf n) n = trimBits bitBuf n := by
+  apply trimBits_eq_self hn
+  rw [trimBits_toNat hn]
+  exact Nat.mod_lt _ (Nat.two_pow_pos n)
+
+theorem trimBits_shiftRight_congr (bitBuf : UInt64) {n k : Nat} (hn : n ≤ 64)
+    (hk : k ≤ n) :
+    trimBits (trimBits bitBuf n >>> k.toUInt64) (n - k) =
+      trimBits (bitBuf >>> k.toUInt64) (n - k) := by
+  by_cases hk64 : k < 64
+  · rw [trimBits_shiftRight bitBuf hn hk hk64, trimBits_idem _ (by omega)]
+  · have hn64 : n = 64 := by omega
+    have hk' : k = 64 := by omega
+    subst n
+    subst k
+    rw [trimBits_eq_self (n := 64) (by omega) (UInt64.toNat_lt _)]
+
+/-- A speculative buffer has `cnt` logically consumed-aligned bits and `avail`
+    physically loaded bits. Every loaded bit is a genuine stream bit. -/
+structure WideBufCorr (data : ByteArray) (bitpos pos : Nat) (bitBuf : UInt64)
+    (cnt avail : Nat) : Prop where
+  span : bitpos + cnt = pos * 8
+  posLe : pos ≤ data.size
+  cntLe : cnt ≤ avail
+  aheadLe : avail ≤ cnt + 8
+  availLe : avail ≤ 64
+  inStream : bitpos + avail ≤ data.size * 8
+  high : bitBuf.toNat < 2 ^ avail
+  bits : ∀ j, j < avail → bitBuf.toNat.testBit j = streamBit data (bitpos + j)
+
+/-- An exact buffer is a speculative buffer with no look-ahead. -/
+theorem BufCorr.toWide {data bitpos pos bitBuf cnt}
+    (h : BufCorr data bitpos pos bitBuf cnt) :
+    WideBufCorr data bitpos pos bitBuf cnt cnt := by
+  refine ⟨h.span, h.posLe, Nat.le_refl _, by omega, h.cntLe, ?_, h.high, h.bits⟩
+  have := h.span
+  have := h.posLe
+  omega
+
+/-- Discarding look-ahead recovers an ordinary exact `BufCorr`. -/
+theorem WideBufCorr.trim {data bitpos pos bitBuf cnt avail}
+    (h : WideBufCorr data bitpos pos bitBuf cnt avail) :
+    BufCorr data bitpos pos (trimBits bitBuf cnt) cnt := by
+  have hcnt64 : cnt ≤ 64 := Nat.le_trans h.cntLe h.availLe
+  refine ⟨h.span, h.posLe, hcnt64, ?_, ?_⟩
+  · rw [trimBits_toNat hcnt64]
+    exact Nat.mod_lt _ (Nat.two_pow_pos cnt)
+  · intro j hj
+    rw [trimBits_toNat hcnt64, Nat.testBit_mod_two_pow]
+    simp only [decide_eq_true_eq.mpr hj, Bool.true_and]
+    exact h.bits j (Nat.lt_of_lt_of_le hj h.cntLe)
+
+/-- Consuming counted bits shifts both the logical count and the loaded extent. -/
+theorem WideBufCorr.consume {data bitpos pos bitBuf cnt avail}
+    (h : WideBufCorr data bitpos pos bitBuf cnt avail) {k : Nat}
+    (hk : k ≤ cnt) (hk64 : k < 64) :
+    WideBufCorr data (bitpos + k) pos (bitBuf >>> k.toUInt64) (cnt - k) (avail - k) := by
+  have hkavail : k ≤ avail := Nat.le_trans hk h.cntLe
+  refine ⟨by have := h.span; omega, h.posLe, Nat.sub_le_sub_right h.cntLe k,
+    ?_, Nat.le_trans (Nat.sub_le avail k) h.availLe, ?_, ?_, ?_⟩
+  · rw [← show cnt + 8 - k = cnt - k + 8 by omega]
+    exact Nat.sub_le_sub_right h.aheadLe k
+  · calc
+      bitpos + k + (avail - k) = bitpos + avail := by omega
+      _ ≤ data.size * 8 := h.inStream
+  · have hkmod : k.toUInt64.toNat % 64 = k := by simp [Nat.toUInt64]; omega
+    rw [UInt64.toNat_shiftRight, hkmod, Nat.shiftRight_eq_div_pow]
+    apply Nat.div_lt_of_lt_mul
+    rw [Nat.mul_comm, ← Nat.pow_add]
+    have hak : avail - k + k = avail := by omega
+    rw [hak]
+    exact h.high
+  · intro j hj
+    have hkmod : k.toUInt64.toNat % 64 = k := by simp [Nat.toUInt64]; omega
+    have hidx : k + j < avail := by omega
+    have he : bitpos + (k + j) = bitpos + k + j := by omega
+    rw [UInt64.toNat_shiftRight, hkmod, Nat.testBit_shiftRight, h.bits (k + j) hidx, he]
+
+/-- The byte tail closes any at-most-one-byte look-ahead window: after ORing the
+    next logical byte, the buffer is exact again. -/
+theorem WideBufCorr.refillByte {data bitpos pos bitBuf cnt avail}
+    (h : WideBufCorr data bitpos pos bitBuf cnt avail)
+    (hcnt : cnt ≤ 56) (hpos : pos < data.size) :
+    BufCorr data bitpos (pos + 1)
+      (bitBuf ||| (data[pos]!.toUInt64 <<< cnt.toUInt64)) (cnt + 8) := by
+  have hcnt64 : cnt ≤ 64 := Nat.le_trans h.cntLe h.availLe
+  have hexact := refill_step h.trim hcnt hpos
+  have heq : bitBuf ||| (data[pos]!.toUInt64 <<< cnt.toUInt64) =
+      trimBits bitBuf cnt ||| (data[pos]!.toUInt64 <<< cnt.toUInt64) := by
+    apply UInt64.toNat_inj.mp
+    apply Nat.eq_of_testBit_eq
+    intro j
+    rw [UInt64.toNat_or, UInt64.toNat_or, Nat.testBit_or, Nat.testBit_or]
+    by_cases hjn : j < cnt
+    · rw [(lowEq_trimBits bitBuf hcnt64) j hjn]
+    · have hz : (trimBits bitBuf cnt).toNat.testBit j = false := by
+        apply Nat.testBit_lt_two_pow
+        rw [trimBits_toNat hcnt64]
+        exact Nat.lt_of_lt_of_le (Nat.mod_lt _ (Nat.two_pow_pos cnt))
+          (Nat.pow_le_pow_right (by omega) (by omega))
+      rw [hz, Bool.false_or]
+      by_cases hjc : j < avail
+      · have hj : j < cnt + 8 := Nat.lt_of_lt_of_le hjc h.aheadLe
+        have he := hexact.bits j hj
+        rw [UInt64.toNat_or, Nat.testBit_or, hz, Bool.false_or] at he
+        rw [h.bits j hjc, he, Bool.or_self]
+      · have hz' : bitBuf.toNat.testBit j = false :=
+          Nat.testBit_lt_two_pow (Nat.lt_of_lt_of_le h.high
+            (Nat.pow_le_pow_right (by omega) (by omega)))
+        rw [hz', Bool.false_or]
+  rw [heq]
+  exact hexact
+
+/-- At end of input a speculative buffer cannot actually have look-ahead: the
+    stream bound and the cursor equation force `avail = cnt`. -/
+theorem WideBufCorr.trim_eq_of_pos_eq {data bitpos pos bitBuf cnt avail}
+    (h : WideBufCorr data bitpos pos bitBuf cnt avail) (hp : pos = data.size) :
+    trimBits bitBuf cnt = bitBuf := by
+  subst pos
+  apply trimBits_eq_self (Nat.le_trans h.cntLe h.availLe)
+  have ha : avail = cnt := by
+    apply Nat.le_antisymm
+    · have hs := h.span
+      have hi := h.inStream
+      omega
+    · exact h.cntLe
+  simpa [ha] using h.high
+
+/-- A full speculative state and its trimmed representative have the same
+    11-bit root-table window. -/
+theorem WideBufCorr.trim_and_0x7FF {data bitpos pos bitBuf cnt avail}
+    (h : WideBufCorr data bitpos pos bitBuf cnt avail)
+    (hfull : 56 < cnt ∨ pos = data.size) :
+    trimBits bitBuf cnt &&& 0x7FF = bitBuf &&& 0x7FF := by
+  rcases hfull with hc | hp
+  · apply LowEq.and_eq (n := cnt)
+      ((lowEq_trimBits bitBuf (Nat.le_trans h.cntLe h.availLe)).symm)
+    have hm : (0x7FF : UInt64).toNat = 2047 := rfl
+    rw [hm]
+    exact Nat.lt_of_lt_of_le (by decide : 2047 < 2 ^ 11)
+      (Nat.pow_le_pow_right (by omega) (by omega))
+  · rw [h.trim_eq_of_pos_eq hp]
+
+theorem refill_eq_self_of_full (data : ByteArray) (pos : Nat) (bitBuf : UInt64)
+    (cnt : Nat) (hfull : 56 < cnt ∨ pos = data.size) :
+    refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by
+  rw [refill]
+  apply dif_neg
+  intro h
+  rcases hfull with hc | hp
+  · omega
+  · omega
+
+theorem refillGuard_usize_false_of_full (data : ByteArray) (pos cnt : USize)
+    (hsz : data.size < USize.size) (hfull : 56 < cnt.toNat ∨ pos.toNat = data.size) :
+    ¬(cnt ≤ 56 ∧ pos < data.size.toUSize) := by
+  intro hg
+  have hgn := (refillGuard_usize data pos cnt hsz).mp hg
+  rcases hfull with hc | hp <;> omega
+
+/-- Any exact full state corresponding to a speculative state is the canonical
+    result of refilling the latter's trimmed input state. -/
+theorem refill_eq_trimmed_full {data : ByteArray} {bitpos p0 p1 : Nat}
+    {b0 b1 : UInt64} {c0 c1 a0 a1 : Nat}
+    (h0 : WideBufCorr data bitpos p0 b0 c0 a0)
+    (h1 : WideBufCorr data bitpos p1 b1 c1 a1)
+    (hfull : 56 < c1 ∨ p1 = data.size) :
+    refill data p0 (trimBits b0 c0) c0 = (p1, trimBits b1 c1, c1) := by
+  calc
+    refill data p0 (trimBits b0 c0) c0 =
+        refill data p1 (trimBits b1 c1) c1 := refill_canonical h0.trim h1.trim
+    _ = (p1, trimBits b1 c1, c1) := refill_eq_self_of_full data p1 _ c1 hfull
+
+/-- A wide little-endian load is exactly the next 64 LSB-first stream bits. -/
+theorem ugetUInt64LE_testBit (data : ByteArray) (pos : USize)
+    (hpos : pos.toNat + 8 ≤ data.size) (j : Nat) (hj : j < 64) :
+    (data.ugetUInt64LE pos hpos).toNat.testBit j =
+      streamBit data (pos.toNat * 8 + j) := by
+  rw [ByteArray.ugetUInt64LE]
+  simp only [UInt64.toNat_or, Nat.testBit_or, UInt8.toNat_toUInt64]
+  rw [byteShift56, byteShift48, byteShift40, byteShift32, byteShift24, byteShift16,
+    byteShift8]
+  simp only [show (8 ≤ j ∧ j < 16) ↔ j / 8 = 1 by simpa using byteInterval_iff j 1,
+    show (16 ≤ j ∧ j < 24) ↔ j / 8 = 2 by simpa using byteInterval_iff j 2,
+    show (24 ≤ j ∧ j < 32) ↔ j / 8 = 3 by simpa using byteInterval_iff j 3,
+    show (32 ≤ j ∧ j < 40) ↔ j / 8 = 4 by simpa using byteInterval_iff j 4,
+    show (40 ≤ j ∧ j < 48) ↔ j / 8 = 5 by simpa using byteInterval_iff j 5,
+    show (48 ≤ j ∧ j < 56) ↔ j / 8 = 6 by simpa using byteInterval_iff j 6,
+    show (56 ≤ j ∧ j < 64) ↔ j / 8 = 7 by simpa using byteInterval_iff j 7]
+  have hcases : j < 8 ∨ (8 ≤ j ∧ j < 16) ∨ (16 ≤ j ∧ j < 24) ∨
+      (24 ≤ j ∧ j < 32) ∨ (32 ≤ j ∧ j < 40) ∨ (40 ≤ j ∧ j < 48) ∨
+      (48 ≤ j ∧ j < 56) ∨ (56 ≤ j ∧ j < 64) := by omega
+  rcases hcases with h | h | h | h | h | h | h | h
+  all_goals
+    simp only [streamBit]
+    have hdiv : (pos.toNat * 8 + j) / 8 = pos.toNat + j / 8 := by omega
+    have hmod : (pos.toNat * 8 + j) % 8 = j % 8 := by omega
+    rw [hdiv, hmod]
+  · have hj0 : j / 8 = 0 := by omega
+    have hjm : j % 8 = j := Nat.mod_eq_of_lt h
+    simp only [hj0, hjm, Nat.add_zero]
+    rw [getElem!_pos data pos.toNat (by omega)]
+    simp [hj0]
+  · have hj0 : j / 8 = 1 := by omega
+    have hjm : j % 8 = j - 8 := by omega
+    simp only [hj0, hjm]
+    rw [getElem!_pos data (pos.toNat + 1) (by omega), byte_testBit_high _ (by omega)]
+    simp [hj0]
+  · have hj0 : j / 8 = 2 := by omega
+    have hjm : j % 8 = j - 16 := by omega
+    simp only [hj0, hjm]
+    rw [getElem!_pos data (pos.toNat + 2) (by omega), byte_testBit_high _ (by omega)]
+    simp [hj0]
+  · have hj0 : j / 8 = 3 := by omega
+    have hjm : j % 8 = j - 24 := by omega
+    simp only [hj0, hjm]
+    rw [getElem!_pos data (pos.toNat + 3) (by omega), byte_testBit_high _ (by omega)]
+    simp [hj0]
+  · have hj0 : j / 8 = 4 := by omega
+    have hjm : j % 8 = j - 32 := by omega
+    simp only [hj0, hjm]
+    rw [getElem!_pos data (pos.toNat + 4) (by omega), byte_testBit_high _ (by omega)]
+    simp [hj0]
+  · have hj0 : j / 8 = 5 := by omega
+    have hjm : j % 8 = j - 40 := by omega
+    simp only [hj0, hjm]
+    rw [getElem!_pos data (pos.toNat + 5) (by omega), byte_testBit_high _ (by omega)]
+    simp [hj0]
+  · have hj0 : j / 8 = 6 := by omega
+    have hjm : j % 8 = j - 48 := by omega
+    simp only [hj0, hjm]
+    rw [getElem!_pos data (pos.toNat + 6) (by omega), byte_testBit_high _ (by omega)]
+    simp [hj0]
+  · have hj0 : j / 8 = 7 := by omega
+    have hjm : j % 8 = j - 56 := by omega
+    simp only [hj0, hjm]
+    rw [getElem!_pos data (pos.toNat + 7) (by omega), byte_testBit_high _ (by omega)]
+    simp [hj0]
+
+private theorem shiftLeft_testBit (word : UInt64) {cnt j : Nat} (hcnt : cnt < 64)
+    (hj : j < 64) :
+    (word <<< cnt.toUInt64).toNat.testBit j =
+      if cnt ≤ j then word.toNat.testBit (j - cnt) else false := by
+  have hcmod : cnt.toUInt64.toNat % 64 = cnt := by simp [Nat.toUInt64]; omega
+  rw [UInt64.toNat_shiftLeft, Nat.testBit_mod_two_pow, Nat.testBit_shiftLeft, hcmod]
+  simp only [hj, decide_true, Bool.true_and]
+  by_cases h : cnt ≤ j <;> simp [h]
+
+/-- A wide load establishes a 64-bit speculative buffer while advancing the
+    logical input cursor by only the whole bytes newly counted. -/
+theorem wideLoad_corr {data : ByteArray} {bitpos avail : Nat} (pos : USize)
+    {bitBuf : UInt64} {cnt : Nat} (h : WideBufCorr data bitpos pos.toNat bitBuf cnt avail)
+    (hcnt : cnt < 64) (hpos : pos.toNat + 8 ≤ data.size) :
+    WideBufCorr data bitpos
+      (pos.toNat + (64 - cnt) / 8)
+      (bitBuf ||| (data.ugetUInt64LE pos hpos <<< cnt.toUInt64))
+      (cnt + 8 * ((64 - cnt) / 8)) 64 := by
+  have hk : 8 * ((64 - cnt) / 8) ≤ 64 - cnt := by omega
+  have hrem : 64 - cnt < 8 * ((64 - cnt) / 8) + 8 := by omega
+  refine ⟨by have := h.span; omega, by omega, by omega, by omega, by omega,
+    by have := h.span; omega, UInt64.toNat_lt _, ?_⟩
+  intro j hj
+  rw [UInt64.toNat_or, Nat.testBit_or, shiftLeft_testBit _ hcnt hj]
+  by_cases hjc : j < cnt
+  · rw [if_neg (by omega), Bool.or_false, h.bits j (Nat.lt_of_lt_of_le hjc h.cntLe)]
+  · rw [if_pos (by omega), ugetUInt64LE_testBit data pos hpos (j - cnt) (by omega)]
+    have heq : pos.toNat * 8 + (j - cnt) = bitpos + j := by
+      have := h.span
+      omega
+    rw [heq]
+    by_cases hja : j < avail
+    · rw [h.bits j hja, Bool.or_self]
+    · have hz : bitBuf.toNat.testBit j = false :=
+        Nat.testBit_lt_two_pow (Nat.lt_of_lt_of_le h.high
+          (Nat.pow_le_pow_right (by omega) (by omega)))
+      rw [hz, Bool.false_or]
+
+/-- `wideRefillU` preserves the speculative-buffer invariant. -/
+theorem wideRefillU_corr {data : ByteArray} {bitpos avail : Nat} (pos : USize)
+    {bitBuf : UInt64} (cnt : USize) (hsz : data.size < USize.size)
+    (h : WideBufCorr data bitpos pos.toNat bitBuf cnt.toNat avail) :
+    ∃ avail', WideBufCorr data bitpos
+      (wideRefillU data pos bitBuf cnt hsz).pos.toNat
+      (wideRefillU data pos bitBuf cnt hsz).bitBuf
+      (wideRefillU data pos bitBuf cnt hsz).cnt.toNat avail' := by
+  simp only [wideRefillU]
+  split
+  · rename_i hw
+    have hg := (refillGuardWide_usize data pos cnt hsz).mp hw
+    have hk := wideRefillK_toNat cnt hg.1
+    have hc := wideRefillCnt_toNat cnt hg.1
+    have hp : (pos + ((64 - cnt) >>> 3)).toNat =
+        pos.toNat + (64 - cnt.toNat) / 8 := by
+      rw [USize.toNat_add, hk]
+      apply Nat.mod_eq_of_lt
+      rw [← USize.size_eq_two_pow]
+      omega
+    refine ⟨64, ?_⟩
+    simp only [hp, hc]
+    rw [usize_toUInt64_toNat]
+    exact wideLoad_corr pos h (by omega) hg.2
+  · exact ⟨avail, h⟩
+
+/-- Once the byte-tail guard is false, the post-wide-refill state is full in
+    exactly the sense used by the canonical refill proof. -/
+theorem wideRefillU_full_of_no_tail {data : ByteArray} {bitpos avail : Nat}
+    (pos : USize) {bitBuf : UInt64} (cnt : USize) (hsz : data.size < USize.size)
+    (h : WideBufCorr data bitpos pos.toNat bitBuf cnt.toNat avail)
+    (hn : ¬((wideRefillU data pos bitBuf cnt hsz).didWide = false ∧
+      (wideRefillU data pos bitBuf cnt hsz).cnt ≤ 56 ∧
+      (wideRefillU data pos bitBuf cnt hsz).pos < data.size.toUSize)) :
+    ∃ avail', WideBufCorr data bitpos
+        (wideRefillU data pos bitBuf cnt hsz).pos.toNat
+        (wideRefillU data pos bitBuf cnt hsz).bitBuf
+        (wideRefillU data pos bitBuf cnt hsz).cnt.toNat avail' ∧
+      (56 < (wideRefillU data pos bitBuf cnt hsz).cnt.toNat ∨
+        (wideRefillU data pos bitBuf cnt hsz).pos.toNat = data.size) := by
+  obtain ⟨avail', hw⟩ := wideRefillU_corr pos cnt hsz h
+  refine ⟨avail', hw, ?_⟩
+  by_cases hd : (wideRefillU data pos bitBuf cnt hsz).didWide = false
+  · by_cases hc : (wideRefillU data pos bitBuf cnt hsz).cnt ≤ 56
+    · have hp : ¬ (wideRefillU data pos bitBuf cnt hsz).pos < data.size.toUSize := by
+        intro hp
+        exact hn ⟨hd, hc, hp⟩
+      right
+      have hs : data.size.toUSize.toNat = data.size := toUSize_toNat_of_lt hsz
+      have hpn : ¬ (wideRefillU data pos bitBuf cnt hsz).pos.toNat < data.size := by
+        intro hlt
+        apply hp
+        apply USize.lt_iff_toNat_lt.mpr
+        rwa [hs]
+      have hple := hw.posLe
+      omega
+    · left
+      have h56 : (56 : USize).toNat = 56 :=
+        USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+      rw [USize.le_iff_toNat_le, h56] at hc
+      omega
+  · simp only [wideRefillU] at hd
+    split at hd
+    · rename_i hg
+      left
+      have hc := wideRefillCnt_toNat cnt ((refillGuardWide_usize data pos cnt hsz).mp hg).1
+      simp only [wideRefillU, dif_pos hg]
+      omega
+    · exact (hd rfl).elim
+
+/-- The runtime cold-tail mask is the proof-side canonical buffer. -/
+theorem trimBitBufU_eq_trimBits (bitBuf : UInt64) (cnt : USize) (hcnt : cnt.toNat ≤ 64) :
+    trimBitBufU bitBuf cnt = trimBits bitBuf cnt.toNat := by
+  unfold trimBitBufU
+  split
+  · rename_i h
+    simp only [beq_iff_eq] at h
+    have h64 : (64 : USize).toNat = 64 :=
+      USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+    have hc : cnt.toNat = 64 := by rw [h, h64]
+    rw [hc, trimBits_eq_self (by omega) (UInt64.toNat_lt _)]
+  · rename_i h
+    have hc : cnt.toNat < 64 := by
+      simp only [beq_iff_eq, not_false_eq_true] at h
+      have h64 : (64 : USize).toNat = 64 :=
+        USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+      have : cnt.toNat ≠ 64 := by intro he; apply h; apply USize.toNat_inj.mp; rw [h64, he]
+      omega
+    apply UInt64.toNat_inj.mp
+    rw [usize_toUInt64_toNat]
+    rw [UInt64.toNat_and, mask_toNat hc, Nat.and_two_pow_sub_one_eq_mod,
+      trimBits_toNat (by omega)]
+
+/-- Canonicalize only the returned buffer of a symbol-decode result. -/
+private def trimDecodeResult (r : UInt16 × UInt64 × Nat × Nat) :
+    UInt16 × UInt64 × Nat × Nat :=
+  (r.1, trimBits r.2.1 r.2.2.1, r.2.2.1, r.2.2.2)
+
+/-- With the production 15-bit tables and a full buffer, speculative bits above
+    `cnt` cannot affect symbol selection. They only survive above the returned
+    count, where `trimDecodeResult` removes them. -/
+theorem decodeSymCanon_trim (ld : HuffTree.LongDecode) (table : HuffTree.DecodeTable)
+    (bitBuf : UInt64) (cnt : Nat) (hcnt : 15 ≤ cnt) (hcnt64 : cnt ≤ 64) :
+    (HuffTree.decodeSymCanon ld table 15 (trimBits bitBuf cnt) cnt).map trimDecodeResult =
+      (HuffTree.decodeSymCanon ld table 15 bitBuf cnt).map trimDecodeResult := by
+  have hlow : LowEq (trimBits bitBuf cnt) bitBuf cnt :=
+    (lowEq_trimBits bitBuf hcnt64).symm
+  have hroot : trimBits bitBuf cnt &&& 0x7FF = bitBuf &&& 0x7FF := by
+    apply hlow.and_eq
+    have : (0x7FF : UInt64).toNat = 2047 := rfl
+    rw [this]
+    exact Nat.lt_of_lt_of_le (by decide) (Nat.pow_le_pow_right (by omega) hcnt)
+  have hshift := hlow.shiftRight (k := 11) (by omega) (by omega)
+  have hsub :
+      (trimBits bitBuf cnt >>> (HuffTree.fastBits : Nat).toUInt64) &&&
+          (2 ^ (15 - HuffTree.fastBits) - 1 : Nat).toUInt64 =
+        (bitBuf >>> (HuffTree.fastBits : Nat).toUInt64) &&&
+          (2 ^ (15 - HuffTree.fastBits) - 1 : Nat).toUInt64 := by
+    apply LowEq.and_eq (n := cnt - 11) hshift
+    simp only [HuffTree.fastBits]
+    have hm : ((2 ^ (15 - 11) - 1 : Nat).toUInt64).toNat = 15 := by decide
+    rw [hm]
+    calc
+      15 < 2 ^ 4 := by decide
+      _ ≤ 2 ^ (cnt - 11) := Nat.pow_le_pow_right (by omega) (by omega)
+  simp only [HuffTree.decodeSymCanon]
+  rw [hroot]
+  split
+  · simp only [HuffTree.subLookup, hroot, hsub]
+    split
+    · rfl
+    · split
+      · rfl
+      · split
+        · rfl
+        · split
+          · rfl
+          · simp only [Except.map, trimDecodeResult]
+            rw [trimBits_shiftRight_congr bitBuf hcnt64 (by omega)]
+  · simp only [Except.map, trimDecodeResult]
+    simp only [Bool.or_eq_true, beq_iff_eq, decide_eq_true_eq, not_or] at ‹¬ _›
+    rw [trimBits_shiftRight_congr bitBuf hcnt64 (by omega)]
+
+theorem WideBufCorr.decodeSymCanon_map_trim (h : WideBufCorr data bitpos pos bitBuf cnt avail)
+    (hready : 15 ≤ cnt ∨ pos = data.size)
+    (ld : HuffTree.LongDecode) (table : HuffTree.DecodeTable) :
+    (HuffTree.decodeSymCanon ld table 15 (trimBits bitBuf cnt) cnt).map trimDecodeResult =
+      (HuffTree.decodeSymCanon ld table 15 bitBuf cnt).map trimDecodeResult := by
+  rcases hready with hc | hp
+  · exact decodeSymCanon_trim ld table bitBuf cnt hc
+      (Nat.le_trans h.cntLe h.availLe)
+  · rw [h.trim_eq_of_pos_eq hp]
+
+/-- A successful canonical-table decode consumes exactly its reported number
+    of bits. This structural fact does not require the table to be valid. -/
+theorem decodeSymCanon_ok_spec (ld : HuffTree.LongDecode) (table : HuffTree.DecodeTable)
+    (maxBits : Nat) (bitBuf : UInt64) (cnt : Nat) {sym : UInt16} {bb : UInt64}
+    {c used : Nat}
+    (h : HuffTree.decodeSymCanon ld table maxBits bitBuf cnt = .ok (sym, bb, c, used)) :
+    bb = bitBuf >>> used.toUInt64 ∧ c = cnt - used ∧ used ≤ cnt := by
+  simp only [HuffTree.decodeSymCanon] at h
+  split at h
+  · simp only [HuffTree.subLookup] at h
+    split at h
+    · contradiction
+    · split at h
+      · contradiction
+      · split at h
+        · contradiction
+        · split at h
+          · contradiction
+          · rename_i hlen
+            simp only [Except.ok.injEq, Prod.mk.injEq] at h
+            obtain ⟨rfl, rfl, rfl, rfl⟩ := h
+            exact ⟨rfl, rfl, Nat.not_lt.mp hlen⟩
+  · rename_i hguard
+    simp only [Bool.or_eq_true, beq_iff_eq, decide_eq_true_eq, not_or] at hguard
+    simp only [Except.ok.injEq, Prod.mk.injEq] at h
+    obtain ⟨rfl, rfl, rfl, rfl⟩ := h
+    exact ⟨rfl, rfl, Nat.not_lt.mp hguard.2⟩
+
+theorem WideBufCorr.decodeSymCanon_trim_ok
+    (h : WideBufCorr data bitpos pos bitBuf cnt avail)
+    (hready : 15 ≤ cnt ∨ pos = data.size)
+    (ld : HuffTree.LongDecode) (table : HuffTree.DecodeTable)
+    {sym : UInt16} {bb : UInt64} {c used : Nat} (hused64 : used < 64)
+    (hde : HuffTree.decodeSymCanon ld table 15 bitBuf cnt = .ok (sym, bb, c, used)) :
+    HuffTree.decodeSymCanon ld table 15 (trimBits bitBuf cnt) cnt =
+      .ok (sym, trimBits bb c, c, used) := by
+  have hm := h.decodeSymCanon_map_trim hready ld table
+  rw [hde] at hm
+  cases hx : HuffTree.decodeSymCanon ld table 15 (trimBits bitBuf cnt) cnt with
+  | error e => rw [hx] at hm; contradiction
+  | ok x =>
+    obtain ⟨xs, xbb, xc, xu⟩ := x
+    rw [hx] at hm
+    simp only [Except.map, trimDecodeResult, Except.ok.injEq, Prod.mk.injEq] at hm
+    obtain ⟨rfl, htrim, rfl, rfl⟩ := hm
+    obtain ⟨hcanon, _, _⟩ := decodeSymCanon_ok_spec ld table 15
+      (trimBits bitBuf cnt) cnt hx
+    obtain ⟨hraw, hc, hu⟩ := decodeSymCanon_ok_spec ld table 15 bitBuf cnt hde
+    rw [hcanon, hraw, hc]
+    congr 2
+    congr 2
+    exact trimBits_shiftRight bitBuf (Nat.le_trans h.cntLe h.availLe) hu hused64
+
+private def trimTakeResult (r : Nat × UInt64 × Nat) : Nat × UInt64 × Nat :=
+  (r.1, trimBits r.2.1 r.2.2, r.2.2)
+
+/-- Speculative bits above the count cannot affect a bounded `takeBits`. -/
+theorem takeBits_trim (bitBuf : UInt64) (cnt n : Nat) (hn : n ≤ cnt)
+    (hn64 : n < 64) (hcnt64 : cnt ≤ 64) :
+    (takeBits (trimBits bitBuf cnt) cnt n).map trimTakeResult =
+      (takeBits bitBuf cnt n).map trimTakeResult := by
+  have hfield :
+      trimBits bitBuf cnt &&& (((1 : UInt64) <<< n.toUInt64) - 1) =
+        bitBuf &&& (((1 : UInt64) <<< n.toUInt64) - 1) := by
+    apply ((lowEq_trimBits bitBuf hcnt64).symm).and_eq
+    rw [mask_toNat hn64]
+    exact Nat.lt_of_lt_of_le
+      (Nat.sub_lt (n := 2 ^ n) (m := 1) (Nat.two_pow_pos n) (by omega))
+      (Nat.pow_le_pow_right (by omega) hn)
+  have hnot : ¬n > cnt := by omega
+  simp only [takeBits, if_neg hnot, Except.map, trimTakeResult]
+  rw [hfield]
+  rw [trimBits_shiftRight_congr bitBuf hcnt64 hn]
+
+theorem takeBits_ok_spec (bitBuf : UInt64) (cnt n : Nat) {v : Nat} {bb : UInt64} {c : Nat}
+    (h : takeBits bitBuf cnt n = .ok (v, bb, c)) :
+    n ≤ cnt ∧ bb = bitBuf >>> n.toUInt64 ∧ c = cnt - n := by
+  simp only [takeBits] at h
+  split at h
+  · contradiction
+  · rename_i hn
+    simp only [Except.ok.injEq, Prod.mk.injEq] at h
+    obtain ⟨rfl, rfl, rfl⟩ := h
+    exact ⟨Nat.not_lt.mp hn, rfl, rfl⟩
+
+theorem takeBits_trim_ok (bitBuf : UInt64) (cnt n : Nat) (hn : n ≤ cnt)
+    (hn64 : n < 64) (hcnt64 : cnt ≤ 64) {v : Nat} {bb : UInt64} {c : Nat}
+    (h : takeBits bitBuf cnt n = .ok (v, bb, c)) :
+    takeBits (trimBits bitBuf cnt) cnt n = .ok (v, trimBits bb c, c) := by
+  have hm := takeBits_trim bitBuf cnt n hn hn64 hcnt64
+  rw [h] at hm
+  cases hx : takeBits (trimBits bitBuf cnt) cnt n with
+  | error e => rw [hx] at hm; contradiction
+  | ok x =>
+    obtain ⟨xv, xbb, xc⟩ := x
+    rw [hx] at hm
+    simp only [Except.map, trimTakeResult, Except.ok.injEq, Prod.mk.injEq] at hm
+    obtain ⟨rfl, htrim, rfl⟩ := hm
+    obtain ⟨_, hcanon, _⟩ := takeBits_ok_spec (trimBits bitBuf cnt) cnt n hx
+    obtain ⟨_, hraw, hc⟩ := takeBits_ok_spec bitBuf cnt n h
+    rw [hcanon, hraw, hc]
+    congr 2
+    congr 2
+    exact trimBits_shiftRight bitBuf hcnt64 hn hn64
+
+theorem takeBits_trim_error (bitBuf : UInt64) (cnt n : Nat) {e : String}
+    (h : takeBits bitBuf cnt n = .error e) :
+    takeBits (trimBits bitBuf cnt) cnt n = .error e := by
+  unfold takeBits at h ⊢
+  by_cases hn : n > cnt
+  · simp only [if_pos hn] at h ⊢
+    exact h
+  · simp only [if_neg hn] at h ⊢
+    contradiction
+
+end Zip.Native.InflateBuf

--- a/ZipTest/InflateFast.lean
+++ b/ZipTest/InflateFast.lean
@@ -135,6 +135,17 @@ def ZipTest.InflateFast.checkOne (label : String) (data : ByteArray) (level : UI
     | .ok b => assert! b == refOut
     | .error e => throw (IO.userError s!"inflateSized {tag} failed on {label} (level {level}): {e}")
 
+/-- Check an already-encoded raw stream. Used for exact input-margin fixtures
+    whose compressed byte length must not depend on the compressor. -/
+def ZipTest.InflateFast.checkPayload (label : String) (compressed expected : ByteArray) : IO Unit := do
+  let refOut ← match Inflate.inflate compressed with
+    | .ok b => pure b
+    | .error e => throw (IO.userError s!"reference inflate failed on {label}: {e}")
+  assert! refOut == expected
+  match Inflate.inflateFastU compressed (sizeHint := expected.size) with
+  | .ok b => assert! b == refOut
+  | .error e => throw (IO.userError s!"inflateFastU failed on {label}: {e}")
+
 def ZipTest.InflateFast.tests : IO Unit := do
   IO.println "  InflateFast (write-once cursor spike, #2799) tests..."
   ZipTest.InflateFast.ffiConformance
@@ -144,6 +155,16 @@ def ZipTest.InflateFast.tests : IO Unit := do
   ZipTest.InflateFast.checkOne "empty" ByteArray.empty
   ZipTest.InflateFast.checkOne "single" (ByteArray.mk #[42])
   ZipTest.InflateFast.checkOne "hello" hello
+  -- Fixed-Huffman empty block (`BFINAL=1`, `BTYPE=01`, EOB=256): two input
+  -- bytes exercise the byte tail, and the eight-byte spelling checks ignored
+  -- trailing input. These intentionally stay on the cold output tail.
+  ZipTest.InflateFast.checkPayload "fixed-input<8" (ByteArray.mk #[0x03, 0x00]) ByteArray.empty
+  ZipTest.InflateFast.checkPayload "fixed-input=8"
+    (ByteArray.mk #[0x03, 0x00, 0, 0, 0, 0, 0, 0]) ByteArray.empty
+  -- Two empty fixed blocks packed without byte alignment (first non-final,
+  -- second final) cover cold-tail block-to-block cursor reconstruction.
+  ZipTest.InflateFast.checkPayload "fixed-multiblock"
+    (ByteArray.mk #[0x02, 0x0C, 0x00]) ByteArray.empty
   -- Block types across levels: stored (0), fixed/dynamic (1, 6, 9).
   for lvl in [0, 1, 6, 9] do
     ZipTest.InflateFast.checkOne s!"hello@L{lvl}" hello lvl.toUInt8
@@ -155,6 +176,22 @@ def ZipTest.InflateFast.tests : IO Unit := do
   -- Longer varied buffer (multiple dynamic blocks, long matches).
   let varied := ByteArray.mk (Array.ofFn (n := 40000) (fun i => (i.val % 251).toUInt8))
   ZipTest.InflateFast.checkOne "varied" varied
+  -- Force two dynamic Huffman blocks at an explicit token-stream midpoint.
+  -- Both sides produce far more than the 299-byte output margin, so the first
+  -- EOB returns directly from `goCurUW` after trimming speculative wide-load
+  -- bits and the block loop reconstructs the next block cursor from that state.
+  let variedTokens := Zip.Native.Deflate.lzMatch varied 6
+  assert! 2 ≤ variedTokens.size
+  let variedMulti := (Zip.Native.Deflate.emitSharedBlocksAt varied variedTokens
+    [variedTokens.size / 2] 0 Zip.Native.BitWriter.empty).flush
+  ZipTest.InflateFast.checkPayload "wide-multiblock" variedMulti varied
+  -- Sweep the input-margin transition independently of compressor output. The
+  -- larger payload takes the wide path; ignored trailing bytes move the final
+  -- `pos + 8 ≤ size` cutoff through every residue and back to the byte tail.
+  let variedCompressed ← RawDeflate.compress varied 6
+  for pad in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16] do
+    let padded := (List.range pad).foldl (fun a _ => a.push 0) variedCompressed
+    ZipTest.InflateFast.checkPayload s!"input-margin+{pad}" padded varied
   -- Margin-boundary sizes: the `uset` fastloop's per-symbol `outPos + 299 ≤
   -- output.size` guard transitions here between the hot margin body and the
   -- `< 299`-byte tail delegation to `goCur`. Sweep both sides across levels.

--- a/progress/wide-refill-2854.md
+++ b/progress/wide-refill-2854.md
@@ -1,0 +1,75 @@
+# Word-at-a-time decoder refill (#2854)
+
+## Benchmark-first result
+
+The implementation replaces `goCurU`'s recursive byte refill with one unaligned
+64-bit load and an exact byte-count update:
+
+```text
+k      := (64 - cnt) >> 3
+bitBuf |= ugetUInt64LE(data, pos) << cnt
+pos    += k
+cnt    := 64 - ((64 - cnt) & 7)
+```
+
+The update runs only behind an eight-byte input margin. The final input tail
+continues through the existing byte-at-a-time refill. Unlike the raw
+libdeflate-shaped spike, this form advances by exactly the number of bytes that
+the old loop would consume, which makes the old and new decoder states directly
+equivalent after speculative high bits are trimmed.
+
+Measurements are same-worktree `perf stat -r 5`, 40 decode repetitions per
+sample, using LTO-built binaries and Silesia level-6 raw-DEFLATE payloads. Lower
+is better.
+
+| corpus | baseline cycles | exact-wide cycles | delta | baseline instructions | exact-wide instructions | delta |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| x-ray | 7,971,160,745 | 7,556,385,788 | -5.20% | 33,885,213,053 | 34,746,232,504 | +2.54% |
+| dickens | 6,295,589,041 | 6,071,650,189 | -3.56% | 24,050,736,857 | 24,250,819,894 | +0.83% |
+| nci | 7,074,985,342 | 6,778,917,179 | -4.18% | 25,417,946,741 | 25,774,013,713 | +1.40% |
+
+All timed binaries first decoded each payload and checked it byte-for-byte
+against the reference decoder. The result is consistently cycle-positive even
+though instruction counts rise: the benefit is the shorter dependent refill
+chain, not less total work.
+
+The cycle-count relative standard deviations reported by `perf` were 0.14% /
+0.06% (baseline / exact-wide) for x-ray, 0.14% / 0.14% for dickens, and 0.25% /
+0.16% for nci. Mean application-reported throughput across the five runs was:
+
+| corpus | baseline MB/s | exact-wide MB/s | delta |
+| --- | ---: | ---: | ---: |
+| x-ray | 201.866 | 213.180 | +5.60% |
+| dickens | 309.222 | 320.314 | +3.59% |
+| nci | 932.877 | 977.273 | +4.76% |
+
+CPU frequency was not pinned; baseline and candidate were run back-to-back on
+the same host. The low `perf` variation and positive result on every corpus are
+the primary signal; throughput is included as a secondary wall-clock view.
+
+## Rejected spike
+
+The initial raw libdeflate update used `(63 - cnt) >> 3` and `cnt |= 56`. It was
+faster (-8.4%, -7.0%, and -3.9% cycles on x-ray, dickens, and nci), but it does
+not preserve the byte refiller's exact `(pos, cnt)` state. In particular, when
+`cnt` is byte-aligned it may stop at exactly 56 counted bits without advancing
+the eighth byte, whereas the old `cnt ≤ 56` refiller consumes that byte and
+stops at 64. The absolute stream bit position still agrees, but landing that
+shape would require replacing the production proof's full returned-tuple
+equality with a representation-equivalence relation through EOB cursor
+reconstruction and every block-loop caller. That larger proof/API change is
+separable from this input-margin optimization and can be re-probed alongside
+the multi-symbol work in #2856. The implementation here therefore uses the
+exact update above. An eager wide top-up (the #2630 shape) and a dynamically
+masked load were also neutral or slower controls.
+
+## Correctness shape
+
+The wide loop carries genuine future stream bits above its logical `cnt`; they
+are not arbitrary garbage. Input- and output-margin exits trim those
+speculative bits before returning to the byte refiller or `goCur`. The proof
+tracks the counted low bits, proves the 64-bit load extends them with the same
+bytes as repeated `refill`, and shows that literal, end-of-block, length, and
+distance consumption preserve the relation. The generated Huffman tables are
+also connected to the proof's maximum-code-length premise, and the proof module
+is imported by the default `Zip` build.


### PR DESCRIPTION
Closes #2854

## Summary

- replace the recursive byte refill in the `goCurU` hot path with one exact-count `ugetUInt64LE` refill behind an eight-byte input margin
- retain the byte-at-a-time tail and trim speculative high bits at input/output margin and EOB handoffs
- prove the new `goCurUW` loop equal to the existing verified decoder and include that proof in the default `Zip` build
- add input-cutoff sweeps and an explicit wide-loop multi-block cursor reconstruction test
- preserve the short-match load/store path from #2873 in the new wide loop

The wide load may read genuine lookahead bytes beyond the end of the current DEFLATE member when the enclosing archive buffer has them; the proof shows those speculative bits are trimmed and do not affect the reconstructed member cursor.

## Benchmark

Same-worktree LTO binaries at current master (`bd307beb`) and this PR, `perf stat -r 5`, 40 `decode-fast-u` repetitions per sample, Silesia level-6 raw-DEFLATE payloads:

| corpus | cycles | instructions | mean throughput |
| --- | ---: | ---: | ---: |
| x-ray | -5.20% | +2.54% | +5.60% |
| dickens | -3.56% | +0.83% | +3.59% |
| nci | -4.18% | +1.40% | +4.76% |

Cycle relative standard deviations were at most 0.25%. Full counts, throughput, and the rejected raw-spike comparison are in `progress/wide-refill-2854.md`.

## Verification

- `lake -R build` (281 targets)
- `lake -R exe test` / rebased test executable (all tests passed)
- `lake -R build Zip.Spec.InflateFastCorrect` after rebasing onto #2873 (89s for the full dependent proof on this host)
- generated C inspected: `WideRefillState` scalarizes; no hot-path constructor allocation
- no `sorry` or `axiom` introduced

## Second opinion

Claude Opus found no correctness blocker and independently traced the proof through the production dispatch. Its concrete concerns were addressed before this PR: stale docs were corrected, a hot-path multi-block fixture was added, benchmark variance and throughput were recorded, the rejected raw-spike proof difference was clarified, and unused masked-load proof helpers were removed.

After opening the PR, master advanced with #2873. The branch was rebased, its short-match dispatch was ported into `goCurUW`, the equality proof was updated, tests were rerun, and all benchmark numbers above were refreshed against that master.