### PR TITLE
bench: refresh the decode-density dashboard after decode levers A–D

### DIFF
--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mc7bef0fa12" d="M 0 0 
+       <path id="m276549be85" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc7bef0fa12" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m276549be85" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc7bef0fa12" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m276549be85" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc7bef0fa12" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m276549be85" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc7bef0fa12" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m276549be85" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc7bef0fa12" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m276549be85" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc7bef0fa12" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m276549be85" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc7bef0fa12" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m276549be85" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -895,23 +895,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 391.391504 
-L 637.2 391.391504 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 390.495497 
+L 637.2 390.495497 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m04f9f157b0" d="M 0 0 
+       <path id="m6e946c99ac" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m04f9f157b0" x="49.078125" y="391.391504" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e946c99ac" x="49.078125" y="390.495497" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 395.190723) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 394.294716) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -920,18 +920,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 265.406518 
-L 637.2 265.406518 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 265.207429 
+L 637.2 265.207429 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m04f9f157b0" x="49.078125" y="265.406518" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e946c99ac" x="49.078125" y="265.207429" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(24.478125 269.205736) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 269.006648) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -940,18 +940,18 @@ L 637.2 265.406518
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 139.421531 
-L 637.2 139.421531 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 139.91936 
+L 637.2 139.91936 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m04f9f157b0" x="49.078125" y="139.421531" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e946c99ac" x="49.078125" y="139.91936" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(24.478125 143.22075) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 143.718579) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -960,282 +960,282 @@ L 637.2 139.421531
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 410.906825 
-L 637.2 410.906825 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 409.902865 
+L 637.2 409.902865 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m36e4edeffc" d="M 0 0 
+       <path id="m831b9f1fc1" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="410.906825" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="409.902865" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 403.600711 
-L 637.2 403.600711 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 402.637166 
+L 637.2 402.637166 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="403.600711" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="402.637166" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 397.156261 
-L 637.2 397.156261 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 396.228365 
+L 637.2 396.228365 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="397.156261" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="396.228365" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 353.466244 
-L 637.2 353.466244 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 352.780031 
+L 637.2 352.780031 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="353.466244" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="352.780031" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 331.281389 
-L 637.2 331.281389 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 330.717897 
+L 637.2 330.717897 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="331.281389" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="330.717897" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 315.540984 
-L 637.2 315.540984 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 315.064564 
+L 637.2 315.064564 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="315.540984" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="315.064564" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 303.331778 
-L 637.2 303.331778 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 302.922896 
+L 637.2 302.922896 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="303.331778" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="302.922896" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 293.356129 
-L 637.2 293.356129 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 293.00243 
+L 637.2 293.00243 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="293.356129" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="293.00243" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 284.921839 
-L 637.2 284.921839 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 284.614796 
+L 637.2 284.614796 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="284.921839" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="284.614796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 277.615724 
-L 637.2 277.615724 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 277.349097 
+L 637.2 277.349097 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="277.615724" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="277.349097" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 271.171274 
-L 637.2 271.171274 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 270.940296 
+L 637.2 270.940296 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="271.171274" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="270.940296" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 227.481258 
-L 637.2 227.481258 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 227.491962 
+L 637.2 227.491962 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="227.481258" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="227.491962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 205.296403 
-L 637.2 205.296403 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 205.429828 
+L 637.2 205.429828 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="205.296403" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="205.429828" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 189.555998 
-L 637.2 189.555998 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 189.776495 
+L 637.2 189.776495 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="189.555998" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="189.776495" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 177.346791 
-L 637.2 177.346791 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 177.634827 
+L 637.2 177.634827 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="177.346791" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="177.634827" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 167.371143 
-L 637.2 167.371143 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 167.714362 
+L 637.2 167.714362 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="167.371143" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="167.714362" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 158.936853 
-L 637.2 158.936853 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 159.326728 
+L 637.2 159.326728 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="158.936853" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="159.326728" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 151.630738 
-L 637.2 151.630738 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 152.061029 
+L 637.2 152.061029 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="151.630738" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="152.061029" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 145.186288 
-L 637.2 145.186288 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 145.652228 
+L 637.2 145.652228 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="145.186288" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="145.652228" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 101.496271 
-L 637.2 101.496271 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 102.203894 
+L 637.2 102.203894 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="101.496271" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="102.203894" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 79.311416 
-L 637.2 79.311416 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 80.14176 
+L 637.2 80.14176 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="79.311416" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="80.14176" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 63.571011 
-L 637.2 63.571011 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 64.488427 
+L 637.2 64.488427 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="63.571011" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="64.488427" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 51.361805 
-L 637.2 51.361805 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 52.346759 
+L 637.2 52.346759 
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m36e4edeffc" x="49.078125" y="51.361805" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m831b9f1fc1" x="49.078125" y="52.346759" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#pc536a1a760)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p6ea05c86c1)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="mbdabb83623" d="M -2.5 2.5 
+     <path id="m8eb26d8194" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc536a1a760)">
-     <use xlink:href="#mbdabb83623" x="75.810937" y="262.971979" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdabb83623" x="105.634056" y="268.971577" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdabb83623" x="204.490635" y="301.738921" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdabb83623" x="234.479899" y="306.528998" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdabb83623" x="242.537956" y="315.114509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdabb83623" x="300.771958" y="297.804449" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdabb83623" x="303.26414" y="308.905974" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdabb83623" x="304.261013" y="318.530644" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdabb83623" x="313.897453" y="318.845042" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdabb83623" x="414.166268" y="335.064122" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdabb83623" x="587.289889" y="328.026168" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdabb83623" x="610.467187" y="318.943936" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6ea05c86c1)">
+     <use xlink:href="#m8eb26d8194" x="75.810937" y="262.280765" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8eb26d8194" x="105.634056" y="272.021677" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8eb26d8194" x="204.490635" y="301.275466" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8eb26d8194" x="234.479899" y="308.620709" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8eb26d8194" x="242.537956" y="315.441307" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8eb26d8194" x="300.771958" y="297.936101" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8eb26d8194" x="303.26414" y="309.305313" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8eb26d8194" x="304.261013" y="318.123955" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8eb26d8194" x="313.897453" y="318.34312" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8eb26d8194" x="414.166268" y="334.444732" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8eb26d8194" x="587.289889" y="327.882059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8eb26d8194" x="610.467187" y="319.108432" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="m40e887b6af" d="M 0 -2.5 
+     <path id="m622e3f5b2c" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc536a1a760)">
-     <use xlink:href="#m40e887b6af" x="75.810937" y="263.076222" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40e887b6af" x="105.634056" y="255.90115" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40e887b6af" x="204.490635" y="299.055066" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40e887b6af" x="234.479899" y="297.649373" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40e887b6af" x="242.537956" y="306.959943" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40e887b6af" x="300.771958" y="287.091113" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40e887b6af" x="303.26414" y="299.68614" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40e887b6af" x="304.261013" y="314.402537" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40e887b6af" x="313.897453" y="306.75453" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40e887b6af" x="414.166268" y="325.079029" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40e887b6af" x="587.289889" y="327.770713" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40e887b6af" x="610.467187" y="317.262571" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6ea05c86c1)">
+     <use xlink:href="#m622e3f5b2c" x="75.810937" y="261.817136" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m622e3f5b2c" x="105.634056" y="256.535885" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m622e3f5b2c" x="204.490635" y="299.187582" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m622e3f5b2c" x="234.479899" y="298.269756" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m622e3f5b2c" x="242.537956" y="304.976587" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m622e3f5b2c" x="300.771958" y="286.311421" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m622e3f5b2c" x="303.26414" y="298.710113" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m622e3f5b2c" x="304.261013" y="313.291378" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m622e3f5b2c" x="313.897453" y="305.918146" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m622e3f5b2c" x="414.166268" y="324.381694" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m622e3f5b2c" x="587.289889" y="326.968699" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m622e3f5b2c" x="610.467187" y="317.1386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m9e4a21ba4b" d="M -0 3.535534 
+     <path id="m8ad9c0f0e8" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc536a1a760)">
-     <use xlink:href="#m9e4a21ba4b" x="75.810937" y="230.59646" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e4a21ba4b" x="105.634056" y="232.493417" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e4a21ba4b" x="204.490635" y="259.843592" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e4a21ba4b" x="234.479899" y="261.613147" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e4a21ba4b" x="242.537956" y="273.024926" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e4a21ba4b" x="300.771958" y="259.982157" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e4a21ba4b" x="303.26414" y="270.115206" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e4a21ba4b" x="304.261013" y="281.39919" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e4a21ba4b" x="313.897453" y="276.610068" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e4a21ba4b" x="414.166268" y="296.031271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e4a21ba4b" x="587.289889" y="300.918176" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e4a21ba4b" x="610.467187" y="296.657281" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6ea05c86c1)">
+     <use xlink:href="#m8ad9c0f0e8" x="75.810937" y="229.846524" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ad9c0f0e8" x="105.634056" y="233.689308" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ad9c0f0e8" x="204.490635" y="260.026861" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ad9c0f0e8" x="234.479899" y="265.455568" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ad9c0f0e8" x="242.537956" y="272.493031" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ad9c0f0e8" x="300.771958" y="259.829831" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ad9c0f0e8" x="303.26414" y="269.992759" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ad9c0f0e8" x="304.261013" y="280.794782" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ad9c0f0e8" x="313.897453" y="280.03635" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ad9c0f0e8" x="414.166268" y="296.378838" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ad9c0f0e8" x="587.289889" y="300.979597" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ad9c0f0e8" x="610.467187" y="300.003451" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m0c494910b7" d="M -0.833333 2.5 
+     <path id="md1442f94c6" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc536a1a760)">
-     <use xlink:href="#m0c494910b7" x="75.810937" y="287.254821" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c494910b7" x="105.634056" y="295.026453" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c494910b7" x="204.490635" y="327.112732" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c494910b7" x="234.479899" y="338.552081" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c494910b7" x="242.537956" y="341.70534" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c494910b7" x="300.771958" y="337.149594" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c494910b7" x="303.26414" y="345.326641" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c494910b7" x="304.261013" y="345.180667" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c494910b7" x="313.897453" y="352.024527" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c494910b7" x="414.166268" y="363.66119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c494910b7" x="587.289889" y="368.471144" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c494910b7" x="610.467187" y="357.413391" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6ea05c86c1)">
+     <use xlink:href="#md1442f94c6" x="75.810937" y="286.936495" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1442f94c6" x="105.634056" y="293.803621" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1442f94c6" x="204.490635" y="325.769841" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1442f94c6" x="234.479899" y="338.049967" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1442f94c6" x="242.537956" y="340.935171" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1442f94c6" x="300.771958" y="335.911343" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1442f94c6" x="303.26414" y="344.38851" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1442f94c6" x="304.261013" y="345.111478" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1442f94c6" x="313.897453" y="350.411028" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1442f94c6" x="414.166268" y="362.050364" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1442f94c6" x="587.289889" y="367.377207" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1442f94c6" x="610.467187" y="356.506866" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="ma43fd9f10f" d="M -1.25 2.5 
+     <path id="m7f26574617" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc536a1a760)">
-     <use xlink:href="#ma43fd9f10f" x="75.810937" y="328.485204" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma43fd9f10f" x="105.634056" y="343.242663" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma43fd9f10f" x="204.490635" y="363.221291" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma43fd9f10f" x="234.479899" y="371.61527" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma43fd9f10f" x="242.537956" y="367.568107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma43fd9f10f" x="300.771958" y="360.429515" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma43fd9f10f" x="303.26414" y="374.922792" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma43fd9f10f" x="304.261013" y="357.888852" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma43fd9f10f" x="313.897453" y="374.829737" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma43fd9f10f" x="414.166268" y="385.151704" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma43fd9f10f" x="587.289889" y="394.353721" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma43fd9f10f" x="610.467187" y="391.304031" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6ea05c86c1)">
+     <use xlink:href="#m7f26574617" x="75.810937" y="327.593592" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f26574617" x="105.634056" y="340.570933" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f26574617" x="204.490635" y="362.627633" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f26574617" x="234.479899" y="370.858995" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f26574617" x="242.537956" y="367.985407" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f26574617" x="300.771958" y="358.779564" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f26574617" x="303.26414" y="373.533108" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f26574617" x="304.261013" y="364.779055" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f26574617" x="313.897453" y="376.855469" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f26574617" x="414.166268" y="384.072189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f26574617" x="587.289889" y="391.605871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f26574617" x="610.467187" y="389.722918" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="mdc5ff6ef3d" d="M 0 -2.5 
+     <path id="m096185fb25" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pc536a1a760)">
-     <use xlink:href="#mdc5ff6ef3d" x="75.810937" y="275.140642" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc5ff6ef3d" x="105.634056" y="287.451755" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc5ff6ef3d" x="204.490635" y="320.461177" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc5ff6ef3d" x="234.479899" y="322.023234" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc5ff6ef3d" x="242.537956" y="326.70359" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc5ff6ef3d" x="300.771958" y="333.752941" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc5ff6ef3d" x="303.26414" y="337.610376" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc5ff6ef3d" x="304.261013" y="346.32109" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc5ff6ef3d" x="313.897453" y="337.416212" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc5ff6ef3d" x="414.166268" y="357.885886" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc5ff6ef3d" x="587.289889" y="366.613596" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc5ff6ef3d" x="610.467187" y="361.271752" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p6ea05c86c1)">
+     <use xlink:href="#m096185fb25" x="75.810937" y="274.913716" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m096185fb25" x="105.634056" y="287.832087" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m096185fb25" x="204.490635" y="320.732478" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m096185fb25" x="234.479899" y="322.13783" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m096185fb25" x="242.537956" y="326.391089" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m096185fb25" x="300.771958" y="332.86924" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m096185fb25" x="303.26414" y="337.020019" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m096185fb25" x="304.261013" y="346.57232" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m096185fb25" x="313.897453" y="336.426587" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m096185fb25" x="414.166268" y="358.022386" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m096185fb25" x="587.289889" y="368.6114" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m096185fb25" x="610.467187" y="359.237143" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m3fd8a222f0" d="M 0 -2.5 
+     <path id="m77546224f9" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc536a1a760)">
-     <use xlink:href="#m3fd8a222f0" x="75.810937" y="347.721735" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3fd8a222f0" x="105.634056" y="349.23256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3fd8a222f0" x="204.490635" y="367.638954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3fd8a222f0" x="234.479899" y="373.291186" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3fd8a222f0" x="242.537956" y="380.180589" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3fd8a222f0" x="300.771958" y="370.816834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3fd8a222f0" x="303.26414" y="375.607345" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3fd8a222f0" x="304.261013" y="383.176511" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3fd8a222f0" x="313.897453" y="385.337526" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3fd8a222f0" x="414.166268" y="391.698767" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3fd8a222f0" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3fd8a222f0" x="610.467187" y="383.849259" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6ea05c86c1)">
+     <use xlink:href="#m77546224f9" x="75.810937" y="345.353035" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77546224f9" x="105.634056" y="351.425842" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77546224f9" x="204.490635" y="366.614113" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77546224f9" x="234.479899" y="372.043785" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77546224f9" x="242.537956" y="379.939419" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77546224f9" x="300.771958" y="368.187254" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77546224f9" x="303.26414" y="374.057516" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77546224f9" x="304.261013" y="382.110973" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77546224f9" x="313.897453" y="384.309637" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77546224f9" x="414.166268" y="389.937921" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77546224f9" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77546224f9" x="610.467187" y="384.023857" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m48cf28ecd0" d="M 0 3.5 
+      <path id="m2eb04e486b" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m48cf28ecd0" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m2eb04e486b" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#mbdabb83623" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8eb26d8194" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#m40e887b6af" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m622e3f5b2c" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m9e4a21ba4b" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8ad9c0f0e8" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m0c494910b7" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md1442f94c6" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#ma43fd9f10f" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7f26574617" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#mdc5ff6ef3d" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m096185fb25" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m3fd8a222f0" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m77546224f9" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#pc536a1a760)">
-     <use xlink:href="#m48cf28ecd0" x="75.810937" y="272.805883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m48cf28ecd0" x="105.634056" y="288.299011" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m48cf28ecd0" x="204.490635" y="322.298027" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m48cf28ecd0" x="234.479899" y="322.158915" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m48cf28ecd0" x="242.537956" y="323.1245" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m48cf28ecd0" x="300.771958" y="312.493664" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m48cf28ecd0" x="303.26414" y="331.266801" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m48cf28ecd0" x="304.261013" y="352.259514" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m48cf28ecd0" x="313.897453" y="335.009427" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m48cf28ecd0" x="414.166268" y="356.246824" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m48cf28ecd0" x="587.289889" y="359.544989" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m48cf28ecd0" x="610.467187" y="342.050655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p6ea05c86c1)">
+     <use xlink:href="#m2eb04e486b" x="75.810937" y="267.508608" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2eb04e486b" x="105.634056" y="284.266125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2eb04e486b" x="204.490635" y="317.072223" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2eb04e486b" x="234.479899" y="315.987833" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2eb04e486b" x="242.537956" y="316.801902" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2eb04e486b" x="300.771958" y="304.613907" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2eb04e486b" x="303.26414" y="319.440589" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2eb04e486b" x="304.261013" y="345.846576" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2eb04e486b" x="313.897453" y="327.206232" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2eb04e486b" x="414.166268" y="346.969409" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2eb04e486b" x="587.289889" y="348.070973" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2eb04e486b" x="610.467187" y="333.312571" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2892,9 +2892,40 @@ z
    </g>
   </g>
   <g id="text_24">
