### PR TITLE
bench: re-record whole-tar L6 after #2882

### DIFF
--- a/bench/results/whole_tar_l6.json
+++ b/bench/results/whole_tar_l6.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-25T15:26:38Z",
+  "date": "2026-07-26T01:39:08Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "d239ef1c",
+  "git_commit": "b5f567a0",
   "tar_bytes": 211957760,
   "reps": 9,
   "note": "Whole-tar L6 comparison: codec-CPU (native vs miniz through the bench harness) plus end-to-end wall of the real lean/rust CLIs. Peak RSS (end_to_end.{lean,rust}.maxrss_kb + rss_ratio) is now tracked too — the whole-tar memory footprint, so a compress PR can be reviewed on memory as well as speed/ratio."
@@ -11,36 +11,36 @@
   "note": "CODEC comparison, measured THROUGH the lean bench harness so both sides pay the same readBinFile + 202 MB ByteArray-alloc I/O and it CANCELS: native (bench csize) vs miniz_oxide (bench compress-miniz) on the whole silesia.tar (211957760 B), cold best-of-9. ms are wall-clock of fresh bench subprocesses; time_ratio_median is median per-rep native_ms/miniz_ms (<1.0 = native codec-CPU faster). This guards a ratio-tuning codec regression; it is NOT the end-to-end zip wall (see end_to_end).",
   "native": {
    "size": 67944712,
-   "ms_best": 5397.224,
-   "ms_median": 5441.348
+   "ms_best": 5224.229,
+   "ms_median": 5241.149
   },
   "miniz": {
    "size": 68112144,
-   "ms_best": 5799.613,
-   "ms_median": 5823.094
+   "ms_best": 5862.396,
+   "ms_median": 5876.367
   },
   "size_margin_pct": 0.2458,
-  "time_ratio_median": 0.9320
+  "time_ratio_median": 0.8917
  },
  "end_to_end": {
   "note": "END-TO-END comparison of two REAL CLI tools as fresh processes: lean compress-file (readBinFile -> deflateRaw -> print size) vs rust miniz-compress-file (std::fs::read -> compress_to_vec -> print len), cold best-of-9, alternating order. This IS the zip silesia.tar wall Kim benchmarks with hyperfine; each side pays its OWN file-read/alloc path (which the codec section cancels). wall_ratio_median is median per-rep lean_wall/rust_wall (>1.0 = rust wall-ahead, <1.0 = lean wall-ahead); read it rather than any prose here. wall/user/sys captured via the bash time builtin. PEAK RSS (maxrss_kb) is the whole-tar memory footprint of each CLI, captured with GNU time -v (Maximum resident set size); it is deterministic so one measured run per side suffices. rss_ratio is lean_maxrss_kb/rust_maxrss_kb: lean holds its whole DEFLATE token stream in memory while rust's miniz keeps only a bounded window, so this ratio is the memory cost of the token pipeline (the target of the token-unboxing work).",
   "lean": {
    "size": 67944712,
-   "wall_ms_best": 5389.000,
-   "wall_ms_median": 5415.000,
-   "user_ms": 5245.000,
-   "sys_ms": 150.000,
-   "maxrss_kb": 481408
+   "wall_ms_best": 5235.000,
+   "wall_ms_median": 5259.000,
+   "user_ms": 5072.000,
+   "sys_ms": 160.000,
+   "maxrss_kb": 483048
   },
   "rust": {
    "size": 68112144,
-   "wall_ms_best": 5779.000,
-   "wall_ms_median": 5786.000,
-   "user_ms": 5684.000,
-   "sys_ms": 80.000,
+   "wall_ms_best": 5767.000,
+   "wall_ms_median": 5779.000,
+   "user_ms": 5677.000,
+   "sys_ms": 82.000,
    "maxrss_kb": 276116
   },
-  "wall_ratio_median": 0.9362,
-  "rss_ratio": 1.7435
+  "wall_ratio_median": 0.9085,
+  "rss_ratio": 1.7494
  }
 }


### PR DESCRIPTION
This PR re-records the whole-tar L6 comparison on current master. Everything else it originally carried — the full native re-measure and the animation replay — is now redundant: #2884 landed a focused L5 refresh plus the animation replay while this was in review, and I have resolved in favour of that. What is left is the one file #2884 did not touch.

| | size | wall best | wall median | sys |
| --- | --- | --- | --- | --- |
| lean | 67,944,712 | 5235 ms | 5259 ms | 160 ms |
| rust (miniz_oxide) | 68,112,144 | 5767 ms | 5779 ms | 82 ms |

`wall_ratio_median` 0.9085, against 0.9362 in the previous record. Output is unchanged — #2882 moves L5 only, and L6 stays byte-identical — so this is the L6 codec gain plus a quieter machine.

Two notes from measuring alongside #2884:

- Our L5 numbers agree within noise: this run read native 58.8 MB/s against miniz_oxide 58.9 at matched ratio, #2884 read 59.04 against 58.88. Both are a tie at this resolution; I would not read the 0.28% in either direction as native "edging past".
- My earlier #2881 refresh merged after #2882 but was measured before it, which is what left master with a dashboard newer in history than the code it described. #2884 has since corrected the L5 rows, so that is resolved.

🤖 Prepared with Claude Code