### PR TITLE
fix: don't spawn probe tools that are not installed

### DIFF
--- a/bench/lakefile.lean
+++ b/bench/lakefile.lean
@@ -19,9 +19,37 @@ C-library comparators; each is auto-detected and falls back to a stub, so
 def splitFlags (s : String) : Array String :=
   s.splitOn " " |>.filter (· ≠ "") |>.toArray
 
+/-- Look `cmd` up on `PATH`, the way a shell would (keep in sync with
+    `../lakefile.lean`). -/
+def onPath (cmd : String) : IO Bool := do
+  let some path ← IO.getEnv "PATH" | return false
+  let sep := if Platform.isWindows then ";" else ":"
+  let exts := if Platform.isWindows then #["", ".exe", ".cmd", ".bat"] else #[""]
+  for dir in path.splitOn sep do
+    if dir.isEmpty then continue
+    for ext in exts do
+      let candidate : FilePath := dir / (cmd ++ ext)
+      if (← candidate.pathExists) && !(← candidate.isDir) then return true
+  return false
+
+/-- Run a probe command, reporting `none` if the tool is not installed (keep in
+    sync with `../lakefile.lean`, which explains why a missing executable must
+    never reach `IO.Process.output`: on the pinned toolchain a failed spawn
+    duplicates Lake's buffered configuration trace, and every later `lake`
+    invocation then rejects the configuration until `-R`). This package probes
+    for `cargo`, which is *expected* to be absent — the comparators fall back to
+    stubs — so it is the most exposed of the two. -/
+def tryOutput (cmd : String) (args : Array String) : IO (Option IO.Process.Output) := do
+  unless (← onPath cmd) do return none
+  match ← (IO.Process.output { cmd, args }).toBaseIO with
+  | .ok out => return some out
+  | .error e =>
+    IO.eprintln s!"warning: could not run the probe '{cmd}': {e}"
+    return none
+
 /-- Run `pkg-config` and split the output into flags. Returns `#[]` on failure. -/
 def pkgConfig (pkg : String) (flag : String) : IO (Array String) := do