-   <!-- 2026-07-18T17:07:56Z  ·  Linux chungus2 x86_64  ·  commit 3f5fffbd  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median-of-5; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(56.445781 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-25T13:56:45Z  ·  Linux chungus2 x86_64  ·  commit 486a77db  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median-of-5; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(52.54875 465.66) scale(0.07 -0.07)">
     <defs>
+     <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -2934,37 +2965,6 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-54" d="M -19 4666 
-L 3928 4666 
-L 3928 4134 
-L 2272 4134 
-L 2272 0 
-L 1638 0 
-L 1638 4134 
-L -19 4134 
-L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-3a" d="M 750 794 
-L 1409 794 
-L 1409 0 
-L 750 0 
-L 750 794 
-z
-M 750 3309 
-L 1409 3309 
-L 1409 2516 
-L 750 2516 
-L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-b7" d="M 684 2619 
-L 1344 2619 
-L 1344 1825 
-L 684 1825 
-L 684 2619 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -3002,17 +3002,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3052,105 +3052,105 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3269.53125 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3304.736328 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3339.941406 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3403.417969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3466.894531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3498.681641 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3530.46875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3562.255859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3594.042969 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3625.830078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3653.613281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3715.136719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3776.416016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3839.794922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3903.271484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3942.134766 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4003.316406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4062.496094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4124.019531 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4165.132812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4198.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4226.607422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4288.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4349.410156 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4412.789062 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4476.412109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4510.103516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4569.283203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4632.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4664.693359 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4728.316406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4791.939453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4823.726562 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4887.349609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4923.433594 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4962.296875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5017.277344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5080.900391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5112.6875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5144.474609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5176.261719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5208.048828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5239.835938 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5279.044922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5342.423828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5381.287109 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5442.46875 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5505.847656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5569.324219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5632.703125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5696.179688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5759.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5798.767578 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5830.554688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5914.34375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5946.130859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6043.542969 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6105.066406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6168.542969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6196.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6257.605469 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(6320.984375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6358.943359 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(6420.125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(6449.830078 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(6485.914062 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6549.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6583.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6615.015625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6656.128906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6717.408203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6756.617188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6784.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6845.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6877.369141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6905.152344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6957.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6989.039062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7052.515625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7114.039062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7153.248047 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7214.771484 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7254.134766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7351.546875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7379.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7442.708984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7470.492188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7522.591797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7561.800781 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7589.583984 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.222656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.009766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.796875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.158203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3764.941406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.744141 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.123047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.462891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.644531 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4173.824219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.347656 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.152344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4337.935547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.458984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.738281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.117188 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.740234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.431641 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.611328 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.234375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.021484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.644531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.267578 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.054688 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.677734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5034.761719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.605469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.228516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.015625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.802734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.589844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.376953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.164062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.373047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5453.751953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.615234 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5553.796875 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.175781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.652344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.03125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.507812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5870.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.095703 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5941.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.458984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6154.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.394531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6279.871094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.654297 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6368.933594 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(6432.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6470.271484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(6531.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(6561.158203 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(6597.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6660.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6694.556641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6726.34375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6767.457031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6828.736328 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6867.945312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6895.728516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.910156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6988.697266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7016.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7068.580078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7100.367188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7163.84375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7225.367188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7264.576172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7326.099609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7365.462891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7462.875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7490.658203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7554.037109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7581.820312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7633.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7673.128906 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7700.912109 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc536a1a760">
+  <clipPath id="p6ea05c86c1">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -40,23 +40,23 @@ z
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 292.132019 308.04375 
-L 292.132019 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 291.975555 308.04375 
+L 291.975555 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m2fd78597e6" d="M 0 0 
+       <path id="m5a428274c3" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2fd78597e6" x="292.132019" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5a428274c3" x="291.975555" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(283.332019 322.642188) scale(0.1 -0.1)">
+      <g transform="translate(283.175555 322.642188) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -134,18 +134,18 @@ z
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 449.712908 308.04375 
-L 449.712908 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 449.186855 308.04375 
+L 449.186855 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2fd78597e6" x="449.712908" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5a428274c3" x="449.186855" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(440.912908 322.642188) scale(0.1 -0.1)">
+      <g transform="translate(440.386855 322.642188) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -175,246 +175,246 @@ z
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 181.987704 308.04375 
-L 181.987704 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 182.089572 308.04375 
+L 182.089572 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m86c12b2678" d="M 0 0 
+       <path id="m3c2d129915" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m86c12b2678" x="181.987704" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="182.089572" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 209.736321 308.04375 
-L 209.736321 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 209.773107 308.04375 
+L 209.773107 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m86c12b2678" x="209.736321" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="209.773107" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 229.424278 308.04375 
-L 229.424278 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 229.414889 308.04375 
+L 229.414889 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m86c12b2678" x="229.424278" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="229.414889" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 244.695444 308.04375 
-L 244.695444 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 244.650238 308.04375 
+L 244.650238 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m86c12b2678" x="244.695444" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="244.650238" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
-      <path d="M 257.172895 308.04375 
-L 257.172895 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 257.098424 308.04375 
+L 257.098424 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m86c12b2678" x="257.172895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="257.098424" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_15">
-      <path d="M 267.72243 308.04375 
-L 267.72243 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 267.623216 308.04375 
+L 267.623216 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m86c12b2678" x="267.72243" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="267.623216" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_17">
-      <path d="M 276.860853 308.04375 
-L 276.860853 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 276.740206 308.04375 
+L 276.740206 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m86c12b2678" x="276.860853" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="276.740206" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_19">
-      <path d="M 284.921513 308.04375 
-L 284.921513 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 284.78196 308.04375 
+L 284.78196 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m86c12b2678" x="284.921513" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="284.78196" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_21">
-      <path d="M 339.568593 308.04375 
-L 339.568593 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 339.300872 308.04375 
+L 339.300872 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m86c12b2678" x="339.568593" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="339.300872" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_23">
-      <path d="M 367.31721 308.04375 
-L 367.31721 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 366.984408 308.04375 
+L 366.984408 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m86c12b2678" x="367.31721" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="366.984408" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_25">
-      <path d="M 387.005168 308.04375 
-L 387.005168 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 386.626189 308.04375 
+L 386.626189 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m86c12b2678" x="387.005168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="386.626189" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_27">
-      <path d="M 402.276334 308.04375 
-L 402.276334 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 401.861538 308.04375 
+L 401.861538 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m86c12b2678" x="402.276334" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="401.861538" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_29">
-      <path d="M 414.753785 308.04375 
-L 414.753785 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 414.309725 308.04375 
+L 414.309725 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m86c12b2678" x="414.753785" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="414.309725" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_31">
-      <path d="M 425.30332 308.04375 
-L 425.30332 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 424.834517 308.04375 
+L 424.834517 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m86c12b2678" x="425.30332" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="424.834517" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_33">
-      <path d="M 434.441742 308.04375 
-L 434.441742 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 433.951506 308.04375 
+L 433.951506 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m86c12b2678" x="434.441742" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="433.951506" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_35">
-      <path d="M 442.502402 308.04375 
-L 442.502402 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 441.993261 308.04375 
+L 441.993261 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m86c12b2678" x="442.502402" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="441.993261" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_37">
-      <path d="M 497.149483 308.04375 
-L 497.149483 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 496.512172 308.04375 
+L 496.512172 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m86c12b2678" x="497.149483" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="496.512172" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_39">
-      <path d="M 524.8981 308.04375 
-L 524.8981 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 524.195708 308.04375 
+L 524.195708 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m86c12b2678" x="524.8981" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="524.195708" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
      <g id="line2d_41">
-      <path d="M 544.586057 308.04375 
-L 544.586057 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 543.837489 308.04375 
+L 543.837489 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m86c12b2678" x="544.586057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="543.837489" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_22">
      <g id="line2d_43">
-      <path d="M 559.857223 308.04375 
-L 559.857223 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 559.072838 308.04375 
+L 559.072838 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m86c12b2678" x="559.857223" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3c2d129915" x="559.072838" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1016,12 +1016,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m717158ed72" d="M 0 0 
+       <path id="md52859a1e9" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m717158ed72" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md52859a1e9" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1093,7 +1093,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m717158ed72" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md52859a1e9" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1160,7 +1160,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m717158ed72" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md52859a1e9" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1216,7 +1216,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m717158ed72" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md52859a1e9" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1263,7 +1263,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m717158ed72" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md52859a1e9" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1376,7 +1376,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m717158ed72" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md52859a1e9" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1392,7 +1392,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m717158ed72" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md52859a1e9" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1439,7 +1439,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m717158ed72" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md52859a1e9" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1461,48 +1461,48 @@ z
    </g>
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
-L 154.631635 296.619375 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 154.595818 296.619375 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
-L 161.123387 263.978304 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 162.764999 263.978304 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
-L 200.598286 231.337232 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 201.002917 231.337232 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
-L 208.365024 198.696161 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 208.044998 198.696161 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
-L 214.058201 166.055089 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+L 222.745964 166.055089 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
-L 240.815684 133.414018 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 240.181892 133.414018 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
-L 248.956282 100.772946 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 248.88703 100.772946 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
-L 286.395117 68.131875 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 285.100783 68.131875 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
-    <path d="M 542.173014 308.04375 
-L 542.173014 56.7075 
-" clip-path="url(#p28f055918f)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+    <path d="M 542.227022 308.04375 
+L 542.227022 56.7075 
+" clip-path="url(#pa3b879b41e)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1526,35 +1526,50 @@ L 565.2 56.7075
    </g>
    <g id="text_12">
     <!-- 134 -->
-    <g style="fill: #17becf" transform="translate(157.970663 298.964844) scale(0.085 -0.085)">
+    <g style="fill: #17becf" transform="translate(157.927015 298.964844) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_13">
-    <!-- 147 -->
-    <g style="fill: #e377c2" transform="translate(164.462416 266.323772) scale(0.085 -0.085)">
+    <!-- 151 -->
+    <g style="fill: #e377c2" transform="translate(166.096197 266.323772) scale(0.085 -0.085)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_14">
-    <!-- 263 -->
-    <g style="fill: #8c564b" transform="translate(203.937315 233.682701) scale(0.085 -0.085)">
+    <!-- 264 -->
+    <g style="fill: #8c564b" transform="translate(204.334114 233.682701) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -1613,12 +1628,12 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_15">
-    <!-- 294 -->
-    <g style="fill: #bcbd22" transform="translate(211.704053 201.041629) scale(0.085 -0.085)">
+    <!-- 293 -->
+    <g style="fill: #bcbd22" transform="translate(211.376196 201.041629) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1653,12 +1668,12 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_16">
-    <!-- 320 -->
-    <g style="fill: #d62728" transform="translate(217.39723 168.400558) scale(0.085 -0.085)">
+    <!-- 363 -->
+    <g style="fill: #d62728" transform="translate(226.077161 168.400558) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-Bold-33" d="M 2981 2516 
 Q 3453 2394 3698 2092 
@@ -1692,109 +1707,110 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-32" d="M 1844 884 
-L 3897 884 
-L 3897 0 
-L 506 0 
-L 506 884 
-L 2209 2388 
-Q 2438 2594 2547 2791 
-Q 2656 2988 2656 3200 
-Q 2656 3528 2436 3728 
-Q 2216 3928 1850 3928 
-Q 1569 3928 1234 3808 
-Q 900 3688 519 3450 
-L 519 4475 
-Q 925 4609 1322 4679 
-Q 1719 4750 2100 4750 
-Q 2938 4750 3402 4381 
-Q 3866 4013 3866 3353 
-Q 3866 2972 3669 2642 
-Q 3472 2313 2841 1759 
-L 1844 884 
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
 z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-30" d="M 2944 2338 
-Q 2944 3213 2780 3570 
-Q 2616 3928 2228 3928 
-Q 1841 3928 1675 3570 
-Q 1509 3213 1509 2338 
-Q 1509 1453 1675 1090 
-Q 1841 728 2228 728 
-Q 2613 728 2778 1090 
-Q 2944 1453 2944 2338 
-z
-M 4147 2328 
-Q 4147 1169 3647 539 
-Q 3147 -91 2228 -91 
-Q 1306 -91 806 539 
-Q 306 1169 306 2328 
-Q 306 3491 806 4120 
-Q 1306 4750 2228 4750 
-Q 3147 4750 3647 4120 
-Q 4147 3491 4147 2328 
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_17">
-    <!-- 472 -->
-    <g style="fill: #1f77b4" transform="translate(244.154712 135.759487) scale(0.085 -0.085)">
+    <!-- 468 -->
+    <g style="fill: #1f77b4" transform="translate(243.51309 135.759487) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_18">
     <!-- 532 -->
-    <g style="fill: #2ca02c" transform="translate(252.295311 103.118415) scale(0.085 -0.085)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g style="fill: #2ca02c" transform="translate(252.218227 103.118415) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_19">
-    <!-- 920 -->
-    <g style="fill: #9467bd" transform="translate(289.734146 70.477344) scale(0.085 -0.085)">
+    <!-- 904 -->
+    <g style="fill: #9467bd" transform="translate(288.43198 70.477344) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- memcpy ≈ 39 GB/s  -->
-    <g style="fill: #777777" transform="translate(540.509264 128.870982) rotate(-90) scale(0.08 -0.08)">
+    <g style="fill: #777777" transform="translate(540.563272 128.870982) rotate(-90) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-79" d="M 2059 -325 
 Q 1816 -950 1584 -1140 
@@ -1876,7 +1892,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m171d329979" d="M 0 3 
+     <path id="mac7f2ad575" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1888,13 +1904,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p28f055918f)">
-     <use xlink:href="#m171d329979" x="154.631635" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#pa3b879b41e)">
+     <use xlink:href="#mac7f2ad575" x="154.595818" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="mb0074303fb" d="M 0 3 
+     <path id="m5762383de4" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1906,13 +1922,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p28f055918f)">
-     <use xlink:href="#mb0074303fb" x="161.123387" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#pa3b879b41e)">
+     <use xlink:href="#m5762383de4" x="162.764999" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m1caa02334b" d="M 0 3 
+     <path id="m6f311c908d" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1924,13 +1940,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p28f055918f)">
-     <use xlink:href="#m1caa02334b" x="200.598286" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#pa3b879b41e)">
+     <use xlink:href="#m6f311c908d" x="201.002917" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m9ae26c2ddf" d="M 0 3 
+     <path id="m7950f8a713" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1942,13 +1958,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p28f055918f)">
-     <use xlink:href="#m9ae26c2ddf" x="208.365024" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#pa3b879b41e)">
+     <use xlink:href="#m7950f8a713" x="208.044998" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m9dc40055d5" d="M 0 5 
+     <path id="m674bcb3b9e" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1960,13 +1976,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p28f055918f)">
-     <use xlink:href="#m9dc40055d5" x="214.058201" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#pa3b879b41e)">
+     <use xlink:href="#m674bcb3b9e" x="222.745964" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="me5fbb10687" d="M 0 3 
+     <path id="m24ec0f1b87" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1978,13 +1994,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p28f055918f)">
-     <use xlink:href="#me5fbb10687" x="240.815684" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pa3b879b41e)">
+     <use xlink:href="#m24ec0f1b87" x="240.181892" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="mf7ecf488ea" d="M 0 3 
+     <path id="m0564790641" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1996,13 +2012,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p28f055918f)">
-     <use xlink:href="#mf7ecf488ea" x="248.956282" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#pa3b879b41e)">
+     <use xlink:href="#m0564790641" x="248.88703" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m479612941f" d="M 0 3 
+     <path id="mf7a6e614c8" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2014,8 +2030,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p28f055918f)">
-     <use xlink:href="#m479612941f" x="286.395117" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#pa3b879b41e)">
+     <use xlink:href="#mf7a6e614c8" x="285.100783" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2500,36 +2516,6 @@ L 0 -594
 L 1644 4666 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
 Q 928 831 1190 764 
@@ -2558,6 +2544,28 @@ Q 1809 3988 1650 3781
 Q 1491 3575 1491 3169 
 Q 1491 2759 1650 2554 
 Q 1809 2350 2125 2350 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Bold-2b" d="M 3053 4013 
@@ -2715,46 +2723,17 @@ z
    </g>
   </g>
   <g id="text_22">
-   <!-- 2026-07-18T17:07:56Z  ·  Linux chungus2 x86_64  ·  commit 3f5fffbd  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median-of-5; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(20.445781 358.2) scale(0.07 -0.07)">
+   <!-- 2026-07-25T13:56:45Z  ·  Linux chungus2 x86_64  ·  commit 486a77db  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median-of-5; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.54875 358.2) scale(0.07 -0.07)">
     <defs>
-     <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
@@ -2834,17 +2813,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2884,105 +2863,105 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3269.53125 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3304.736328 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3339.941406 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3403.417969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3466.894531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3498.681641 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3530.46875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3562.255859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3594.042969 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3625.830078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3653.613281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3715.136719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3776.416016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3839.794922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3903.271484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3942.134766 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4003.316406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4062.496094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4124.019531 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4165.132812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4198.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4226.607422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4288.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4349.410156 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4412.789062 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4476.412109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4510.103516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4569.283203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4632.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4664.693359 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4728.316406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4791.939453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4823.726562 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4887.349609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4923.433594 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4962.296875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5017.277344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5080.900391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5112.6875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5144.474609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5176.261719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5208.048828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5239.835938 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5279.044922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5342.423828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5381.287109 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5442.46875 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5505.847656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5569.324219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5632.703125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5696.179688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5759.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5798.767578 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5830.554688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5914.34375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5946.130859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6043.542969 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6105.066406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6168.542969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6196.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6257.605469 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(6320.984375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6358.943359 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(6420.125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(6449.830078 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(6485.914062 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6549.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6583.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6615.015625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6656.128906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6717.408203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6756.617188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6784.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6845.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6877.369141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6905.152344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6957.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6989.039062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7052.515625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7114.039062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7153.248047 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7214.771484 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7254.134766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7351.546875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7379.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7442.708984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7470.492188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7522.591797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7561.800781 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7589.583984 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.222656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.009766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.796875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.158203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3764.941406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.744141 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.123047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.462891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.644531 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4173.824219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.347656 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.152344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4337.935547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.458984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.738281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.117188 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.740234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.431641 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.611328 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.234375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.021484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.644531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.267578 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.054688 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.677734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5034.761719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.605469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.228516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.015625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.802734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.589844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.376953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.164062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.373047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5453.751953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.615234 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5553.796875 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.175781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.652344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.03125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.507812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5870.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.095703 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5941.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.458984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6154.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.394531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6279.871094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.654297 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6368.933594 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(6432.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6470.271484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(6531.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(6561.158203 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(6597.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6660.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6694.556641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6726.34375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6767.457031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6828.736328 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6867.945312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6895.728516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.910156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6988.697266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7016.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7068.580078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7100.367188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7163.84375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7225.367188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7264.576172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7326.099609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7365.462891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7462.875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7490.658203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7554.037109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7581.820312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7633.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7673.128906 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7700.912109 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p28f055918f">
+  <clipPath id="pa3b879b41e">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/results/decode_density.json
+++ b/bench/results/decode_density.json
@@ -1,12 +1,11 @@
 {
 "meta": {
-"date": "2026-07-18T17:07:56Z",
+"date": "2026-07-25T13:56:45Z",
 "machine": "Linux chungus2 x86_64",
-"git_commit": "3f5fffbd",
+"git_commit": "486a77db",
 "toolchain": "leanprover/lean4:v4.30.0-rc2",
 "timing_aggregation": "median",
 "timing_reps": 5,
-"timing_provenance": "Schema backfill only; measurement rows are unchanged. At the recorded producer revision, runDecodeDensity passed reps=5 to measureNs for every in-process measurement, while each merged Go/JS/Zig/OCaml decoder ran five timing samples and selected the median.",
 "experiment": "decode-density: fixed encoder (libdeflate levels + zopfli, level 0 = zopfli), ratio = encoder compression ratio, decompress_mbps = each decoder on identical streams; compressor field holds the decoder name"
 },
 "results": [
@@ -18,7 +17,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 224.28
+"decompress_mbps": 258.21
 },
 {
 "compressor": "zlib",
@@ -28,7 +27,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 386.5
+"decompress_mbps": 384.19
 },
 {
 "compressor": "miniz_oxide",
@@ -38,7 +37,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 449.31
+"decompress_mbps": 458.48
 },
 {
 "compressor": "libdeflate",
@@ -48,7 +47,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 777.75
+"decompress_mbps": 771.45
 },
 {
 "compressor": "memcpy",
@@ -58,7 +57,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 44782.95
+"decompress_mbps": 56577.36
 },
 {
 "compressor": "native",
@@ -68,7 +67,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 285.79
+"decompress_mbps": 330.71
 },
 {
 "compressor": "zlib",
@@ -78,7 +77,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 394.17
+"decompress_mbps": 392.0
 },
 {
 "compressor": "miniz_oxide",
@@ -88,7 +87,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 490.83
+"decompress_mbps": 491.0
 },
 {
 "compressor": "libdeflate",
@@ -98,7 +97,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 872.22
+"decompress_mbps": 880.07
 },
 {
 "compressor": "memcpy",
@@ -108,7 +107,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 39568.8
+"decompress_mbps": 51212.71
 },
 {
 "compressor": "native",
@@ -118,7 +117,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 280.24
+"decompress_mbps": 320.0
 },
 {
 "compressor": "zlib",
@@ -128,7 +127,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 376.56
+"decompress_mbps": 376.61
 },
 {
 "compressor": "miniz_oxide",
@@ -138,7 +137,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 469.68
+"decompress_mbps": 473.22
 },
 {
 "compressor": "libdeflate",
@@ -148,7 +147,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 814.84
+"decompress_mbps": 761.45
 },
 {
 "compressor": "memcpy",
@@ -158,7 +157,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 43215.81
+"decompress_mbps": 47251.17
 },
 {
 "compressor": "native",
@@ -168,7 +167,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 274.96
+"decompress_mbps": 310.42
 },
 {
 "compressor": "zlib",
@@ -178,7 +177,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 378.58
+"decompress_mbps": 373.05
 },
 {
 "compressor": "miniz_oxide",
@@ -188,7 +187,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 443.5
+"decompress_mbps": 443.41
 },
 {
 "compressor": "libdeflate",
@@ -198,7 +197,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 758.48
+"decompress_mbps": 743.28
 },
 {
 "compressor": "memcpy",
@@ -208,7 +207,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 42990.09
+"decompress_mbps": 44764.6
 },
 {
 "compressor": "native",
@@ -218,7 +217,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 294.66
+"decompress_mbps": 339.19
 },
 {
 "compressor": "zlib",
@@ -228,7 +227,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 430.4
+"decompress_mbps": 422.53
 },
 {
 "compressor": "miniz_oxide",
@@ -238,7 +237,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 504.88
+"decompress_mbps": 506.14
 },
 {
 "compressor": "libdeflate",
@@ -248,7 +247,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 905.49
+"decompress_mbps": 889.48
 },
 {
 "compressor": "memcpy",
@@ -258,7 +257,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 56649.91
+"decompress_mbps": 45689.79
 },
 {
 "compressor": "native",
@@ -268,7 +267,7 @@
 "out_size": 3673380,
 "ratio": 0.3604,
 "compress_mbps": null,
-"decompress_mbps": 281.87
+"decompress_mbps": 342.58
 },
 {
 "compressor": "zlib",
@@ -278,7 +277,7 @@
 "out_size": 3673380,
 "ratio": 0.3604,
 "compress_mbps": null,
-"decompress_mbps": 416.25
+"decompress_mbps": 412.07
 },
 {
 "compressor": "miniz_oxide",
@@ -288,7 +287,7 @@
 "out_size": 3673380,
 "ratio": 0.3604,
 "compress_mbps": null,
-"decompress_mbps": 471.04
+"decompress_mbps": 471.88
 },
 {
 "compressor": "libdeflate",
@@ -298,7 +297,7 @@
 "out_size": 3673380,
 "ratio": 0.3604,
 "compress_mbps": null,
-"decompress_mbps": 822.46
+"decompress_mbps": 841.27
 },
 {
 "compressor": "memcpy",
@@ -308,7 +307,7 @@
 "out_size": 3673380,
 "ratio": 0.3604,
 "compress_mbps": null,
-"decompress_mbps": 40815.25
+"decompress_mbps": 58014.86
 },
 {
 "compressor": "native",
@@ -318,7 +317,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 254.43
+"decompress_mbps": 285.23
 },
 {
 "compressor": "zlib",
@@ -328,7 +327,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 373.37
+"decompress_mbps": 374.97
 },
 {
 "compressor": "miniz_oxide",
@@ -338,7 +337,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 422.66
+"decompress_mbps": 427.97
 },
 {
 "compressor": "libdeflate",
@@ -348,7 +347,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 735.55
+"decompress_mbps": 739.17
 },
 {
 "compressor": "memcpy",
@@ -358,7 +357,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 19512.74
+"decompress_mbps": 21815.55
 },
 {
 "compressor": "native",
@@ -368,7 +367,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 192.35
+"decompress_mbps": 214.05
 },
 {
 "compressor": "zlib",
@@ -378,7 +377,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 372.25
+"decompress_mbps": 372.32
 },
 {
 "compressor": "miniz_oxide",
@@ -388,7 +387,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 389.22
+"decompress_mbps": 394.32
 },
 {
 "compressor": "libdeflate",
@@ -398,7 +397,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 719.49
+"decompress_mbps": 720.93
 },
 {
 "compressor": "memcpy",
@@ -408,7 +407,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 19610.58
+"decompress_mbps": 21544.59
 },
 {
 "compressor": "native",
@@ -418,7 +417,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 204.46
+"decompress_mbps": 227.18
 },
 {
 "compressor": "zlib",
@@ -428,7 +427,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 378.73
+"decompress_mbps": 378.13
 },
 {
 "compressor": "miniz_oxide",
@@ -438,7 +437,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 408.41
+"decompress_mbps": 413.25
 },
 {
 "compressor": "libdeflate",
@@ -448,7 +447,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 746.55
+"decompress_mbps": 750.91
 },
 {
 "compressor": "memcpy",
@@ -458,7 +457,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 20068.97
+"decompress_mbps": 21063.66
 },
 {
 "compressor": "native",
@@ -468,7 +467,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 206.27
+"decompress_mbps": 229.05
 },
 {
 "compressor": "zlib",
@@ -478,7 +477,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 379.87
+"decompress_mbps": 378.8
 },
 {
 "compressor": "miniz_oxide",
@@ -488,7 +487,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 415.28
+"decompress_mbps": 416.39
 },
 {
 "compressor": "libdeflate",
@@ -498,7 +497,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 755.3
+"decompress_mbps": 762.34
 },
 {
 "compressor": "memcpy",
@@ -508,7 +507,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 20261.38
+"decompress_mbps": 19771.63
 },
 {
 "compressor": "native",
@@ -518,7 +517,7 @@
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 187.09
+"decompress_mbps": 206.42
 },
 {
 "compressor": "zlib",
@@ -528,7 +527,7 @@
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 381.39
+"decompress_mbps": 377.9
 },
 {
 "compressor": "miniz_oxide",
@@ -538,7 +537,7 @@
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 399.65
+"decompress_mbps": 401.63
 },
 {
 "compressor": "libdeflate",
@@ -548,7 +547,7 @@
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 747.35
+"decompress_mbps": 742.07
 },
 {
 "compressor": "memcpy",
@@ -558,7 +557,7 @@
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 19889.26
+"decompress_mbps": 19946.77
 },
 {
 "compressor": "native",
@@ -568,7 +567,7 @@
 "out_size": 18317341,
 "ratio": 0.3576,
 "compress_mbps": null,
-"decompress_mbps": 261.25
+"decompress_mbps": 304.58
 },
 {
 "compressor": "zlib",
@@ -578,7 +577,7 @@
 "out_size": 18317341,
 "ratio": 0.3576,
 "compress_mbps": null,
-"decompress_mbps": 387.18
+"decompress_mbps": 387.2
 },
 {
 "compressor": "miniz_oxide",
@@ -588,7 +587,7 @@
 "out_size": 18317341,
 "ratio": 0.3576,
 "compress_mbps": null,
-"decompress_mbps": 412.66
+"decompress_mbps": 420.89
 },
 {
 "compressor": "libdeflate",
@@ -598,7 +597,7 @@
 "out_size": 18317341,
 "ratio": 0.3576,
 "compress_mbps": null,
-"decompress_mbps": 766.3
+"decompress_mbps": 773.61
 },
 {
 "compressor": "memcpy",
@@ -608,7 +607,7 @@
 "out_size": 18317341,
 "ratio": 0.3576,
 "compress_mbps": null,
-"decompress_mbps": 19853.24
+"decompress_mbps": 20107.36
 },
 {
 "compressor": "native",
@@ -618,7 +617,7 @@
 "out_size": 3740775,
 "ratio": 0.3752,
 "compress_mbps": null,
-"decompress_mbps": 261.11
+"decompress_mbps": 287.53
 },
 {
 "compressor": "zlib",
@@ -628,7 +627,7 @@
 "out_size": 3740775,
 "ratio": 0.3752,
 "compress_mbps": null,
-"decompress_mbps": 449.51
+"decompress_mbps": 443.81
 },
 {
 "compressor": "miniz_oxide",
@@ -638,7 +637,7 @@
 "out_size": 3740775,
 "ratio": 0.3752,
 "compress_mbps": null,
-"decompress_mbps": 542.04
+"decompress_mbps": 544.25
 },
 {
 "compressor": "libdeflate",
@@ -648,7 +647,7 @@
 "out_size": 3740775,
 "ratio": 0.3752,
 "compress_mbps": null,
-"decompress_mbps": 860.58
+"decompress_mbps": 861.13
 },
 {
 "compressor": "memcpy",
@@ -658,7 +657,7 @@
 "out_size": 3740775,
 "ratio": 0.3752,
 "compress_mbps": null,
-"decompress_mbps": 39274.34
+"decompress_mbps": 33077.55
 },
 {
 "compressor": "native",
@@ -668,7 +667,7 @@
 "out_size": 3672389,
 "ratio": 0.3683,
 "compress_mbps": null,
-"decompress_mbps": 282.81
+"decompress_mbps": 334.37
 },
 {
 "compressor": "zlib",
@@ -678,7 +677,7 @@
 "out_size": 3672389,
 "ratio": 0.3683,
 "compress_mbps": null,
-"decompress_mbps": 457.16
+"decompress_mbps": 452.57
 },
 {
 "compressor": "miniz_oxide",
@@ -688,7 +687,7 @@
 "out_size": 3672389,
 "ratio": 0.3683,
 "compress_mbps": null,
-"decompress_mbps": 546.32
+"decompress_mbps": 541.26
 },
 {
 "compressor": "libdeflate",
@@ -698,7 +697,7 @@
 "out_size": 3672389,
 "ratio": 0.3683,
 "compress_mbps": null,
-"decompress_mbps": 910.17
+"decompress_mbps": 909.63
 },
 {
 "compressor": "memcpy",
@@ -708,7 +707,7 @@
 "out_size": 3672389,
 "ratio": 0.3683,
 "compress_mbps": null,
-"decompress_mbps": 40412.73
+"decompress_mbps": 56357.7
 },
 {
 "compressor": "native",
@@ -718,7 +717,7 @@
 "out_size": 3648644,
 "ratio": 0.3659,
 "compress_mbps": null,
-"decompress_mbps": 300.08
+"decompress_mbps": 369.09
 },
 {
 "compressor": "zlib",
@@ -728,7 +727,7 @@
 "out_size": 3648644,
 "ratio": 0.3659,
 "compress_mbps": null,
-"decompress_mbps": 451.57
+"decompress_mbps": 444.66
 },
 {
 "compressor": "miniz_oxide",
@@ -738,7 +737,7 @@
 "out_size": 3648644,
 "ratio": 0.3659,
 "compress_mbps": null,
-"decompress_mbps": 534.45
+"decompress_mbps": 540.25
 },
 {
 "compressor": "libdeflate",
@@ -748,7 +747,7 @@
 "out_size": 3648644,
 "ratio": 0.3659,
 "compress_mbps": null,
-"decompress_mbps": 917.54
+"decompress_mbps": 915.81
 },
 {
 "compressor": "memcpy",
@@ -758,7 +757,7 @@
 "out_size": 3648644,
 "ratio": 0.3659,
 "compress_mbps": null,
-"decompress_mbps": 51542.26
+"decompress_mbps": 57637.39
 },
 {
 "compressor": "native",
@@ -768,7 +767,7 @@
 "out_size": 3625176,
 "ratio": 0.3636,
 "compress_mbps": null,
-"decompress_mbps": 291.29
+"decompress_mbps": 344.95
 },
 {
 "compressor": "zlib",
@@ -778,7 +777,7 @@
 "out_size": 3625176,
 "ratio": 0.3636,
 "compress_mbps": null,
-"decompress_mbps": 458.45
+"decompress_mbps": 447.34
 },
 {
 "compressor": "miniz_oxide",
@@ -788,7 +787,7 @@
 "out_size": 3625176,
 "ratio": 0.3636,
 "compress_mbps": null,
-"decompress_mbps": 531.1
+"decompress_mbps": 533.37
 },
 {
 "compressor": "libdeflate",
@@ -798,7 +797,7 @@
 "out_size": 3625176,
 "ratio": 0.3636,
 "compress_mbps": null,
-"decompress_mbps": 893.37
+"decompress_mbps": 919.88
 },
 {
 "compressor": "memcpy",
@@ -808,7 +807,7 @@
 "out_size": 3625176,
 "ratio": 0.3636,
 "compress_mbps": null,
-"decompress_mbps": 44963.99
+"decompress_mbps": 57348.17
 },
 {
 "compressor": "native",
@@ -818,7 +817,7 @@
 "out_size": 3447985,
 "ratio": 0.3458,
 "compress_mbps": null,
-"decompress_mbps": 285.19
+"decompress_mbps": 344.11
 },
 {
 "compressor": "zlib",
@@ -828,7 +827,7 @@
 "out_size": 3447985,
 "ratio": 0.3458,
 "compress_mbps": null,
-"decompress_mbps": 489.53
+"decompress_mbps": 482.59
 },
 {
 "compressor": "miniz_oxide",
@@ -838,7 +837,7 @@
 "out_size": 3447985,
 "ratio": 0.3458,
 "compress_mbps": null,
-"decompress_mbps": 510.85
+"decompress_mbps": 527.33
 },
 {
 "compressor": "libdeflate",
@@ -848,7 +847,7 @@
 "out_size": 3447985,
 "ratio": 0.3458,
 "compress_mbps": null,
-"decompress_mbps": 893.73
+"decompress_mbps": 886.58
 },
 {
 "compressor": "memcpy",
@@ -858,7 +857,7 @@
 "out_size": 3447985,
 "ratio": 0.3458,
 "compress_mbps": null,
-"decompress_mbps": 55465.49
+"decompress_mbps": 38049.75
 },
 {
 "compressor": "native",
@@ -868,7 +867,7 @@
 "out_size": 3450225,
 "ratio": 0.346,
 "compress_mbps": null,
-"decompress_mbps": 262.71
+"decompress_mbps": 297.13
 },
 {
 "compressor": "zlib",
@@ -878,7 +877,7 @@
 "out_size": 3450225,
 "ratio": 0.346,
 "compress_mbps": null,
-"decompress_mbps": 429.53
+"decompress_mbps": 416.32
 },
 {
 "compressor": "miniz_oxide",
@@ -888,7 +887,7 @@
 "out_size": 3450225,
 "ratio": 0.346,
 "compress_mbps": null,
-"decompress_mbps": 520.36
+"decompress_mbps": 524.62
 },
 {
 "compressor": "libdeflate",
@@ -898,7 +897,7 @@
 "out_size": 3450225,
 "ratio": 0.346,
 "compress_mbps": null,
-"decompress_mbps": 839.62
+"decompress_mbps": 843.39
 },
 {
 "compressor": "memcpy",
@@ -908,7 +907,7 @@
 "out_size": 3450225,
 "ratio": 0.346,
 "compress_mbps": null,
-"decompress_mbps": 33280.38
+"decompress_mbps": 54815.45
 },
 {
 "compressor": "native",
@@ -918,7 +917,7 @@
 "out_size": 3837577,
 "ratio": 0.1144,
 "compress_mbps": null,
-"decompress_mbps": 631.02
+"decompress_mbps": 693.72
 },
 {
 "compressor": "zlib",
@@ -928,7 +927,7 @@
 "out_size": 3837577,
 "ratio": 0.1144,
 "compress_mbps": null,
-"decompress_mbps": 886.69
+"decompress_mbps": 890.54
 },
 {
 "compressor": "miniz_oxide",
@@ -938,7 +937,7 @@
 "out_size": 3837577,
 "ratio": 0.1144,
 "compress_mbps": null,
-"decompress_mbps": 833.85
+"decompress_mbps": 861.79
 },
 {
 "compressor": "libdeflate",
@@ -948,7 +947,7 @@
 "out_size": 3837577,
 "ratio": 0.1144,
 "compress_mbps": null,
-"decompress_mbps": 1792.72
+"decompress_mbps": 1758.0
 },
 {
 "compressor": "memcpy",
@@ -958,7 +957,7 @@
 "out_size": 3837577,
 "ratio": 0.1144,
 "compress_mbps": null,
-"decompress_mbps": 20349.65
+"decompress_mbps": 21510.73
 },
 {
 "compressor": "native",
@@ -968,7 +967,7 @@
 "out_size": 3599455,
 "ratio": 0.1073,
 "compress_mbps": null,
-"decompress_mbps": 678.92
+"decompress_mbps": 814.03
 },
 {
 "compressor": "zlib",
@@ -978,7 +977,7 @@
 "out_size": 3599455,
 "ratio": 0.1073,
 "compress_mbps": null,
-"decompress_mbps": 935.17
+"decompress_mbps": 950.95
 },
 {
 "compressor": "miniz_oxide",
@@ -988,7 +987,7 @@
 "out_size": 3599455,
 "ratio": 0.1073,
 "compress_mbps": null,
-"decompress_mbps": 905.24
+"decompress_mbps": 919.8
 },
 {
 "compressor": "libdeflate",
@@ -998,7 +997,7 @@
 "out_size": 3599455,
 "ratio": 0.1073,
 "compress_mbps": null,
-"decompress_mbps": 1856.54
+"decompress_mbps": 1889.94
 },
 {
 "compressor": "memcpy",
@@ -1008,7 +1007,7 @@
 "out_size": 3599455,
 "ratio": 0.1073,
 "compress_mbps": null,
-"decompress_mbps": 20250.86
+"decompress_mbps": 22474.23
 },
 {
 "compressor": "native",
@@ -1018,7 +1017,7 @@
 "out_size": 3091741,
 "ratio": 0.0921,
 "compress_mbps": null,
-"decompress_mbps": 873.51
+"decompress_mbps": 958.59
 },
 {
 "compressor": "zlib",
@@ -1028,7 +1027,7 @@
 "out_size": 3091741,
 "ratio": 0.0921,
 "compress_mbps": null,
-"decompress_mbps": 1045.5
+"decompress_mbps": 1055.26
 },
 {
 "compressor": "miniz_oxide",
@@ -1038,7 +1037,7 @@
 "out_size": 3091741,
 "ratio": 0.0921,
 "compress_mbps": null,
-"decompress_mbps": 1043.51
+"decompress_mbps": 1064.29
 },
 {
 "compressor": "libdeflate",
@@ -1048,7 +1047,7 @@
 "out_size": 3091741,
 "ratio": 0.0921,
 "compress_mbps": null,
-"decompress_mbps": 1889.31
+"decompress_mbps": 1915.3
 },
 {
 "compressor": "memcpy",
@@ -1058,7 +1057,7 @@
 "out_size": 3091741,
 "ratio": 0.0921,
 "compress_mbps": null,
-"decompress_mbps": 19194.77
+"decompress_mbps": 19946.69
 },
 {
 "compressor": "native",
@@ -1068,7 +1067,7 @@
 "out_size": 2925243,
 "ratio": 0.0872,
 "compress_mbps": null,
-"decompress_mbps": 978.09
+"decompress_mbps": 1070.61
 },
 {
 "compressor": "zlib",
@@ -1078,7 +1077,7 @@
 "out_size": 2925243,
 "ratio": 0.0872,
 "compress_mbps": null,
-"decompress_mbps": 1090.59
+"decompress_mbps": 1114.83
 },
 {
 "compressor": "miniz_oxide",
@@ -1088,7 +1087,7 @@
 "out_size": 2925243,
 "ratio": 0.0872,
 "compress_mbps": null,
-"decompress_mbps": 1076.71
+"decompress_mbps": 1138.55
 },
 {
 "compressor": "libdeflate",
@@ -1098,7 +1097,7 @@
 "out_size": 2925243,
 "ratio": 0.0872,
 "compress_mbps": null,
-"decompress_mbps": 1929.12
+"decompress_mbps": 1972.32
 },
 {
 "compressor": "memcpy",
@@ -1108,7 +1107,7 @@
 "out_size": 2925243,
 "ratio": 0.0872,
 "compress_mbps": null,
-"decompress_mbps": 19429.38
+"decompress_mbps": 19382.23
 },
 {
 "compressor": "native",
@@ -1118,7 +1117,7 @@
 "out_size": 2748273,
 "ratio": 0.0819,
 "compress_mbps": null,
-"decompress_mbps": 876.41
+"decompress_mbps": 947.71
 },
 {
 "compressor": "zlib",
@@ -1128,7 +1127,7 @@
 "out_size": 2748273,
 "ratio": 0.0819,
 "compress_mbps": null,
-"decompress_mbps": 1104.7
+"decompress_mbps": 1130.31
 },
 {
 "compressor": "miniz_oxide",
@@ -1138,7 +1137,7 @@
 "out_size": 2748273,
 "ratio": 0.0819,
 "compress_mbps": null,
-"decompress_mbps": 1076.89
+"decompress_mbps": 1142.98
 },
 {
 "compressor": "libdeflate",
@@ -1148,7 +1147,7 @@
 "out_size": 2748273,
 "ratio": 0.0819,
 "compress_mbps": null,
-"decompress_mbps": 1968.07
+"decompress_mbps": 1975.7
 },
 {
 "compressor": "memcpy",
@@ -1158,7 +1157,7 @@
 "out_size": 2748273,
 "ratio": 0.0819,
 "compress_mbps": null,
-"decompress_mbps": 20105.85
+"decompress_mbps": 19340.12
 },
 {
 "compressor": "native",
@@ -1168,7 +1167,7 @@
 "out_size": 2740598,
 "ratio": 0.0817,
 "compress_mbps": null,
-"decompress_mbps": 1078.42
+"decompress_mbps": 1188.75
 },
 {
 "compressor": "zlib",
@@ -1178,7 +1177,7 @@
 "out_size": 2740598,
 "ratio": 0.0817,
 "compress_mbps": null,
-"decompress_mbps": 1108.12
+"decompress_mbps": 1127.35
 },
 {
 "compressor": "miniz_oxide",
@@ -1188,7 +1187,7 @@
 "out_size": 2740598,
 "ratio": 0.0817,
 "compress_mbps": null,
-"decompress_mbps": 1110.1
+"decompress_mbps": 1154.76
 },
 {
 "compressor": "libdeflate",
@@ -1198,7 +1197,7 @@
 "out_size": 2740598,
 "ratio": 0.0817,
 "compress_mbps": null,
-"decompress_mbps": 1987.24
+"decompress_mbps": 2007.14
 },
 {
 "compressor": "memcpy",
@@ -1208,7 +1207,7 @@
 "out_size": 2740598,
 "ratio": 0.0817,
 "compress_mbps": null,
-"decompress_mbps": 20661.4
+"decompress_mbps": 19485.19
 },
 {
 "compressor": "native",
@@ -1218,7 +1217,7 @@
 "out_size": 3275124,
 "ratio": 0.5324,
 "compress_mbps": null,
-"decompress_mbps": 198.95
+"decompress_mbps": 225.12
 },
 {
 "compressor": "zlib",
@@ -1228,7 +1227,7 @@
 "out_size": 3275124,
 "ratio": 0.5324,
 "compress_mbps": null,
-"decompress_mbps": 282.98
+"decompress_mbps": 282.3
 },
 {
 "compressor": "miniz_oxide",
@@ -1238,7 +1237,7 @@
 "out_size": 3275124,
 "ratio": 0.5324,
 "compress_mbps": null,
-"decompress_mbps": 366.46
+"decompress_mbps": 365.3
 },
 {
 "compressor": "libdeflate",
@@ -1248,7 +1247,7 @@
 "out_size": 3275124,
 "ratio": 0.5324,
 "compress_mbps": null,
-"decompress_mbps": 583.87
+"decompress_mbps": 574.18
 },
 {
 "compressor": "memcpy",
@@ -1258,7 +1257,7 @@
 "out_size": 3275124,
 "ratio": 0.5324,
 "compress_mbps": null,
-"decompress_mbps": 62106.36
+"decompress_mbps": 61765.72
 },
 {
 "compressor": "native",
@@ -1268,7 +1267,7 @@
 "out_size": 3137061,
 "ratio": 0.5099,
 "compress_mbps": null,
-"decompress_mbps": 179.17
+"decompress_mbps": 209.07
 },
 {
 "compressor": "zlib",
@@ -1278,7 +1277,7 @@
 "out_size": 3137061,
 "ratio": 0.5099,
 "compress_mbps": null,
-"decompress_mbps": 277.41
+"decompress_mbps": 276.67
 },
 {
 "compressor": "miniz_oxide",
@@ -1288,7 +1287,7 @@
 "out_size": 3137061,
 "ratio": 0.5099,
 "compress_mbps": null,
-"decompress_mbps": 326.76
+"decompress_mbps": 330.53
 },
 {
 "compressor": "libdeflate",
@@ -1298,7 +1297,7 @@
 "out_size": 3137061,
 "ratio": 0.5099,
 "compress_mbps": null,
-"decompress_mbps": 553.72
+"decompress_mbps": 550.46
 },
 {
 "compressor": "memcpy",
@@ -1308,7 +1307,7 @@
 "out_size": 3137061,
 "ratio": 0.5099,
 "compress_mbps": null,
-"decompress_mbps": 63273.78
+"decompress_mbps": 62384.37
 },
 {
 "compressor": "native",
@@ -1318,7 +1317,7 @@
 "out_size": 3072378,
 "ratio": 0.4994,
 "compress_mbps": null,
-"decompress_mbps": 190.09
+"decompress_mbps": 222.54
 },
 {
 "compressor": "zlib",
@@ -1328,7 +1327,7 @@
 "out_size": 3072378,
 "ratio": 0.4994,
 "compress_mbps": null,
-"decompress_mbps": 279.96
+"decompress_mbps": 280.14
 },
 {
 "compressor": "miniz_oxide",
@@ -1338,7 +1337,7 @@
 "out_size": 3072378,
 "ratio": 0.4994,
 "compress_mbps": null,
-"decompress_mbps": 336.01
+"decompress_mbps": 337.05
 },
 {
 "compressor": "libdeflate",
@@ -1348,7 +1347,7 @@
 "out_size": 3072378,
 "ratio": 0.4994,
 "compress_mbps": null,
-"decompress_mbps": 571.37
+"decompress_mbps": 563.9
 },
 {
 "compressor": "memcpy",
@@ -1358,7 +1357,7 @@
 "out_size": 3072378,
 "ratio": 0.4994,
 "compress_mbps": null,
-"decompress_mbps": 61338.89
+"decompress_mbps": 61538.33
 },
 {
 "compressor": "native",
@@ -1368,7 +1367,7 @@
 "out_size": 3066968,
 "ratio": 0.4985,
 "compress_mbps": null,
-"decompress_mbps": 195.14
+"decompress_mbps": 226.03
 },
 {
 "compressor": "zlib",
@@ -1378,7 +1377,7 @@
 "out_size": 3066968,
 "ratio": 0.4985,
 "compress_mbps": null,
-"decompress_mbps": 282.97
+"decompress_mbps": 281.85
 },
 {
 "compressor": "miniz_oxide",
@@ -1388,7 +1387,7 @@
 "out_size": 3066968,
 "ratio": 0.4985,
 "compress_mbps": null,
-"decompress_mbps": 342.92
+"decompress_mbps": 348.14
 },
 {
 "compressor": "libdeflate",
@@ -1398,7 +1397,7 @@
 "out_size": 3066968,
 "ratio": 0.4985,
 "compress_mbps": null,
-"decompress_mbps": 582.16
+"decompress_mbps": 579.0
 },
 {
 "compressor": "memcpy",
@@ -1408,7 +1407,7 @@
 "out_size": 3066968,
 "ratio": 0.4985,
 "compress_mbps": null,
-"decompress_mbps": 61441.67
+"decompress_mbps": 59531.51
 },
 {
 "compressor": "native",
@@ -1418,7 +1417,7 @@
 "out_size": 2994086,
 "ratio": 0.4867,
 "compress_mbps": null,
-"decompress_mbps": 180.59
+"decompress_mbps": 215.22
 },
 {
 "compressor": "zlib",
@@ -1428,7 +1427,7 @@
 "out_size": 2994086,
 "ratio": 0.4867,
 "compress_mbps": null,
-"decompress_mbps": 278.44
+"decompress_mbps": 276.52
 },
 {
 "compressor": "miniz_oxide",
@@ -1438,7 +1437,7 @@
 "out_size": 2994086,
 "ratio": 0.4867,
 "compress_mbps": null,
-"decompress_mbps": 319.36
+"decompress_mbps": 325.24
 },
 {
 "compressor": "libdeflate",
@@ -1448,7 +1447,7 @@
 "out_size": 2994086,
 "ratio": 0.4867,
 "compress_mbps": null,
-"decompress_mbps": 560.88
+"decompress_mbps": 557.9
 },
 {
 "compressor": "memcpy",
@@ -1458,7 +1457,7 @@
 "out_size": 2994086,
 "ratio": 0.4867,
 "compress_mbps": null,
-"decompress_mbps": 63727.37
+"decompress_mbps": 59230.42
 },
 {
 "compressor": "native",
@@ -1468,7 +1467,7 @@
 "out_size": 2992113,
 "ratio": 0.4863,
 "compress_mbps": null,
-"decompress_mbps": 185.86
+"decompress_mbps": 223.76
 },
 {
 "compressor": "zlib",
@@ -1478,7 +1477,7 @@
 "out_size": 2992113,
 "ratio": 0.4863,
 "compress_mbps": null,
-"decompress_mbps": 278.05
+"decompress_mbps": 277.78
 },
 {
 "compressor": "miniz_oxide",
@@ -1488,7 +1487,7 @@
 "out_size": 2992113,
 "ratio": 0.4863,
 "compress_mbps": null,
-"decompress_mbps": 321.37
+"decompress_mbps": 326.2
 },
 {
 "compressor": "libdeflate",
@@ -1498,7 +1497,7 @@
 "out_size": 2992113,
 "ratio": 0.4863,
 "compress_mbps": null,
-"decompress_mbps": 561.04
+"decompress_mbps": 558.35
 },
 {
 "compressor": "memcpy",
@@ -1508,7 +1507,7 @@
 "out_size": 2992113,
 "ratio": 0.4863,
 "compress_mbps": null,
-"decompress_mbps": 62994.56
+"decompress_mbps": 62717.8
 },
 {
 "compressor": "native",
@@ -1518,7 +1517,7 @@
 "out_size": 3868663,
 "ratio": 0.3836,
 "compress_mbps": null,
-"decompress_mbps": 302.55
+"decompress_mbps": 332.06
 },
 {
 "compressor": "zlib",
@@ -1528,7 +1527,7 @@
 "out_size": 3868663,
 "ratio": 0.3836,
 "compress_mbps": null,
-"decompress_mbps": 523.48
+"decompress_mbps": 517.94
 },
 {
 "compressor": "miniz_oxide",
@@ -1538,7 +1537,7 @@
 "out_size": 3868663,
 "ratio": 0.3836,
 "compress_mbps": null,
-"decompress_mbps": 628.37
+"decompress_mbps": 626.29
 },
 {
 "compressor": "libdeflate",
@@ -1548,7 +1547,7 @@
 "out_size": 3868663,
 "ratio": 0.3836,
 "compress_mbps": null,
-"decompress_mbps": 1038.76
+"decompress_mbps": 1030.41
 },
 {
 "compressor": "memcpy",
@@ -1558,7 +1557,7 @@
 "out_size": 3868663,
 "ratio": 0.3836,
 "compress_mbps": null,
-"decompress_mbps": 54525.79
+"decompress_mbps": 44265.13
 },
 {
 "compressor": "native",
@@ -1567,318 +1566,318 @@
 "level": 3,
 "out_size": 3818964,
 "ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 460.41
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 540.15
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 633.59
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 1095.22
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 55136.22
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 484.7
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 547.99
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 678.51
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 1103.88
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 51447.43
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 482.81
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 549.98
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 683.77
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 1115.25
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 57355.49
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 485.08
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 555.41
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 676.59
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 1098.22
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 54460.95
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 540.25
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 575.79
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 705.08
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 1089.72
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 38499.86
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 304.95
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 425.26
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 524.84
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 922.98
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 39727.9
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
 "compress_mbps": null,
 "decompress_mbps": 403.77
 },
 {
 "compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 546.12
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 633.43
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 1080.5
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 32880.92
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 422.91
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 553.15
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 672.79
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 1104.22
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 57793.85
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 425.45
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 552.04
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 679.12
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 1095.31
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 44622.86
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 415.12
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 554.88
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 670.5
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 1110.01
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 38186.06
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 0,
-"out_size": 3607217,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 463.36
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 0,
-"out_size": 3607217,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 572.19
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 0,
-"out_size": 3607217,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 713.46
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 0,
-"out_size": 3607217,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 1140.97
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 0,
-"out_size": 3607217,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 44246.8
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 267.42
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 437.41
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 543.85
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 1014.13
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 61907.44
-},
-{
-"compressor": "native",
 "pattern": "silesia/reymont",
 "size": 6627202,
 "level": 3,
 "out_size": 2021047,
 "ratio": 0.305,
 "compress_mbps": null,
-"decompress_mbps": 341.23
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 472.46
+"decompress_mbps": 461.64
 },
 {
 "compressor": "miniz_oxide",
@@ -1888,7 +1887,7 @@
 "out_size": 2021047,
 "ratio": 0.305,
 "compress_mbps": null,
-"decompress_mbps": 584.99
+"decompress_mbps": 571.33
 },
 {
 "compressor": "libdeflate",
@@ -1898,7 +1897,7 @@
 "out_size": 2021047,
 "ratio": 0.305,
 "compress_mbps": null,
-"decompress_mbps": 1169.14
+"decompress_mbps": 1035.62
 },
 {
 "compressor": "memcpy",
@@ -1908,7 +1907,7 @@
 "out_size": 2021047,
 "ratio": 0.305,
 "compress_mbps": null,
-"decompress_mbps": 62261.77
+"decompress_mbps": 59328.93
 },
 {
 "compressor": "native",
@@ -1918,7 +1917,7 @@
 "out_size": 1876257,
 "ratio": 0.2831,
 "compress_mbps": null,
-"decompress_mbps": 354.43
+"decompress_mbps": 393.27
 },
 {
 "compressor": "zlib",
@@ -1928,7 +1927,7 @@
 "out_size": 1876257,
 "ratio": 0.2831,
 "compress_mbps": null,
-"decompress_mbps": 471.62
+"decompress_mbps": 450.29
 },
 {
 "compressor": "miniz_oxide",
@@ -1938,7 +1937,7 @@
 "out_size": 1876257,
 "ratio": 0.2831,
 "compress_mbps": null,
-"decompress_mbps": 554.72
+"decompress_mbps": 544.64
 },
 {
 "compressor": "libdeflate",
@@ -1948,7 +1947,7 @@
 "out_size": 1876257,
 "ratio": 0.2831,
 "compress_mbps": null,
-"decompress_mbps": 1071.79
+"decompress_mbps": 995.45
 },
 {
 "compressor": "memcpy",
@@ -1958,7 +1957,7 @@
 "out_size": 1876257,
 "ratio": 0.2831,
 "compress_mbps": null,
-"decompress_mbps": 62988.39
+"decompress_mbps": 61968.14
 },
 {
 "compressor": "native",
@@ -1968,7 +1967,7 @@
 "out_size": 1806374,
 "ratio": 0.2726,
 "compress_mbps": null,
-"decompress_mbps": 360.15
+"decompress_mbps": 396.38
 },
 {
 "compressor": "zlib",
@@ -1978,7 +1977,7 @@
 "out_size": 1806374,
 "ratio": 0.2726,
 "compress_mbps": null,
-"decompress_mbps": 459.3
+"decompress_mbps": 452.21
 },
 {
 "compressor": "miniz_oxide",
@@ -1988,7 +1987,7 @@
 "out_size": 1806374,
 "ratio": 0.2726,
 "compress_mbps": null,
-"decompress_mbps": 528.95
+"decompress_mbps": 522.26
 },
 {
 "compressor": "libdeflate",
@@ -1998,7 +1997,7 @@
 "out_size": 1806374,
 "ratio": 0.2726,
 "compress_mbps": null,
-"decompress_mbps": 974.27
+"decompress_mbps": 975.91
 },
 {
 "compressor": "memcpy",
@@ -2008,7 +2007,7 @@
 "out_size": 1806374,
 "ratio": 0.2726,
 "compress_mbps": null,
-"decompress_mbps": 62089.89
+"decompress_mbps": 63247.46
 },
 {
 "compressor": "native",
@@ -2018,7 +2017,7 @@
 "out_size": 1696488,
 "ratio": 0.256,
 "compress_mbps": null,
-"decompress_mbps": 364.36
+"decompress_mbps": 412.14
 },
 {
 "compressor": "zlib",
@@ -2028,7 +2027,7 @@
 "out_size": 1696488,
 "ratio": 0.256,
 "compress_mbps": null,
-"decompress_mbps": 541.04
+"decompress_mbps": 530.92
 },
 {
 "compressor": "miniz_oxide",
@@ -2038,7 +2037,7 @@
 "out_size": 1696488,
 "ratio": 0.256,
 "compress_mbps": null,
-"decompress_mbps": 592.89
+"decompress_mbps": 590.53
 },
 {
 "compressor": "libdeflate",
@@ -2048,7 +2047,7 @@
 "out_size": 1696488,
 "ratio": 0.256,
 "compress_mbps": null,
-"decompress_mbps": 1170.28
+"decompress_mbps": 916.49
 },
 {
 "compressor": "memcpy",
@@ -2058,7 +2057,7 @@
 "out_size": 1696488,
 "ratio": 0.256,
 "compress_mbps": null,
-"decompress_mbps": 60885.83
+"decompress_mbps": 55465.1
 },
 {
 "compressor": "native",
@@ -2068,7 +2067,7 @@
 "out_size": 1691994,
 "ratio": 0.2553,
 "compress_mbps": null,
-"decompress_mbps": 374.15
+"decompress_mbps": 431.16
 },
 {
 "compressor": "zlib",
@@ -2078,7 +2077,7 @@
 "out_size": 1691994,
 "ratio": 0.2553,
 "compress_mbps": null,
-"decompress_mbps": 543.8
+"decompress_mbps": 535.3
 },
 {
 "compressor": "miniz_oxide",
@@ -2088,7 +2087,7 @@
 "out_size": 1691994,
 "ratio": 0.2553,
 "compress_mbps": null,
-"decompress_mbps": 595.7
+"decompress_mbps": 597.62
 },
 {
 "compressor": "libdeflate",
@@ -2098,7 +2097,7 @@
 "out_size": 1691994,
 "ratio": 0.2553,
 "compress_mbps": null,
-"decompress_mbps": 1158.46
+"decompress_mbps": 1161.95
 },
 {
 "compressor": "memcpy",
@@ -2108,7 +2107,7 @@
 "out_size": 1691994,
 "ratio": 0.2553,
 "compress_mbps": null,
-"decompress_mbps": 62906.89
+"decompress_mbps": 50583.8
 },
 {
 "compressor": "native",
@@ -2118,7 +2117,7 @@
 "out_size": 5866517,
 "ratio": 0.2715,
 "compress_mbps": null,
-"decompress_mbps": 372.49
+"decompress_mbps": 403.05
 },
 {
 "compressor": "zlib",
@@ -2128,7 +2127,7 @@
 "out_size": 5866517,
 "ratio": 0.2715,
 "compress_mbps": null,
-"decompress_mbps": 563.85
+"decompress_mbps": 559.3
 },
 {
 "compressor": "miniz_oxide",
@@ -2138,7 +2137,7 @@
 "out_size": 5866517,
 "ratio": 0.2715,
 "compress_mbps": null,
-"decompress_mbps": 673.01
+"decompress_mbps": 592.43
 },
 {
 "compressor": "libdeflate",
@@ -2148,7 +2147,7 @@
 "out_size": 5866517,
 "ratio": 0.2715,
 "compress_mbps": null,
-"decompress_mbps": 1058.72
+"decompress_mbps": 1078.28
 },
 {
 "compressor": "memcpy",
@@ -2158,7 +2157,7 @@
 "out_size": 5866517,
 "ratio": 0.2715,
 "compress_mbps": null,
-"decompress_mbps": 17127.35
+"decompress_mbps": 18402.18
 },
 {
 "compressor": "native",
@@ -2168,7 +2167,7 @@
 "out_size": 5605878,
 "ratio": 0.2595,
 "compress_mbps": null,
-"decompress_mbps": 326.97
+"decompress_mbps": 357.08
 },
 {
 "compressor": "zlib",
@@ -2178,7 +2177,7 @@
 "out_size": 5605878,
 "ratio": 0.2595,
 "compress_mbps": null,
-"decompress_mbps": 575.98
+"decompress_mbps": 570.59
 },
 {
 "compressor": "miniz_oxide",
@@ -2188,7 +2187,7 @@
 "out_size": 5605878,
 "ratio": 0.2595,
 "compress_mbps": null,
-"decompress_mbps": 675.88
+"decompress_mbps": 602.45
 },
 {
 "compressor": "libdeflate",
@@ -2198,7 +2197,7 @@
 "out_size": 5605878,
 "ratio": 0.2595,
 "compress_mbps": null,
-"decompress_mbps": 1111.61
+"decompress_mbps": 1134.66
 },
 {
 "compressor": "memcpy",
@@ -2208,7 +2207,7 @@
 "out_size": 5605878,
 "ratio": 0.2595,
 "compress_mbps": null,
-"decompress_mbps": 18814.98
+"decompress_mbps": 18453.0
 },
 {
 "compressor": "native",
@@ -2218,7 +2217,7 @@
 "out_size": 5337149,
 "ratio": 0.247,
 "compress_mbps": null,
-"decompress_mbps": 353.53
+"decompress_mbps": 385.51
 },
 {
 "compressor": "zlib",
@@ -2228,7 +2227,7 @@
 "out_size": 5337149,
 "ratio": 0.247,
 "compress_mbps": null,
-"decompress_mbps": 514.77
+"decompress_mbps": 515.37
 },
 {
 "compressor": "miniz_oxide",
@@ -2238,7 +2237,7 @@
 "out_size": 5337149,
 "ratio": 0.247,
 "compress_mbps": null,
-"decompress_mbps": 540.65
+"decompress_mbps": 535.53
 },
 {
 "compressor": "libdeflate",
@@ -2248,7 +2247,7 @@
 "out_size": 5337149,
 "ratio": 0.247,
 "compress_mbps": null,
-"decompress_mbps": 1107.02
+"decompress_mbps": 1099.89
 },
 {
 "compressor": "memcpy",
@@ -2258,7 +2257,7 @@
 "out_size": 5337149,
 "ratio": 0.247,
 "compress_mbps": null,
-"decompress_mbps": 18310.13
+"decompress_mbps": 22581.01
 },
 {
 "compressor": "native",
@@ -2268,7 +2267,7 @@
 "out_size": 5270405,
 "ratio": 0.2439,
 "compress_mbps": null,
-"decompress_mbps": 366.75
+"decompress_mbps": 396.9
 },
 {
 "compressor": "zlib",
@@ -2278,7 +2277,7 @@
 "out_size": 5270405,
 "ratio": 0.2439,
 "compress_mbps": null,
-"decompress_mbps": 527.21
+"decompress_mbps": 528.58
 },
 {
 "compressor": "miniz_oxide",
@@ -2288,7 +2287,7 @@
 "out_size": 5270405,
 "ratio": 0.2439,
 "compress_mbps": null,
-"decompress_mbps": 542.66
+"decompress_mbps": 541.94
 },
 {
 "compressor": "libdeflate",
@@ -2298,7 +2297,7 @@
 "out_size": 5270405,
 "ratio": 0.2439,
 "compress_mbps": null,
-"decompress_mbps": 1095.49
+"decompress_mbps": 1057.96
 },
 {
 "compressor": "memcpy",
@@ -2308,7 +2307,7 @@
 "out_size": 5270405,
 "ratio": 0.2439,
 "compress_mbps": null,
-"decompress_mbps": 18200.49
+"decompress_mbps": 20868.33
 },
 {
 "compressor": "native",
@@ -2318,7 +2317,7 @@
 "out_size": 5118130,
 "ratio": 0.2369,
 "compress_mbps": null,
-"decompress_mbps": 303.87
+"decompress_mbps": 320.47
 },
 {
 "compressor": "zlib",
@@ -2328,7 +2327,7 @@
 "out_size": 5118130,
 "ratio": 0.2369,
 "compress_mbps": null,
-"decompress_mbps": 609.96
+"decompress_mbps": 534.99
 },
 {
 "compressor": "miniz_oxide",
@@ -2338,7 +2337,7 @@
 "out_size": 5118130,
 "ratio": 0.2369,
 "compress_mbps": null,
-"decompress_mbps": 661.96
+"decompress_mbps": 533.22
 },
 {
 "compressor": "libdeflate",
@@ -2348,7 +2347,7 @@
 "out_size": 5118130,
 "ratio": 0.2369,
 "compress_mbps": null,
-"decompress_mbps": 1112.01
+"decompress_mbps": 1075.39
 },
 {
 "compressor": "memcpy",
@@ -2358,7 +2357,7 @@
 "out_size": 5118130,
 "ratio": 0.2369,
 "compress_mbps": null,
-"decompress_mbps": 20154.69
+"decompress_mbps": 21969.3
 },
 {
 "compressor": "native",
@@ -2368,7 +2367,7 @@
 "out_size": 5107588,
 "ratio": 0.2364,
 "compress_mbps": null,
-"decompress_mbps": 426.42
+"decompress_mbps": 470.71
 },
 {
 "compressor": "zlib",
@@ -2378,7 +2377,7 @@
 "out_size": 5107588,
 "ratio": 0.2364,
 "compress_mbps": null,
-"decompress_mbps": 554.94
+"decompress_mbps": 553.22
 },
 {
 "compressor": "miniz_oxide",
@@ -2388,7 +2387,7 @@
 "out_size": 5107588,
 "ratio": 0.2364,
 "compress_mbps": null,
-"decompress_mbps": 559.71
+"decompress_mbps": 551.88
 },
 {
 "compressor": "libdeflate",
@@ -2398,7 +2397,7 @@
 "out_size": 5107588,
 "ratio": 0.2364,
 "compress_mbps": null,
-"decompress_mbps": 1153.69
+"decompress_mbps": 1116.79
 },
 {
 "compressor": "memcpy",
@@ -2408,7 +2407,7 @@
 "out_size": 5107588,
 "ratio": 0.2364,
 "compress_mbps": null,
-"decompress_mbps": 18585.7
+"decompress_mbps": 20864.52
 },
 {
 "compressor": "native",
@@ -2418,7 +2417,7 @@
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 210.05
+"decompress_mbps": 232.17
 },
 {
 "compressor": "zlib",
@@ -2428,7 +2427,7 @@
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 373.58
+"decompress_mbps": 372.99
 },
 {
 "compressor": "miniz_oxide",
@@ -2438,7 +2437,7 @@
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 394.86
+"decompress_mbps": 393.14
 },
 {
 "compressor": "libdeflate",
@@ -2448,7 +2447,7 @@
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 581.99
+"decompress_mbps": 539.05
 },
 {
 "compressor": "memcpy",
@@ -2458,7 +2457,7 @@
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 61460.74
+"decompress_mbps": 40229.14
 },
 {
 "compressor": "native",
@@ -2468,7 +2467,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 242.79
+"decompress_mbps": 283.99
 },
 {
 "compressor": "zlib",
@@ -2478,7 +2477,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 377.13
+"decompress_mbps": 372.6
 },
 {
 "compressor": "miniz_oxide",
@@ -2488,7 +2487,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 392.24
+"decompress_mbps": 390.89
 },
 {
 "compressor": "libdeflate",
@@ -2498,7 +2497,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 578.18
+"decompress_mbps": 569.67
 },
 {
 "compressor": "memcpy",
@@ -2508,7 +2507,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 61281.03
+"decompress_mbps": 48755.68
 },
 {
 "compressor": "native",
@@ -2518,7 +2517,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 246.4
+"decompress_mbps": 286.03
 },
 {
 "compressor": "zlib",
@@ -2528,7 +2527,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 375.88
+"decompress_mbps": 371.35
 },
 {
 "compressor": "miniz_oxide",
@@ -2538,7 +2537,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 387.61
+"decompress_mbps": 385.04
 },
 {
 "compressor": "libdeflate",
@@ -2548,7 +2547,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 564.87
+"decompress_mbps": 527.56
 },
 {
 "compressor": "memcpy",
@@ -2558,7 +2557,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 57851.66
+"decompress_mbps": 45552.4
 },
 {
 "compressor": "native",
@@ -2568,7 +2567,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 248.08
+"decompress_mbps": 283.55
 },
 {
 "compressor": "zlib",
@@ -2578,7 +2577,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 379.3
+"decompress_mbps": 376.24
 },
 {
 "compressor": "miniz_oxide",
@@ -2588,7 +2587,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 387.42
+"decompress_mbps": 386.81
 },
 {
 "compressor": "libdeflate",
@@ -2598,7 +2597,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 567.32
+"decompress_mbps": 559.08
 },
 {
 "compressor": "memcpy",
@@ -2608,7 +2607,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 62157.85
+"decompress_mbps": 58369.7
 },
 {
 "compressor": "native",
@@ -2618,7 +2617,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 247.88
+"decompress_mbps": 286.11
 },
 {
 "compressor": "zlib",
@@ -2628,7 +2627,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 380.11
+"decompress_mbps": 377.11
 },
 {
 "compressor": "miniz_oxide",
@@ -2638,7 +2637,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 395.21
+"decompress_mbps": 394.27
 },
 {
 "compressor": "libdeflate",
@@ -2648,7 +2647,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 585.25
+"decompress_mbps": 578.09
 },
 {
 "compressor": "memcpy",
@@ -2658,7 +2657,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 61042.5
+"decompress_mbps": 61477.13
 },
 {
 "compressor": "native",
@@ -2668,7 +2667,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 208.6
+"decompress_mbps": 234.89
 },
 {
 "compressor": "zlib",
@@ -2678,7 +2677,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 372.48
+"decompress_mbps": 371.25
 },
 {
 "compressor": "miniz_oxide",
@@ -2688,7 +2687,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 387.03
+"decompress_mbps": 388.2
 },
 {
 "compressor": "libdeflate",
@@ -2698,7 +2697,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 574.37
+"decompress_mbps": 573.48
 },
 {
 "compressor": "memcpy",
@@ -2708,7 +2707,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 62018.5
+"decompress_mbps": 59210.24
 },
 {
 "compressor": "native",
@@ -2718,7 +2717,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 274.69
+"decompress_mbps": 304.0
 },
 {
 "compressor": "zlib",
@@ -2728,7 +2727,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 387.9
+"decompress_mbps": 383.24
 },
 {
 "compressor": "miniz_oxide",
@@ -2738,7 +2737,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 435.67
+"decompress_mbps": 441.62
 },
 {
 "compressor": "libdeflate",
@@ -2748,7 +2747,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 837.23
+"decompress_mbps": 846.48
 },
 {
 "compressor": "memcpy",
@@ -2758,7 +2757,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 19650.93
+"decompress_mbps": 20210.13
 },
 {
 "compressor": "native",
@@ -2768,7 +2767,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 340.5
+"decompress_mbps": 383.56
 },
 {
 "compressor": "zlib",
@@ -2778,7 +2777,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 399.36
+"decompress_mbps": 398.85
 },
 {
 "compressor": "miniz_oxide",
@@ -2788,7 +2787,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 460.59
+"decompress_mbps": 472.19
 },
 {
 "compressor": "libdeflate",
@@ -2798,7 +2797,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 906.53
+"decompress_mbps": 915.83
 },
 {
 "compressor": "memcpy",
@@ -2808,7 +2807,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 20284.8
+"decompress_mbps": 20412.1
 },
 {
 "compressor": "native",
@@ -2818,7 +2817,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 348.23
+"decompress_mbps": 387.43
 },
 {
 "compressor": "zlib",
@@ -2828,7 +2827,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 403.13
+"decompress_mbps": 397.24
 },
 {
 "compressor": "miniz_oxide",
@@ -2838,7 +2837,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 467.92
+"decompress_mbps": 481.48
 },
 {
 "compressor": "libdeflate",
@@ -2848,7 +2847,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 870.02
+"decompress_mbps": 874.68
 },
 {
 "compressor": "memcpy",
@@ -2858,7 +2857,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 19746.76
+"decompress_mbps": 20698.71
 },
 {
 "compressor": "native",
@@ -2868,7 +2867,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 350.8
+"decompress_mbps": 386.59
 },
 {
 "compressor": "zlib",
@@ -2878,7 +2877,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 404.8
+"decompress_mbps": 398.38
 },
 {
 "compressor": "miniz_oxide",
@@ -2888,7 +2887,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 466.19
+"decompress_mbps": 469.51
 },
 {
 "compressor": "libdeflate",
@@ -2898,7 +2897,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 840.03
+"decompress_mbps": 828.1
 },
 {
 "compressor": "memcpy",
@@ -2908,7 +2907,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 19602.73
+"decompress_mbps": 19896.82
 },
 {
 "compressor": "native",
@@ -2918,7 +2917,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 353.01
+"decompress_mbps": 387.4
 },
 {
 "compressor": "zlib",
@@ -2928,7 +2927,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 422.02
+"decompress_mbps": 418.71
 },
 {
 "compressor": "miniz_oxide",
@@ -2938,7 +2937,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 477.62
+"decompress_mbps": 492.05
 },
 {
 "compressor": "libdeflate",
@@ -2948,7 +2947,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 877.38
+"decompress_mbps": 891.75
 },
 {
 "compressor": "memcpy",
@@ -2958,7 +2957,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 19450.41
+"decompress_mbps": 20209.4
 },
 {
 "compressor": "native",
@@ -2968,7 +2967,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 367.46
+"decompress_mbps": 407.23
 },
 {
 "compressor": "zlib",
@@ -2978,7 +2977,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 426.45
+"decompress_mbps": 424.6
 },
 {
 "compressor": "miniz_oxide",
@@ -2988,7 +2987,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 485.38
+"decompress_mbps": 492.56
 },
 {
 "compressor": "libdeflate",
@@ -2998,7 +2997,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 881.73
+"decompress_mbps": 861.96
 },
 {
 "compressor": "memcpy",
@@ -3008,7 +3007,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 18768.21
+"decompress_mbps": 19736.09
 },
 {
 "compressor": "native",
@@ -3018,7 +3017,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 205.4
+"decompress_mbps": 215.01
 },
 {
 "compressor": "zlib",
@@ -3028,7 +3027,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 327.92
+"decompress_mbps": 326.95
 },
 {
 "compressor": "miniz_oxide",
@@ -3038,7 +3037,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 355.5
+"decompress_mbps": 353.24
 },
 {
 "compressor": "libdeflate",
@@ -3048,7 +3047,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 507.48
+"decompress_mbps": 505.36
 },
 {
 "compressor": "memcpy",
@@ -3058,7 +3057,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 59779.61
+"decompress_mbps": 46615.67
 },
 {
 "compressor": "native",
@@ -3068,7 +3067,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 165.4
+"decompress_mbps": 195.05
 },
 {
 "compressor": "zlib",
@@ -3078,7 +3077,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 275.55
+"decompress_mbps": 273.61
 },
 {
 "compressor": "miniz_oxide",
@@ -3088,7 +3087,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 298.54
+"decompress_mbps": 300.51
 },
 {
 "compressor": "libdeflate",
@@ -3098,7 +3097,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 467.75
+"decompress_mbps": 466.44
 },
 {
 "compressor": "memcpy",
@@ -3108,7 +3107,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 60912.79
+"decompress_mbps": 61394.03
 },
 {
 "compressor": "native",
@@ -3118,7 +3117,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 178.97
+"decompress_mbps": 218.08
 },
 {
 "compressor": "zlib",
@@ -3128,7 +3127,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 318.39
+"decompress_mbps": 316.05
 },
 {
 "compressor": "miniz_oxide",
@@ -3138,7 +3137,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 319.88
+"decompress_mbps": 321.4
 },
 {
 "compressor": "libdeflate",
@@ -3148,7 +3147,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 522.55
+"decompress_mbps": 518.18
 },
 {
 "compressor": "memcpy",
@@ -3158,7 +3157,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 59118.42
+"decompress_mbps": 61254.9
 },
 {
 "compressor": "native",
@@ -3168,7 +3167,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 178.07
+"decompress_mbps": 216.16
 },
 {
 "compressor": "zlib",
@@ -3178,7 +3177,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 311.37
+"decompress_mbps": 310.48
 },
 {
 "compressor": "miniz_oxide",
@@ -3188,7 +3187,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 313.34
+"decompress_mbps": 314.68
 },
 {
 "compressor": "libdeflate",
@@ -3198,7 +3197,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 510.07
+"decompress_mbps": 494.68
 },
 {
 "compressor": "memcpy",
@@ -3208,7 +3207,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 56443.3
+"decompress_mbps": 59775.19
 },
 {
 "compressor": "native",
@@ -3218,7 +3217,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 182.82
+"decompress_mbps": 233.15
 },
 {
 "compressor": "zlib",
@@ -3228,7 +3227,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 296.62
+"decompress_mbps": 295.17
 },
 {
 "compressor": "miniz_oxide",
@@ -3238,7 +3237,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 329.74
+"decompress_mbps": 323.71
 },
 {
 "compressor": "libdeflate",
@@ -3248,7 +3247,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 561.62
+"decompress_mbps": 552.2
 },
 {
 "compressor": "memcpy",
@@ -3258,7 +3257,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 59726.59
+"decompress_mbps": 56117.61
 },
 {
 "compressor": "native",
@@ -3268,7 +3267,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 177.2
+"decompress_mbps": 222.73
 },
 {
 "compressor": "zlib",
@@ -3278,7 +3277,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 287.1
+"decompress_mbps": 285.94
 },
 {
 "compressor": "miniz_oxide",
@@ -3288,7 +3287,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 326.7
+"decompress_mbps": 328.65
 },
 {
 "compressor": "libdeflate",
@@ -3298,7 +3297,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 558.23
+"decompress_mbps": 557.37
 },
 {
 "compressor": "memcpy",
@@ -3308,7 +3307,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 60149.79
+"decompress_mbps": 60392.51
 },
 {
 "compressor": "native",
@@ -3318,7 +3317,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 479.63
+"decompress_mbps": 528.16
 },
 {
 "compressor": "zlib",
@@ -3328,7 +3327,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 762.88
+"decompress_mbps": 748.43
 },
 {
 "compressor": "miniz_oxide",
@@ -3338,7 +3337,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 912.18
+"decompress_mbps": 914.74
 },
 {
 "compressor": "libdeflate",
@@ -3348,7 +3347,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 1664.62
+"decompress_mbps": 1578.7
 },
 {
 "compressor": "memcpy",
@@ -3358,7 +3357,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 63809.24
+"decompress_mbps": 61430.13
 },
 {
 "compressor": "native",
@@ -3368,7 +3367,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 596.87
+"decompress_mbps": 666.64
 },
 {
 "compressor": "zlib",
@@ -3378,7 +3377,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 854.07
+"decompress_mbps": 836.37
 },
 {
 "compressor": "miniz_oxide",
@@ -3388,7 +3387,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 1076.18
+"decompress_mbps": 1074.11
 },
 {
 "compressor": "libdeflate",
@@ -3398,7 +3397,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 1824.15
+"decompress_mbps": 1813.41
 },
 {
 "compressor": "memcpy",
@@ -3408,7 +3407,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 61720.2
+"decompress_mbps": 51650.08
 },
 {
 "compressor": "native",
@@ -3418,7 +3417,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 658.1
+"decompress_mbps": 704.5
 },
 {
 "compressor": "zlib",
@@ -3428,7 +3427,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 936.92
+"decompress_mbps": 882.29
 },
 {
 "compressor": "miniz_oxide",
@@ -3438,7 +3437,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 1189.73
+"decompress_mbps": 1172.77
 },
 {
 "compressor": "libdeflate",
@@ -3448,7 +3447,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 1824.93
+"decompress_mbps": 1784.7
 },
 {
 "compressor": "memcpy",
@@ -3458,7 +3457,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 65032.74
+"decompress_mbps": 64398.5
 },
 {
 "compressor": "native",
@@ -3468,7 +3467,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 684.64
+"decompress_mbps": 745.8
 },
 {
 "compressor": "zlib",
@@ -3478,7 +3477,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 965.09
+"decompress_mbps": 971.9
 },
 {
 "compressor": "miniz_oxide",
@@ -3488,7 +3487,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 1178.07
+"decompress_mbps": 1155.1
 },
 {
 "compressor": "libdeflate",
@@ -3498,7 +3497,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 1811.98
+"decompress_mbps": 1631.24
 },
 {
 "compressor": "memcpy",
@@ -3508,7 +3507,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 64472.61
+"decompress_mbps": 60878.44
 },
 {
 "compressor": "native",
@@ -3518,7 +3517,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 639.92
+"decompress_mbps": 695.02
 },
 {
 "compressor": "zlib",
@@ -3528,7 +3527,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 983.62
+"decompress_mbps": 1002.61
 },
 {
 "compressor": "miniz_oxide",
@@ -3538,7 +3537,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 1187.88
+"decompress_mbps": 1214.3
 },
 {
 "compressor": "libdeflate",
@@ -3548,7 +3547,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 1878.29
+"decompress_mbps": 1717.39
 },
 {
 "compressor": "memcpy",
@@ -3558,7 +3557,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 64293.72
+"decompress_mbps": 63962.16
 },
 {
 "compressor": "native",
@@ -3568,7 +3567,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 728.02
+"decompress_mbps": 772.9
 },
 {
 "compressor": "zlib",
@@ -3578,7 +3577,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 1001.81
+"decompress_mbps": 995.35
 },
 {
 "compressor": "miniz_oxide",
@@ -3588,7 +3587,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 1211.48
+"decompress_mbps": 1251.12
 },
 {
 "compressor": "libdeflate",
@@ -3598,7 +3597,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 1884.9
+"decompress_mbps": 1842.62
 },
 {
 "compressor": "memcpy",
@@ -3608,7 +3607,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 60159.27
+"decompress_mbps": 64603.35
 },
 {
 "compressor": "go",
@@ -3618,7 +3617,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 192.06
+"decompress_mbps": 193.35
 },
 {
 "compressor": "go",
@@ -3628,7 +3627,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 221.08
+"decompress_mbps": 221.11
 },
 {
 "compressor": "go",
@@ -3638,7 +3637,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 202.07
+"decompress_mbps": 208.84
 },
 {
 "compressor": "go",
@@ -3648,7 +3647,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 205.34
+"decompress_mbps": 208.9
 },
 {
 "compressor": "go",
@@ -3658,7 +3657,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 203.21
+"decompress_mbps": 206.08
 },
 {
 "compressor": "go",
@@ -3668,7 +3667,7 @@
 "out_size": 3673380,
 "ratio": 0.3604,
 "compress_mbps": null,
-"decompress_mbps": 214.43
+"decompress_mbps": 215.07
 },
 {
 "compressor": "go",
@@ -3678,7 +3677,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 231.18
+"decompress_mbps": 227.13
 },
 {
 "compressor": "go",
@@ -3688,7 +3687,7 @@
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 231.96
+"decompress_mbps": 232
 },
 {
 "compressor": "go",
@@ -3698,7 +3697,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 224.51
+"decompress_mbps": 225.31
 },
 {
 "compressor": "go",
@@ -3708,7 +3707,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 232.7
+"decompress_mbps": 230.27
 },
 {
 "compressor": "go",
@@ -3718,7 +3717,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 234.15
+"decompress_mbps": 237.98
 },
 {
 "compressor": "go",
@@ -3728,7 +3727,7 @@
 "out_size": 18317341,
 "ratio": 0.3576,
 "compress_mbps": null,
-"decompress_mbps": 238.76
+"decompress_mbps": 240.47
 },
 {
 "compressor": "go",
@@ -3738,7 +3737,7 @@
 "out_size": 3740775,
 "ratio": 0.3752,
 "compress_mbps": null,
-"decompress_mbps": 230.41
+"decompress_mbps": 234.62
 },
 {
 "compressor": "go",
@@ -3748,7 +3747,7 @@
 "out_size": 3447985,
 "ratio": 0.3458,
 "compress_mbps": null,
-"decompress_mbps": 235.41
+"decompress_mbps": 238.06
 },
 {
 "compressor": "go",
@@ -3758,7 +3757,7 @@
 "out_size": 3672389,
 "ratio": 0.3683,
 "compress_mbps": null,
-"decompress_mbps": 225.26
+"decompress_mbps": 227.19
 },
 {
 "compressor": "go",
@@ -3768,7 +3767,7 @@
 "out_size": 3648644,
 "ratio": 0.3659,
 "compress_mbps": null,
-"decompress_mbps": 232.08
+"decompress_mbps": 233.35
 },
 {
 "compressor": "go",
@@ -3778,7 +3777,7 @@
 "out_size": 3625176,
 "ratio": 0.3636,
 "compress_mbps": null,
-"decompress_mbps": 233
+"decompress_mbps": 231.02
 },
 {
 "compressor": "go",
@@ -3788,7 +3787,7 @@
 "out_size": 3450225,
 "ratio": 0.346,
 "compress_mbps": null,
-"decompress_mbps": 233.65
+"decompress_mbps": 233.98
 },
 {
 "compressor": "go",
@@ -3798,7 +3797,7 @@
 "out_size": 3837577,
 "ratio": 0.1144,
 "compress_mbps": null,
-"decompress_mbps": 580.78
+"decompress_mbps": 564.78
 },
 {
 "compressor": "go",
@@ -3808,7 +3807,7 @@
 "out_size": 2748273,
 "ratio": 0.0819,
 "compress_mbps": null,
-"decompress_mbps": 784.5
+"decompress_mbps": 736.46
 },
 {
 "compressor": "go",
@@ -3818,7 +3817,7 @@
 "out_size": 3599455,
 "ratio": 0.1073,
 "compress_mbps": null,
-"decompress_mbps": 599.89
+"decompress_mbps": 566.65
 },
 {
 "compressor": "go",
@@ -3828,7 +3827,7 @@
 "out_size": 3091741,
 "ratio": 0.0921,
 "compress_mbps": null,
-"decompress_mbps": 670.78
+"decompress_mbps": 670.76
 },
 {
 "compressor": "go",
@@ -3838,7 +3837,7 @@
 "out_size": 2925243,
 "ratio": 0.0872,
 "compress_mbps": null,
-"decompress_mbps": 741.92
+"decompress_mbps": 716.34
 },
 {
 "compressor": "go",
@@ -3848,7 +3847,7 @@
 "out_size": 2740598,
 "ratio": 0.0817,
 "compress_mbps": null,
-"decompress_mbps": 749.65
+"decompress_mbps": 760.64
 },
 {
 "compressor": "go",
@@ -3858,7 +3857,7 @@
 "out_size": 3275124,
 "ratio": 0.5324,
 "compress_mbps": null,
-"decompress_mbps": 168.31
+"decompress_mbps": 170.14
 },
 {
 "compressor": "go",
@@ -3868,7 +3867,7 @@
 "out_size": 2994086,
 "ratio": 0.4867,
 "compress_mbps": null,
-"decompress_mbps": 160.64
+"decompress_mbps": 161.28
 },
 {
 "compressor": "go",
@@ -3878,7 +3877,7 @@
 "out_size": 3137061,
 "ratio": 0.5099,
 "compress_mbps": null,
-"decompress_mbps": 155.39
+"decompress_mbps": 160.44
 },
 {
 "compressor": "go",
@@ -3888,7 +3887,7 @@
 "out_size": 3072378,
 "ratio": 0.4994,
 "compress_mbps": null,
-"decompress_mbps": 166
+"decompress_mbps": 168.67
 },
 {
 "compressor": "go",
@@ -3898,7 +3897,7 @@
 "out_size": 3066968,
 "ratio": 0.4985,
 "compress_mbps": null,
-"decompress_mbps": 169.75
+"decompress_mbps": 169.33
 },
 {
 "compressor": "go",
@@ -3908,7 +3907,7 @@
 "out_size": 2992113,
 "ratio": 0.4863,
 "compress_mbps": null,
-"decompress_mbps": 160.99
+"decompress_mbps": 160.83
 },
 {
 "compressor": "go",
@@ -3918,7 +3917,7 @@
 "out_size": 3868663,
 "ratio": 0.3836,
 "compress_mbps": null,
-"decompress_mbps": 253.4
+"decompress_mbps": 256.33
 },
 {
 "compressor": "go",
@@ -3928,7 +3927,7 @@
 "out_size": 3608138,
 "ratio": 0.3577,
 "compress_mbps": null,
-"decompress_mbps": 269.43
+"decompress_mbps": 274.17
 },
 {
 "compressor": "go",
@@ -3938,7 +3937,7 @@
 "out_size": 3818964,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 262.57
+"decompress_mbps": 275.09
 },
 {
 "compressor": "go",
@@ -3948,7 +3947,7 @@
 "out_size": 3660266,
 "ratio": 0.3629,
 "compress_mbps": null,
-"decompress_mbps": 269.49
+"decompress_mbps": 272.69
 },
 {
 "compressor": "go",
@@ -3958,7 +3957,7 @@
 "out_size": 3654860,
 "ratio": 0.3624,
 "compress_mbps": null,
-"decompress_mbps": 270.57
+"decompress_mbps": 274.42
 },
 {
 "compressor": "go",
@@ -3968,7 +3967,7 @@
 "out_size": 3607217,
 "ratio": 0.3577,
 "compress_mbps": null,
-"decompress_mbps": 285.93
+"decompress_mbps": 285.61
 },
 {
 "compressor": "go",
@@ -3978,7 +3977,7 @@
 "out_size": 2197055,
 "ratio": 0.3315,
 "compress_mbps": null,
-"decompress_mbps": 227.09
+"decompress_mbps": 230.01
 },
 {
 "compressor": "go",
@@ -3988,7 +3987,7 @@
 "out_size": 1696488,
 "ratio": 0.256,
 "compress_mbps": null,
-"decompress_mbps": 283.58
+"decompress_mbps": 284.38
 },
 {
 "compressor": "go",
@@ -3998,7 +3997,7 @@
 "out_size": 2021047,
 "ratio": 0.305,
 "compress_mbps": null,
-"decompress_mbps": 256.09
+"decompress_mbps": 257.75
 },
 {
 "compressor": "go",
@@ -4008,7 +4007,7 @@
 "out_size": 1876257,
 "ratio": 0.2831,
 "compress_mbps": null,
-"decompress_mbps": 262.67
+"decompress_mbps": 262.18
 },
 {
 "compressor": "go",
@@ -4018,7 +4017,7 @@
 "out_size": 1806374,
 "ratio": 0.2726,
 "compress_mbps": null,
-"decompress_mbps": 260.9
+"decompress_mbps": 257.63
 },
 {
 "compressor": "go",
@@ -4028,7 +4027,7 @@
 "out_size": 1691994,
 "ratio": 0.2553,
 "compress_mbps": null,
-"decompress_mbps": 285.32
+"decompress_mbps": 291.56
 },
 {
 "compressor": "go",
@@ -4038,7 +4037,7 @@
 "out_size": 5866517,
 "ratio": 0.2715,
 "compress_mbps": null,
-"decompress_mbps": 306.97
+"decompress_mbps": 304.25
 },
 {
 "compressor": "go",
@@ -4048,7 +4047,7 @@
 "out_size": 5118130,
 "ratio": 0.2369,
 "compress_mbps": null,
-"decompress_mbps": 324.28
+"decompress_mbps": 326.16
 },
 {
 "compressor": "go",
@@ -4058,7 +4057,7 @@
 "out_size": 5605878,
 "ratio": 0.2595,
 "compress_mbps": null,
-"decompress_mbps": 316.81
+"decompress_mbps": 316.44
 },
 {
 "compressor": "go",
@@ -4068,7 +4067,7 @@
 "out_size": 5337149,
 "ratio": 0.247,
 "compress_mbps": null,
-"decompress_mbps": 323.75
+"decompress_mbps": 328.56
 },
 {
 "compressor": "go",
@@ -4078,7 +4077,7 @@
 "out_size": 5270405,
 "ratio": 0.2439,
 "compress_mbps": null,
-"decompress_mbps": 328.64
+"decompress_mbps": 331.47
 },
 {
 "compressor": "go",
@@ -4088,7 +4087,7 @@
 "out_size": 5107588,
 "ratio": 0.2364,
 "compress_mbps": null,
-"decompress_mbps": 344.93
+"decompress_mbps": 350.2
 },
 {
 "compressor": "go",
@@ -4098,7 +4097,7 @@
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 182.22
+"decompress_mbps": 188.98
 },
 {
 "compressor": "go",
@@ -4108,7 +4107,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 188.68
+"decompress_mbps": 188.85
 },
 {
 "compressor": "go",
@@ -4118,7 +4117,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 187.28
+"decompress_mbps": 186.55
 },
 {
 "compressor": "go",
@@ -4128,7 +4127,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 186.08
+"decompress_mbps": 186.76
 },
 {
 "compressor": "go",
@@ -4138,7 +4137,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 188.75
+"decompress_mbps": 190.74
 },
 {
 "compressor": "go",
@@ -4148,7 +4147,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 186.36
+"decompress_mbps": 184.62
 },
 {
 "compressor": "go",
@@ -4158,7 +4157,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 225.06
+"decompress_mbps": 226.37
 },
 {
 "compressor": "go",
@@ -4168,7 +4167,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 256.66
+"decompress_mbps": 256.34
 },
 {
 "compressor": "go",
@@ -4178,7 +4177,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 242.54
+"decompress_mbps": 246.06
 },
 {
 "compressor": "go",
@@ -4188,7 +4187,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 247.96
+"decompress_mbps": 248.64
 },
 {
 "compressor": "go",
@@ -4198,7 +4197,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 250.83
+"decompress_mbps": 251.13
 },
 {
 "compressor": "go",
@@ -4208,7 +4207,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 256.89
+"decompress_mbps": 266.97
 },
 {
 "compressor": "go",
@@ -4218,7 +4217,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 166.3
+"decompress_mbps": 172.09
 },
 {
 "compressor": "go",
@@ -4228,7 +4227,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 140.99
+"decompress_mbps": 141.68
 },
 {
 "compressor": "go",
@@ -4238,7 +4237,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 144.96
+"decompress_mbps": 142.47
 },
 {
 "compressor": "go",
@@ -4248,7 +4247,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 152.03
+"decompress_mbps": 152.94
 },
 {
 "compressor": "go",
@@ -4258,7 +4257,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 149.13
+"decompress_mbps": 150.92
 },
 {
 "compressor": "go",
@@ -4268,7 +4267,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 136.8
+"decompress_mbps": 138.17
 },
 {
 "compressor": "go",
@@ -4278,7 +4277,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 440.5
+"decompress_mbps": 432.36
 },
 {
 "compressor": "go",
@@ -4288,7 +4287,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 615.59
+"decompress_mbps": 608.77
 },
 {
 "compressor": "go",
@@ -4298,7 +4297,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 507.61
+"decompress_mbps": 518.58
 },
 {
 "compressor": "go",
@@ -4308,7 +4307,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 581.96
+"decompress_mbps": 591.23
 },
 {
 "compressor": "go",
@@ -4318,7 +4317,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 607.22
+"decompress_mbps": 615.66
 },
 {
 "compressor": "go",
@@ -4328,7 +4327,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 618.22
+"decompress_mbps": 638.03
 },
 {
 "compressor": "js",
@@ -4338,7 +4337,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 110.32
+"decompress_mbps": 110.14
 },
 {
 "compressor": "js",
@@ -4348,7 +4347,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 121.35
+"decompress_mbps": 122.5
 },
 {
 "compressor": "js",
@@ -4358,7 +4357,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 135.89
+"decompress_mbps": 123.96
 },
 {
 "compressor": "js",
@@ -4368,7 +4367,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 135.35
+"decompress_mbps": 128.49
 },
 {
 "compressor": "js",
@@ -4378,7 +4377,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 122.04
+"decompress_mbps": 119.14
 },
 {
 "compressor": "js",
@@ -4388,7 +4387,7 @@
 "out_size": 3673380,
 "ratio": 0.3604,
 "compress_mbps": null,
-"decompress_mbps": 129.36
+"decompress_mbps": 138.5
 },
 {
 "compressor": "js",
@@ -4398,7 +4397,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 157.13
+"decompress_mbps": 160.15
 },
 {
 "compressor": "js",
@@ -4408,7 +4407,7 @@
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 151.8
+"decompress_mbps": 157.1
 },
 {
 "compressor": "js",
@@ -4418,7 +4417,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 155.7
+"decompress_mbps": 167.58
 },
 {
 "compressor": "js",
@@ -4428,7 +4427,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 184.47
+"decompress_mbps": 160.42
 },
 {
 "compressor": "js",
@@ -4438,7 +4437,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 161.51
+"decompress_mbps": 163.37
 },
 {
 "compressor": "js",
@@ -4448,7 +4447,7 @@
 "out_size": 18317341,
 "ratio": 0.3576,
 "compress_mbps": null,
-"decompress_mbps": 179.47
+"decompress_mbps": 167.08
 },
 {
 "compressor": "js",
@@ -4458,7 +4457,7 @@
 "out_size": 3740775,
 "ratio": 0.3752,
 "compress_mbps": null,
-"decompress_mbps": 139.97
+"decompress_mbps": 207.49
 },
 {
 "compressor": "js",
@@ -4468,7 +4467,7 @@
 "out_size": 3447985,
 "ratio": 0.3458,
 "compress_mbps": null,
-"decompress_mbps": 140.17
+"decompress_mbps": 142.94
 },
 {
 "compressor": "js",
@@ -4478,7 +4477,7 @@
 "out_size": 3672389,
 "ratio": 0.3683,
 "compress_mbps": null,
-"decompress_mbps": 142.22
+"decompress_mbps": 143.79
 },
 {
 "compressor": "js",
@@ -4488,7 +4487,7 @@
 "out_size": 3648644,
 "ratio": 0.3659,
 "compress_mbps": null,
-"decompress_mbps": 135.12
+"decompress_mbps": 136.58
 },
 {
 "compressor": "js",
@@ -4498,7 +4497,7 @@
 "out_size": 3625176,
 "ratio": 0.3636,
 "compress_mbps": null,
-"decompress_mbps": 134.98
+"decompress_mbps": 136.62
 },
 {
 "compressor": "js",
@@ -4508,7 +4507,7 @@
 "out_size": 3450225,
 "ratio": 0.346,
 "compress_mbps": null,
-"decompress_mbps": 135.73
+"decompress_mbps": 166.81
 },
 {
 "compressor": "js",
@@ -4518,7 +4517,7 @@
 "out_size": 3837577,
 "ratio": 0.1144,
 "compress_mbps": null,
-"decompress_mbps": 247.01
+"decompress_mbps": 243.91
 },
 {
 "compressor": "js",
@@ -4528,7 +4527,7 @@
 "out_size": 2748273,
 "ratio": 0.0819,
 "compress_mbps": null,
-"decompress_mbps": 288.55
+"decompress_mbps": 290.14
 },
 {
 "compressor": "js",
@@ -4538,7 +4537,7 @@
 "out_size": 3599455,
 "ratio": 0.1073,
 "compress_mbps": null,
-"decompress_mbps": 285.59
+"decompress_mbps": 283.6
 },
 {
 "compressor": "js",
@@ -4548,7 +4547,7 @@
 "out_size": 3091741,
 "ratio": 0.0921,
 "compress_mbps": null,
-"decompress_mbps": 315.73
+"decompress_mbps": 317.73
 },
 {
 "compressor": "js",
@@ -4558,7 +4557,7 @@
 "out_size": 2925243,
 "ratio": 0.0872,
 "compress_mbps": null,
-"decompress_mbps": 325.56
+"decompress_mbps": 269.85
 },
 {
 "compressor": "js",
@@ -4568,7 +4567,7 @@
 "out_size": 2740598,
 "ratio": 0.0817,
 "compress_mbps": null,
-"decompress_mbps": 282.97
+"decompress_mbps": 292.01
 },
 {
 "compressor": "js",
@@ -4577,398 +4576,398 @@
 "level": 1,
 "out_size": 3275124,
 "ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 104.07
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 99.41
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 112.93
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 112.53
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 105.2
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 88.37
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 147.74
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 168.12
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 174.86
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 179.12
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 150.11
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 166.98
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 156.64
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 146.18
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 148.1
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 143.46
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 145.31
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 0,
+"out_size": 1691994,
+"ratio": 0.2553,
+"compress_mbps": null,
+"decompress_mbps": 115.64
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 210.36
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 149.97
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 200.34
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 166.89
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 173.66
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 0,
+"out_size": 5107588,
+"ratio": 0.2364,
+"compress_mbps": null,
+"decompress_mbps": 140.95
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 99.04
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 12,
+"out_size": 5250745,
+"ratio": 0.724,
+"compress_mbps": null,
+"decompress_mbps": 103.98
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 108.26
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 101.43
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323197,
+"ratio": 0.734,
+"compress_mbps": null,
+"decompress_mbps": 112.29
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 0,
+"out_size": 5242394,
+"ratio": 0.7229,
+"compress_mbps": null,
+"decompress_mbps": 114.55
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 13550569,
+"ratio": 0.3268,
+"compress_mbps": null,
+"decompress_mbps": 143.16
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 12,
+"out_size": 11520871,
+"ratio": 0.2779,
+"compress_mbps": null,
+"decompress_mbps": 153.51
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 12839361,
+"ratio": 0.3097,
+"compress_mbps": null,
+"decompress_mbps": 149.43
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12140474,
+"ratio": 0.2928,
+"compress_mbps": null,
+"decompress_mbps": 151.24
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 11882496,
+"ratio": 0.2866,
+"compress_mbps": null,
+"decompress_mbps": 155.53
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 0,
+"out_size": 11518290,
+"ratio": 0.2778,
+"compress_mbps": null,
+"decompress_mbps": 155.38
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6293390,
+"ratio": 0.7426,
+"compress_mbps": null,
+"decompress_mbps": 106.96
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 12,
+"out_size": 5747146,
+"ratio": 0.6782,
+"compress_mbps": null,
+"decompress_mbps": 108.56
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6058381,
+"ratio": 0.7149,
 "compress_mbps": null,
 "decompress_mbps": 103.44
 },
 {
 "compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 100.24
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 111.59
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 112.08
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 100.54
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 0,
-"out_size": 2992113,
-"ratio": 0.4863,
-"compress_mbps": null,
-"decompress_mbps": 86.65
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 147.38
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 179.06
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 162.32
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 176.1
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 161.28
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 0,
-"out_size": 3607217,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 178.95
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 116.87
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 143.07
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 147.34
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 143.54
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 144.39
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 0,
-"out_size": 1691994,
-"ratio": 0.2553,
-"compress_mbps": null,
-"decompress_mbps": 107.62
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 171.56
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 169.28
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 157
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 167.34
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 175.15
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 0,
-"out_size": 5107588,
-"ratio": 0.2364,
-"compress_mbps": null,
-"decompress_mbps": 190.12
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 99.87
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 12,
-"out_size": 5250745,
-"ratio": 0.724,
-"compress_mbps": null,
-"decompress_mbps": 98.34
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 104.89
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 100.16
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": null,
-"decompress_mbps": 107.95
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 0,
-"out_size": 5242394,
-"ratio": 0.7229,
-"compress_mbps": null,
-"decompress_mbps": 112.69
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13550569,
-"ratio": 0.3268,
-"compress_mbps": null,
-"decompress_mbps": 141.66
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 12,
-"out_size": 11520871,
-"ratio": 0.2779,
-"compress_mbps": null,
-"decompress_mbps": 158.68
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12839361,
-"ratio": 0.3097,
-"compress_mbps": null,
-"decompress_mbps": 148.82
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12140474,
-"ratio": 0.2928,
-"compress_mbps": null,
-"decompress_mbps": 154.56
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11882496,
-"ratio": 0.2866,
-"compress_mbps": null,
-"decompress_mbps": 162.66
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 0,
-"out_size": 11518290,
-"ratio": 0.2778,
-"compress_mbps": null,
-"decompress_mbps": 145.3
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6293390,
-"ratio": 0.7426,
-"compress_mbps": null,
-"decompress_mbps": 100.14
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 12,
-"out_size": 5747146,
-"ratio": 0.6782,
-"compress_mbps": null,
-"decompress_mbps": 107.98
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6058381,
-"ratio": 0.7149,
-"compress_mbps": null,
-"decompress_mbps": 102.33
-},
-{
-"compressor": "js",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 6,
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 94.73
+"decompress_mbps": 97.98
 },
 {
 "compressor": "js",
@@ -4978,7 +4977,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 105.01
+"decompress_mbps": 106.61
 },
 {
 "compressor": "js",
@@ -4988,7 +4987,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 96.26
+"decompress_mbps": 96.62
 },
 {
 "compressor": "js",
@@ -4998,7 +4997,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 183.84
+"decompress_mbps": 173.61
 },
 {
 "compressor": "js",
@@ -5008,7 +5007,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 269.82
+"decompress_mbps": 275.06
 },
 {
 "compressor": "js",
@@ -5018,7 +5017,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 181.01
+"decompress_mbps": 194.12
 },
 {
 "compressor": "js",
@@ -5028,7 +5027,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 241.09
+"decompress_mbps": 250.31
 },
 {
 "compressor": "js",
@@ -5038,7 +5037,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 241.61
+"decompress_mbps": 260.4
 },
 {
 "compressor": "js",
@@ -5048,7 +5047,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 150.18
+"decompress_mbps": 237.32
 },
 {
 "compressor": "zig",
@@ -5058,7 +5057,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 221.52
+"decompress_mbps": 229.82
 },
 {
 "compressor": "zig",
@@ -5068,7 +5067,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 279.11
+"decompress_mbps": 288.96
 },
 {
 "compressor": "zig",
@@ -5078,7 +5077,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 271.68
+"decompress_mbps": 272.53
 },
 {
 "compressor": "zig",
@@ -5088,7 +5087,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 268.18
+"decompress_mbps": 270.12
 },
 {
 "compressor": "zig",
@@ -5098,7 +5097,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 261.3
+"decompress_mbps": 260.97
 },
 {
 "compressor": "zig",
@@ -5108,7 +5107,7 @@
 "out_size": 3673380,
 "ratio": 0.3604,
 "compress_mbps": null,
-"decompress_mbps": 280.48
+"decompress_mbps": 281.0
 },
 {
 "compressor": "zig",
@@ -5118,7 +5117,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 235.66
+"decompress_mbps": 232.81
 },
 {
 "compressor": "zig",
@@ -5128,7 +5127,7 @@
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 217.47
+"decompress_mbps": 213.99
 },
 {
 "compressor": "zig",
@@ -5138,7 +5137,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 217.25
+"decompress_mbps": 214.61
 },
 {
 "compressor": "zig",
@@ -5148,7 +5147,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 227.9
+"decompress_mbps": 224.17
 },
 {
 "compressor": "zig",
@@ -5158,7 +5157,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 231.3
+"decompress_mbps": 226.08
 },
 {
 "compressor": "zig",
@@ -5168,7 +5167,7 @@
 "out_size": 18317341,
 "ratio": 0.3576,
 "compress_mbps": null,
-"decompress_mbps": 252.69
+"decompress_mbps": 247.31
 },
 {
 "compressor": "zig",
@@ -5178,7 +5177,7 @@
 "out_size": 3740775,
 "ratio": 0.3752,
 "compress_mbps": null,
-"decompress_mbps": 231.68
+"decompress_mbps": 231.7
 },
 {
 "compressor": "zig",
@@ -5188,7 +5187,7 @@
 "out_size": 3447985,
 "ratio": 0.3458,
 "compress_mbps": null,
-"decompress_mbps": 267.47
+"decompress_mbps": 265.03
 },
 {
 "compressor": "zig",
@@ -5198,7 +5197,7 @@
 "out_size": 3672389,
 "ratio": 0.3683,
 "compress_mbps": null,
-"decompress_mbps": 260.13
+"decompress_mbps": 255.75
 },
 {
 "compressor": "zig",
@@ -5208,7 +5207,7 @@
 "out_size": 3648644,
 "ratio": 0.3659,
 "compress_mbps": null,
-"decompress_mbps": 267.23
+"decompress_mbps": 267.19
 },
 {
 "compressor": "zig",
@@ -5218,7 +5217,7 @@
 "out_size": 3625176,
 "ratio": 0.3636,
 "compress_mbps": null,
-"decompress_mbps": 269.92
+"decompress_mbps": 266.17
 },
 {
 "compressor": "zig",
@@ -5228,7 +5227,7 @@
 "out_size": 3450225,
 "ratio": 0.346,
 "compress_mbps": null,
-"decompress_mbps": 250.54
+"decompress_mbps": 248.42
 },
 {
 "compressor": "zig",
@@ -5238,7 +5237,7 @@
 "out_size": 3837577,
 "ratio": 0.1144,
 "compress_mbps": null,
-"decompress_mbps": 681.98
+"decompress_mbps": 671.94
 },
 {
 "compressor": "zig",
@@ -5248,7 +5247,7 @@
 "out_size": 2748273,
 "ratio": 0.0819,
 "compress_mbps": null,
-"decompress_mbps": 850.06
+"decompress_mbps": 842.43
 },
 {
 "compressor": "zig",
@@ -5258,7 +5257,7 @@
 "out_size": 3599455,
 "ratio": 0.1073,
 "compress_mbps": null,
-"decompress_mbps": 740.59
+"decompress_mbps": 734.95
 },
 {
 "compressor": "zig",
@@ -5268,7 +5267,7 @@
 "out_size": 3091741,
 "ratio": 0.0921,
 "compress_mbps": null,
-"decompress_mbps": 837.02
+"decompress_mbps": 836.62
 },
 {
 "compressor": "zig",
@@ -5278,7 +5277,7 @@
 "out_size": 2925243,
 "ratio": 0.0872,
 "compress_mbps": null,
-"decompress_mbps": 898.09
+"decompress_mbps": 893.28
 },
 {
 "compressor": "zig",
@@ -5288,7 +5287,7 @@
 "out_size": 2740598,
 "ratio": 0.0817,
 "compress_mbps": null,
-"decompress_mbps": 929.1
+"decompress_mbps": 935.11
 },
 {
 "compressor": "zig",
@@ -5298,7 +5297,7 @@
 "out_size": 3275124,
 "ratio": 0.5324,
 "compress_mbps": null,
-"decompress_mbps": 175.52
+"decompress_mbps": 174.65
 },
 {
 "compressor": "zig",
@@ -5308,7 +5307,7 @@
 "out_size": 2994086,
 "ratio": 0.4867,
 "compress_mbps": null,
-"decompress_mbps": 180.02
+"decompress_mbps": 177.75
 },
 {
 "compressor": "zig",
@@ -5318,7 +5317,7 @@
 "out_size": 3137061,
 "ratio": 0.5099,
 "compress_mbps": null,
-"decompress_mbps": 176.42
+"decompress_mbps": 173.58
 },
 {
 "compressor": "zig",
@@ -5328,7 +5327,7 @@
 "out_size": 3072378,
 "ratio": 0.4994,
 "compress_mbps": null,
-"decompress_mbps": 184.48
+"decompress_mbps": 181.63
 },
 {
 "compressor": "zig",
@@ -5338,7 +5337,7 @@
 "out_size": 3066968,
 "ratio": 0.4985,
 "compress_mbps": null,
-"decompress_mbps": 187.36
+"decompress_mbps": 184.6
 },
 {
 "compressor": "zig",
@@ -5348,7 +5347,7 @@
 "out_size": 2992113,
 "ratio": 0.4863,
 "compress_mbps": null,
-"decompress_mbps": 181.46
+"decompress_mbps": 178.38
 },
 {
 "compressor": "zig",
@@ -5358,7 +5357,7 @@
 "out_size": 3868663,
 "ratio": 0.3836,
 "compress_mbps": null,
-"decompress_mbps": 253.03
+"decompress_mbps": 252.89
 },
 {
 "compressor": "zig",
@@ -5368,7 +5367,7 @@
 "out_size": 3608138,
 "ratio": 0.3577,
 "compress_mbps": null,
-"decompress_mbps": 290.53
+"decompress_mbps": 289.98
 },
 {
 "compressor": "zig",
@@ -5378,7 +5377,7 @@
 "out_size": 3818964,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 282.62
+"decompress_mbps": 285.0
 },
 {
 "compressor": "zig",
@@ -5388,7 +5387,7 @@
 "out_size": 3660266,
 "ratio": 0.3629,
 "compress_mbps": null,
-"decompress_mbps": 286.75
+"decompress_mbps": 288.37
 },
 {
 "compressor": "zig",
@@ -5398,7 +5397,7 @@
 "out_size": 3654860,
 "ratio": 0.3624,
 "compress_mbps": null,
-"decompress_mbps": 287.31
+"decompress_mbps": 286.14
 },
 {
 "compressor": "zig",
@@ -5408,7 +5407,7 @@
 "out_size": 3607217,
 "ratio": 0.3577,
 "compress_mbps": null,
-"decompress_mbps": 289.16
+"decompress_mbps": 288.7
 },
 {
 "compressor": "zig",
@@ -5418,7 +5417,7 @@
 "out_size": 2197055,
 "ratio": 0.3315,
 "compress_mbps": null,
-"decompress_mbps": 286.4
+"decompress_mbps": 283.32
 },
 {
 "compressor": "zig",
@@ -5428,7 +5427,7 @@
 "out_size": 1696488,
 "ratio": 0.256,
 "compress_mbps": null,
-"decompress_mbps": 374.93
+"decompress_mbps": 369.59
 },
 {
 "compressor": "zig",
@@ -5438,7 +5437,7 @@
 "out_size": 2021047,
 "ratio": 0.305,
 "compress_mbps": null,
-"decompress_mbps": 352.79
+"decompress_mbps": 347.38
 },
 {
 "compressor": "zig",
@@ -5448,7 +5447,7 @@
 "out_size": 1876257,
 "ratio": 0.2831,
 "compress_mbps": null,
-"decompress_mbps": 355.31
+"decompress_mbps": 351.24
 },
 {
 "compressor": "zig",
@@ -5458,7 +5457,7 @@
 "out_size": 1806374,
 "ratio": 0.2726,
 "compress_mbps": null,
-"decompress_mbps": 347.95
+"decompress_mbps": 345.68
 },
 {
 "compressor": "zig",
@@ -5468,7 +5467,7 @@
 "out_size": 1691994,
 "ratio": 0.2553,
 "compress_mbps": null,
-"decompress_mbps": 380.13
+"decompress_mbps": 377.82
 },
 {
 "compressor": "zig",
@@ -5478,7 +5477,7 @@
 "out_size": 5866517,
 "ratio": 0.2715,
 "compress_mbps": null,
-"decompress_mbps": 349.73
+"decompress_mbps": 352.43
 },
 {
 "compressor": "zig",
@@ -5488,7 +5487,7 @@
 "out_size": 5118130,
 "ratio": 0.2369,
 "compress_mbps": null,
-"decompress_mbps": 329.93
+"decompress_mbps": 329.1
 },
 {
 "compressor": "zig",
@@ -5498,7 +5497,7 @@
 "out_size": 5605878,
 "ratio": 0.2595,
 "compress_mbps": null,
-"decompress_mbps": 342.11
+"decompress_mbps": 340.12
 },
 {
 "compressor": "zig",
@@ -5508,7 +5507,7 @@
 "out_size": 5337149,
 "ratio": 0.247,
 "compress_mbps": null,
-"decompress_mbps": 365.6
+"decompress_mbps": 360.43
 },
 {
 "compressor": "zig",
@@ -5518,7 +5517,7 @@
 "out_size": 5270405,
 "ratio": 0.2439,
 "compress_mbps": null,
-"decompress_mbps": 369.05
+"decompress_mbps": 365.35
 },
 {
 "compressor": "zig",
@@ -5528,7 +5527,7 @@
 "out_size": 5107588,
 "ratio": 0.2364,
 "compress_mbps": null,
-"decompress_mbps": 398.36
+"decompress_mbps": 396.56
 },
 {
 "compressor": "zig",
@@ -5538,7 +5537,7 @@
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 159.66
+"decompress_mbps": 162.24
 },
 {
 "compressor": "zig",
@@ -5548,7 +5547,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 174.01
+"decompress_mbps": 178.91
 },
 {
 "compressor": "zig",
@@ -5558,7 +5557,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 172.0
+"decompress_mbps": 175.28
 },
 {
 "compressor": "zig",
@@ -5568,7 +5567,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 173.41
+"decompress_mbps": 177.62
 },
 {
 "compressor": "zig",
@@ -5578,7 +5577,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 175.23
+"decompress_mbps": 176.28
 },
 {
 "compressor": "zig",
@@ -5588,7 +5587,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 165.88
+"decompress_mbps": 167.38
 },
 {
 "compressor": "zig",
@@ -5598,7 +5597,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 275.01
+"decompress_mbps": 277.12
 },
 {
 "compressor": "zig",
@@ -5608,7 +5607,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 330.5
+"decompress_mbps": 331.36
 },
 {
 "compressor": "zig",
@@ -5618,7 +5617,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 316.23
+"decompress_mbps": 317.86
 },
 {
 "compressor": "zig",
@@ -5628,7 +5627,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 326.18
+"decompress_mbps": 324.83
 },
 {
 "compressor": "zig",
@@ -5638,7 +5637,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 328.09
+"decompress_mbps": 324.65
 },
 {
 "compressor": "zig",
@@ -5648,7 +5647,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 338.32
+"decompress_mbps": 336.19
 },
 {
 "compressor": "zig",
@@ -5658,7 +5657,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 150.88
+"decompress_mbps": 150.12
 },
 {
 "compressor": "zig",
@@ -5668,7 +5667,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 149.76
+"decompress_mbps": 144.47
 },
 {
 "compressor": "zig",
@@ -5678,7 +5677,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 143.82
+"decompress_mbps": 138.61
 },
 {
 "compressor": "zig",
@@ -5688,7 +5687,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 157.28
+"decompress_mbps": 149.51
 },
 {
 "compressor": "zig",
@@ -5698,7 +5697,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 154.91
+"decompress_mbps": 152.88
 },
 {
 "compressor": "zig",
@@ -5708,7 +5707,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 145.13
+"decompress_mbps": 142.17
 },
 {
 "compressor": "zig",
@@ -5718,7 +5717,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 507.13
+"decompress_mbps": 504.77
 },
 {
 "compressor": "zig",
@@ -5728,7 +5727,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 667.01
+"decompress_mbps": 662.69
 },
 {
 "compressor": "zig",
@@ -5738,7 +5737,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 600.84
+"decompress_mbps": 602.07
 },
 {
 "compressor": "zig",
@@ -5748,7 +5747,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 668.37
+"decompress_mbps": 659.81
 },
 {
 "compressor": "zig",
@@ -5758,7 +5757,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 685.14
+"decompress_mbps": 678.61
 },
 {
 "compressor": "zig",
@@ -5768,7 +5767,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 710.32
+"decompress_mbps": 700.89
 },
 {
 "compressor": "ocaml",
@@ -5778,7 +5777,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 105.29
+"decompress_mbps": 106.29
 },
 {
 "compressor": "ocaml",
@@ -5788,7 +5787,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 115.26
+"decompress_mbps": 115.74
 },
 {
 "compressor": "ocaml",
@@ -5798,7 +5797,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 110.2
+"decompress_mbps": 110.12
 },
 {
 "compressor": "ocaml",
@@ -5808,7 +5807,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 111.7
+"decompress_mbps": 112.04
 },
 {
 "compressor": "ocaml",
@@ -5818,7 +5817,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 112.72
+"decompress_mbps": 109.51
 },
 {
 "compressor": "ocaml",
@@ -5828,7 +5827,7 @@
 "out_size": 3673380,
 "ratio": 0.3604,
 "compress_mbps": null,
-"decompress_mbps": 110.97
+"decompress_mbps": 114.84
 },
 {
 "compressor": "ocaml",
@@ -5838,7 +5837,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 122.7
+"decompress_mbps": 119.41
 },
 {
 "compressor": "ocaml",
@@ -5848,7 +5847,7 @@
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 116.84
+"decompress_mbps": 114.65
 },
 {
 "compressor": "ocaml",
@@ -5858,7 +5857,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 112.59
+"decompress_mbps": 113.63
 },
 {
 "compressor": "ocaml",
@@ -5868,7 +5867,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 116.2
+"decompress_mbps": 116.66
 },
 {
 "compressor": "ocaml",
@@ -5878,7 +5877,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 120.86
+"decompress_mbps": 119.22
 },
 {
 "compressor": "ocaml",
@@ -5888,7 +5887,7 @@
 "out_size": 18317341,
 "ratio": 0.3576,
 "compress_mbps": null,
-"decompress_mbps": 123.3
+"decompress_mbps": 124.65
 },
 {
 "compressor": "ocaml",
@@ -5898,7 +5897,7 @@
 "out_size": 3740775,
 "ratio": 0.3752,
 "compress_mbps": null,
-"decompress_mbps": 135.81
+"decompress_mbps": 138.85
 },
 {
 "compressor": "ocaml",
@@ -5908,7 +5907,7 @@
 "out_size": 3447985,
 "ratio": 0.3458,
 "compress_mbps": null,
-"decompress_mbps": 132.57
+"decompress_mbps": 133.58
 },
 {
 "compressor": "ocaml",
@@ -5918,7 +5917,7 @@
 "out_size": 3672389,
 "ratio": 0.3683,
 "compress_mbps": null,
-"decompress_mbps": 129.0
+"decompress_mbps": 134.54
 },
 {
 "compressor": "ocaml",
@@ -5928,7 +5927,7 @@
 "out_size": 3648644,
 "ratio": 0.3659,
 "compress_mbps": null,
-"decompress_mbps": 133.44
+"decompress_mbps": 135.27
 },
 {
 "compressor": "ocaml",
@@ -5938,7 +5937,7 @@
 "out_size": 3625176,
 "ratio": 0.3636,
 "compress_mbps": null,
-"decompress_mbps": 132.48
+"decompress_mbps": 137.15
 },
 {
 "compressor": "ocaml",
@@ -5948,7 +5947,7 @@
 "out_size": 3450225,
 "ratio": 0.346,
 "compress_mbps": null,
-"decompress_mbps": 135.63
+"decompress_mbps": 135.64
 },
 {
 "compressor": "ocaml",
@@ -5958,7 +5957,7 @@
 "out_size": 3837577,
 "ratio": 0.1144,
 "compress_mbps": null,
-"decompress_mbps": 213.53
+"decompress_mbps": 204.76
 },
 {
 "compressor": "ocaml",
@@ -5968,7 +5967,7 @@
 "out_size": 2748273,
 "ratio": 0.0819,
 "compress_mbps": null,
-"decompress_mbps": 233.62
+"decompress_mbps": 236.98
 },
 {
 "compressor": "ocaml",
@@ -5978,7 +5977,7 @@
 "out_size": 3599455,
 "ratio": 0.1073,
 "compress_mbps": null,
-"decompress_mbps": 220.32
+"decompress_mbps": 209.2
 },
 {
 "compressor": "ocaml",
@@ -5988,7 +5987,7 @@
 "out_size": 3091741,
 "ratio": 0.0921,
 "compress_mbps": null,
-"decompress_mbps": 222.14
+"decompress_mbps": 229.25
 },
 {
 "compressor": "ocaml",
@@ -5998,7 +5997,7 @@
 "out_size": 2925243,
 "ratio": 0.0872,
 "compress_mbps": null,
-"decompress_mbps": 225.08
+"decompress_mbps": 213.91
 },
 {
 "compressor": "ocaml",
@@ -6008,7 +6007,7 @@
 "out_size": 2740598,
 "ratio": 0.0817,
 "compress_mbps": null,
-"decompress_mbps": 235.5
+"decompress_mbps": 223.58
 },
 {
 "compressor": "ocaml",
@@ -6018,7 +6017,7 @@
 "out_size": 3275124,
 "ratio": 0.5324,
 "compress_mbps": null,
-"decompress_mbps": 105.75
+"decompress_mbps": 104.57
 },
 {
 "compressor": "ocaml",
@@ -6028,7 +6027,7 @@
 "out_size": 2994086,
 "ratio": 0.4867,
 "compress_mbps": null,
-"decompress_mbps": 98.03
+"decompress_mbps": 98.79
 },
 {
 "compressor": "ocaml",
@@ -6038,7 +6037,7 @@
 "out_size": 3137061,
 "ratio": 0.5099,
 "compress_mbps": null,
-"decompress_mbps": 98.21
+"decompress_mbps": 97.08
 },
 {
 "compressor": "ocaml",
@@ -6048,7 +6047,7 @@
 "out_size": 3072378,
 "ratio": 0.4994,
 "compress_mbps": null,
-"decompress_mbps": 99.44
+"decompress_mbps": 101.03
 },
 {
 "compressor": "ocaml",
@@ -6058,7 +6057,7 @@
 "out_size": 3066968,
 "ratio": 0.4985,
 "compress_mbps": null,
-"decompress_mbps": 99.62
+"decompress_mbps": 102.48
 },
 {
 "compressor": "ocaml",
@@ -6068,7 +6067,7 @@
 "out_size": 2992113,
 "ratio": 0.4863,
 "compress_mbps": null,
-"decompress_mbps": 97.22
+"decompress_mbps": 99.25
 },
 {
 "compressor": "ocaml",
@@ -6078,7 +6077,7 @@
 "out_size": 3868663,
 "ratio": 0.3836,
 "compress_mbps": null,
-"decompress_mbps": 142.69
+"decompress_mbps": 148.45
 },
 {
 "compressor": "ocaml",
@@ -6088,7 +6087,7 @@
 "out_size": 3608138,
 "ratio": 0.3577,
 "compress_mbps": null,
-"decompress_mbps": 149.33
+"decompress_mbps": 149.68
 },
 {
 "compressor": "ocaml",
@@ -6098,7 +6097,7 @@
 "out_size": 3818964,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 142.62
+"decompress_mbps": 148.51
 },
 {
 "compressor": "ocaml",
@@ -6108,7 +6107,7 @@
 "out_size": 3660266,
 "ratio": 0.3629,
 "compress_mbps": null,
-"decompress_mbps": 145.65
+"decompress_mbps": 150.68
 },
 {
 "compressor": "ocaml",
@@ -6118,7 +6117,7 @@
 "out_size": 3654860,
 "ratio": 0.3624,
 "compress_mbps": null,
-"decompress_mbps": 146.05
+"decompress_mbps": 151.44
 },
 {
 "compressor": "ocaml",
@@ -6128,7 +6127,7 @@
 "out_size": 3607217,
 "ratio": 0.3577,
 "compress_mbps": null,
-"decompress_mbps": 152.57
+"decompress_mbps": 152.87
 },
 {
 "compressor": "ocaml",
@@ -6138,7 +6137,7 @@
 "out_size": 2197055,
 "ratio": 0.3315,
 "compress_mbps": null,
-"decompress_mbps": 122.54
+"decompress_mbps": 125.98
 },
 {
 "compressor": "ocaml",
@@ -6148,7 +6147,7 @@
 "out_size": 1696488,
 "ratio": 0.256,
 "compress_mbps": null,
-"decompress_mbps": 147.3
+"decompress_mbps": 149.07
 },
 {
 "compressor": "ocaml",
@@ -6158,7 +6157,7 @@
 "out_size": 2021047,
 "ratio": 0.305,
 "compress_mbps": null,
-"decompress_mbps": 130.7
+"decompress_mbps": 135.03
 },
 {
 "compressor": "ocaml",
@@ -6168,7 +6167,7 @@
 "out_size": 1876257,
 "ratio": 0.2831,
 "compress_mbps": null,
-"decompress_mbps": 139.21
+"decompress_mbps": 140.37
 },
 {
 "compressor": "ocaml",
@@ -6178,7 +6177,7 @@
 "out_size": 1806374,
 "ratio": 0.2726,
 "compress_mbps": null,
-"decompress_mbps": 138.26
+"decompress_mbps": 139.22
 },
 {
 "compressor": "ocaml",
@@ -6188,7 +6187,7 @@
 "out_size": 1691994,
 "ratio": 0.2553,
 "compress_mbps": null,
-"decompress_mbps": 144.91
+"decompress_mbps": 142.3
 },
 {
 "compressor": "ocaml",
@@ -6198,7 +6197,7 @@
 "out_size": 5866517,
 "ratio": 0.2715,
 "compress_mbps": null,
-"decompress_mbps": 154.54
+"decompress_mbps": 155.63
 },
 {
 "compressor": "ocaml",
@@ -6208,7 +6207,7 @@
 "out_size": 5118130,
 "ratio": 0.2369,
 "compress_mbps": null,
-"decompress_mbps": 157.5
+"decompress_mbps": 153.02
 },
 {
 "compressor": "ocaml",
@@ -6218,7 +6217,7 @@
 "out_size": 5605878,
 "ratio": 0.2595,
 "compress_mbps": null,
-"decompress_mbps": 151.36
+"decompress_mbps": 152.34
 },
 {
 "compressor": "ocaml",
@@ -6228,7 +6227,7 @@
 "out_size": 5337149,
 "ratio": 0.247,
 "compress_mbps": null,
-"decompress_mbps": 154.36
+"decompress_mbps": 155.1
 },
 {
 "compressor": "ocaml",
@@ -6238,7 +6237,7 @@
 "out_size": 5270405,
 "ratio": 0.2439,
 "compress_mbps": null,
-"decompress_mbps": 161.93
+"decompress_mbps": 156.59
 },
 {
 "compressor": "ocaml",
@@ -6248,7 +6247,7 @@
 "out_size": 5107588,
 "ratio": 0.2364,
 "compress_mbps": null,
-"decompress_mbps": 159.84
+"decompress_mbps": 162.59
 },
 {
 "compressor": "ocaml",
@@ -6258,7 +6257,7 @@
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 108.47
+"decompress_mbps": 105.89
 },
 {
 "compressor": "ocaml",
@@ -6268,7 +6267,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 111.25
+"decompress_mbps": 107.49
 },
 {
 "compressor": "ocaml",
@@ -6278,7 +6277,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 111.49
+"decompress_mbps": 109.88
 },
 {
 "compressor": "ocaml",
@@ -6288,7 +6287,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 114.78
+"decompress_mbps": 112.63
 },
 {
 "compressor": "ocaml",
@@ -6298,7 +6297,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 115.99
+"decompress_mbps": 114.79
 },
 {
 "compressor": "ocaml",
@@ -6308,7 +6307,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 107.65
+"decompress_mbps": 105.07
 },
 {
 "compressor": "ocaml",
@@ -6318,7 +6317,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 115.09
+"decompress_mbps": 113.95
 },
 {
 "compressor": "ocaml",
@@ -6328,7 +6327,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 125.88
+"decompress_mbps": 120.88
 },
 {
 "compressor": "ocaml",
@@ -6338,7 +6337,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 123.59
+"decompress_mbps": 116.5
 },
 {
 "compressor": "ocaml",
@@ -6348,7 +6347,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 122.74
+"decompress_mbps": 121.41
 },
 {
 "compressor": "ocaml",
@@ -6358,7 +6357,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 123.85
+"decompress_mbps": 123.84
 },
 {
 "compressor": "ocaml",
@@ -6368,7 +6367,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 128.15
+"decompress_mbps": 120.47
 },
 {
 "compressor": "ocaml",
@@ -6378,7 +6377,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 104.36
+"decompress_mbps": 104.39
 },
 {
 "compressor": "ocaml",
@@ -6388,7 +6387,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 91.78
+"decompress_mbps": 92.24
 },
 {
 "compressor": "ocaml",
@@ -6398,7 +6397,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 91.81
+"decompress_mbps": 92.07
 },
 {
 "compressor": "ocaml",
@@ -6408,7 +6407,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 91.6
+"decompress_mbps": 90.06
 },
 {
 "compressor": "ocaml",
@@ -6418,7 +6417,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 93.99
+"decompress_mbps": 94.09
 },
 {
 "compressor": "ocaml",
@@ -6428,7 +6427,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 92.35
+"decompress_mbps": 88.78
 },
 {
 "compressor": "ocaml",
@@ -6438,7 +6437,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 192.55
+"decompress_mbps": 189.44
 },
 {
 "compressor": "ocaml",
@@ -6448,7 +6447,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 228.12
+"decompress_mbps": 223.66
 },
 {
 "compressor": "ocaml",
@@ -6458,7 +6457,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 195.16
+"decompress_mbps": 203.79
 },
 {
 "compressor": "ocaml",
@@ -6468,7 +6467,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 216.09
+"decompress_mbps": 205.04
 },
 {
 "compressor": "ocaml",
@@ -6478,7 +6477,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 219.58
+"decompress_mbps": 218.16
 },
 {
 "compressor": "ocaml",
@@ -6488,7 +6487,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 221.88
+"decompress_mbps": 220.46
 }
 ]
 }


### PR DESCRIPTION
This PR refreshes the decode-density dashboard on current master, whose committed `decode_density.json` had gone stale since https://github.com/kim-em/lean-zip/pull/2849 "perf(bench): route decode-density through the verified exact-size fastloop" — predating the four decode levers that landed since: https://github.com/kim-em/lean-zip/pull/2873 "perf(decode): inline short-match copies in goCurU" (Lever A), https://github.com/kim-em/lean-zip/pull/2874 "perf(decode): refill input a word at a time" (Lever B), https://github.com/kim-em/lean-zip/pull/2878 "perf(decode): keep match arithmetic USize-native" (Lever D), and the two-literal wide-refill unroll from https://github.com/kim-em/lean-zip/issues/2856 "perf(decode): decode 2-3 literals per refill in goCurU (Lever C)".

Native decode geomean over the 72-cell silesia matrix moves 319.6 → 362.8 MB/s (+13.5%), narrowing miniz_oxide's decode lead from 1.67x to 1.47x. All twelve silesia files improved. Every decoder was freshly re-timed on chungus2 in one sitting: the comparators land within 1-2% of the prior snapshot (miniz_oxide 532.0, zlib 468.3, libdeflate 904.2, zig 292.5, go 263.8, js 150.7, ocaml 133.7), confirming machine consistency, while native reflects the levers. `silesia_decode_ranking.svg` and `silesia_decode_density.svg` are regenerated from the refreshed data; the compress-side SVGs are untouched because their `latest.json` inputs did not change.

🤖 Prepared with Claude Code