-  let out ← IO.Process.output { cmd := "pkg-config", args := #[flag, pkg] }
+  let some out ← tryOutput "pkg-config" #[flag, pkg] | return #[]
   if out.exitCode != 0 then return #[]
   return splitFlags out.stdout.trimAscii.toString
 
@@ -34,14 +62,15 @@ def cHeaderProbe (header : String) : IO Bool := do
   let src := "#include <" ++ header ++ ">\nint main(void) { return 0; }\n"
   try
     IO.FS.writeFile probe src
-    let out ← IO.Process.output { cmd := "cc", args := #["-fsyntax-only", probe.toString] }
+    let some out ← tryOutput "cc" #["-fsyntax-only", probe.toString] | return false
     try IO.FS.removeFile probe catch _ => pure ()
     return out.exitCode == 0
   catch _ => return false
 
 /-- Run `xcrun --show-sdk-path` and return the SDK path on Apple platforms. -/
 def macSdkPath : IO (Option FilePath) := do
-  let out ← IO.Process.output { cmd := "xcrun", args := #["--show-sdk-path"] }
+  if !Platform.isOSX then return none
+  let some out ← tryOutput "xcrun" #["--show-sdk-path"] | return none
   if out.exitCode != 0 then
     return none
   else
@@ -121,7 +150,7 @@ def minizLdFlagsOverride : IO (Option (Array String)) := do
 def minizOxideEnabled : IO Bool := do
   if (← IO.getEnv "MINIZ_OXIDE_DISABLE").isSome then return false
   if (← IO.getEnv "MINIZ_OXIDE_LDFLAGS").isSome then return true
-  let out ← IO.Process.output { cmd := "cargo", args := #["--version"] }
+  let some out ← tryOutput "cargo" #["--version"] | return false
   return out.exitCode == 0
 
 /-- Build (or refresh) the Rust shim via `cargo build --release`. Returns
@@ -129,10 +158,8 @@ def minizOxideEnabled : IO Bool := do
 def buildMinizOxideRust : IO Bool := do
   let manifest := (← minizShimDir) / "Cargo.toml"
   unless (← manifest.pathExists) do return false
-  let out ← IO.Process.output {
-    cmd := "cargo"
-    args := #["build", "--release", "--manifest-path", manifest.toString]
-  }
+  let some out ← tryOutput "cargo" #["build", "--release", "--manifest-path", manifest.toString]
+    | return false
   if out.exitCode != 0 then
     IO.eprintln s!"warning: miniz_oxide cargo build failed:\n{out.stderr}\n\
                     miniz_oxide comparator will be disabled."

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -5,15 +5,50 @@ open System Lake DSL
 def splitFlags (s : String) : Array String :=
   s.splitOn " " |>.filter (· ≠ "") |>.toArray
 
+/-- Look `cmd` up on `PATH`, the way a shell would. -/
+def onPath (cmd : String) : IO Bool := do
+  let some path ← IO.getEnv "PATH" | return false
+  let sep := if Platform.isWindows then ";" else ":"
+  let exts := if Platform.isWindows then #["", ".exe", ".cmd", ".bat"] else #[""]
+  for dir in path.splitOn sep do
+    if dir.isEmpty then continue
+    for ext in exts do
+      let candidate : FilePath := dir / (cmd ++ ext)
+      if (← candidate.pathExists) && !(← candidate.isDir) then return true
+  return false
+
+/-- Run a probe command, reporting `none` if the tool is not installed.
+
+    We must not hand `IO.Process.output` a command that does not exist. On the
+    pinned toolchain (v4.30.0-rc2), a failed spawn duplicates whatever is
+    sitting unflushed in the parent's file buffers, and one of those buffers
+    belongs to Lake: it writes the configuration trace, then elaborates this
+    file with that write still buffered. The trace ends up holding its JSON
+    object twice, which Lake's own parser rejects, so the first `lake` command
+    in a fresh clone succeeds and every one after it fails with "compiled
+    configuration is invalid; run with '-R' to reconfigure" until you actually
+    run `-R`. That is fixed from v4.31.0-rc1 on; until we move, look the tool up
+    on `PATH` first. (`IO.Process.output` does not throw for a missing
+    executable — it reports exit code 255 — but it can still fail for other
+    reasons, hence the fallible call below.) -/
+def tryOutput (cmd : String) (args : Array String) : IO (Option IO.Process.Output) := do
+  unless (← onPath cmd) do return none
+  match ← (IO.Process.output { cmd, args }).toBaseIO with
+  | .ok out => return some out
+  | .error e =>
+    IO.eprintln s!"warning: could not run the probe '{cmd}': {e}"
+    return none
+
 /-- Run `pkg-config` and split the output into flags. Returns `#[]` on failure. -/
 def pkgConfig (pkg : String) (flag : String) : IO (Array String) := do
-  let out ← IO.Process.output { cmd := "pkg-config", args := #[flag, pkg] }
+  let some out ← tryOutput "pkg-config" #[flag, pkg] | return #[]
   if out.exitCode != 0 then return #[]
   return splitFlags out.stdout.trimAscii.toString
 
 /-- Run `xcrun --show-sdk-path` and return the SDK path on Apple platforms. -/
 def macSdkPath : IO (Option FilePath) := do
-  let out ← IO.Process.output { cmd := "xcrun", args := #["--show-sdk-path"] }
+  if !Platform.isOSX then return none
+  let some out ← tryOutput "xcrun" #["--show-sdk-path"] | return none
   if out.exitCode != 0 then
     return none
   else


### PR DESCRIPTION
This PR stops the lakefiles from handing `IO.Process.output` a command that is not installed.

The symptom: the first `lake` command in a fresh clone works, and every one after it fails.

```
$ lake resolve-deps
info: zipCommon: cloning https://github.com/kim-em/lean-zip-common
$ lake resolve-deps
error: compiled configuration is invalid; run with '-R' to reconfigure
```

That hits the root package on any machine where pkg-config cannot find zlib, because `zlibLinkFlags` then falls through to `macSdkPath`, which probes for `xcrun` — no Linux machine has one. It hits `bench/` on any machine without cargo, which is exactly the case its own module docstring says auto-detects and falls back to a stub. It also breaks downstream consumers that shell back into the project: Verso extracting a code anchor from a `require lean-zip` project runs `lake build subverso-extract-mod` inside it, which fails for the same reason.

The cause is not the probe failing, it is the *spawn* failing. On the pinned toolchain a failed spawn duplicates whatever is sitting unflushed in the parent's file buffers, and one of those buffers belongs to Lake: it writes the configuration trace, then elaborates the lakefile with that write still buffered. The trace ends up holding its JSON object two or three times over, and Lake's own parser then rejects it:

```
$ cat .lake/config/lean-zip/lakefile.olean.trace
{"platform": "x86_64-unknown-linux-gnu",
 ...
 "configHash": "23745651da196e96"}
{"platform": "x86_64-unknown-linux-gnu",
 ...
 "configHash": "23745651da196e96"}
```

Reduced to a package with no zlib in sight:

```lean
def probe : IO (Array String) := do
  let h ← IO.FS.Handle.mk "/tmp/log" .append
  h.putStrLn "ran"
  let _ ← IO.Process.output {cmd := "definitely-not-a-real-executable"}
  return #[]

package repro where
  moreLinkArgs := run_io probe
```

The probe runs once, but `/tmp/log` holds `ran` twice on v4.30.0-rc2 and once from v4.31.0-rc1 on, so this stops mattering whenever the toolchain moves. Until then, every probe goes through `tryOutput`, which looks the tool up on `PATH` and spawns it only if it is there, and `xcrun` is skipped off Apple platforms.

Also worth noting: `IO.Process.output` does *not* throw for a missing executable, it reports exit code 255. So `cHeaderProbe`'s `try/catch` never protected anything — the corruption had already happened by the time it saw the exit code. It now goes through `tryOutput` too.

Verified on NixOS outside `shell.nix` (no zlib.pc, no cargo, no xcrun): before, the second `lake` invocation fails in both packages and the bench trace accumulates three objects; after, three consecutive invocations succeed in both and every trace file holds exactly one object.

🤖 Prepared with Claude Code